### PR TITLE
fix: evaluate calls to other model functions

### DIFF
--- a/tests/examples/fail/lockserver_bug.fly
+++ b/tests/examples/fail/lockserver_bug.fly
@@ -1,0 +1,24 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Lock server example, translated from mypyvy
+
+sort node
+
+mutable lock_msg(node): bool
+mutable grant_msg(node): bool
+mutable unlock_msg(node): bool
+mutable holds_lock(node): bool
+mutable server_holds_lock: bool
+
+# inits:
+assume (forall N:node. !lock_msg(N)) & (forall N:node. !grant_msg(N)) & (forall N:node. !unlock_msg(N)) & (forall N:node. !holds_lock(N)) & (server_holds_lock)
+
+# transitions:
+assume always (exists n:node. (forall N:node. ((lock_msg(N))') <-> lock_msg(N) | N = n) & (forall x0:node. ((grant_msg(x0))') = grant_msg(x0)) & (forall x0:node. ((unlock_msg(x0))') = unlock_msg(x0)) & (forall x0:node. ((holds_lock(x0))') = holds_lock(x0)) & ((server_holds_lock)') = server_holds_lock) | (exists n:node. (forall N:node. server_holds_lock & lock_msg(n) & !((server_holds_lock)') & (((lock_msg(N))') <-> lock_msg(N) & N != n) & (((grant_msg(N))') <-> grant_msg(N) | N = n)) & (forall x0:node. ((unlock_msg(x0))') = unlock_msg(x0)) & (forall x0:node. ((holds_lock(x0))') = holds_lock(x0))) | (exists n:node. (forall N:node. grant_msg(n) & (((grant_msg(N))') <-> grant_msg(N) & N != n) & (((holds_lock(N))') <-> holds_lock(N) | N = n)) & (forall x0:node. ((lock_msg(x0))') = lock_msg(x0)) & (forall x0:node. ((unlock_msg(x0))') = unlock_msg(x0)) & ((server_holds_lock)') = server_holds_lock) | (exists n:node. (forall N:node. holds_lock(n) & (((holds_lock(N))') <-> holds_lock(N) & N != n) & (((unlock_msg(N))') <-> unlock_msg(N) | N = n)) & (forall x0:node. ((lock_msg(x0))') = lock_msg(x0)) & (forall x0:node. ((grant_msg(x0))') = grant_msg(x0)) & ((server_holds_lock)') = server_holds_lock) | (exists n:node. (forall N:node. unlock_msg(n) & (((unlock_msg(N))') <-> unlock_msg(N) & N != n) & ((server_holds_lock)')) & (forall x0:node. ((lock_msg(x0))') = lock_msg(x0)) & (forall x0:node. ((grant_msg(x0))') = grant_msg(x0)) & (forall x0:node. ((holds_lock(x0))') = holds_lock(x0)))
+
+# safety:
+assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = N2)
+proof {
+    invariant server_holds_lock
+}

--- a/tests/examples/snapshots/fail/lockserver_bug.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/lockserver_bug.fly.cvc4.snap
@@ -1,0 +1,22 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/lockserver_bug.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+verification errors:
+error: invariant is not inductive
+   ┌─ tests/examples/fail/lockserver_bug.fly:21:1
+   │
+21 │ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = N2)
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = counter example:
+     lock_msg(@node_0) = true
+     grant_msg(@node_0) = false
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = true
+     server_holds_lock = true
+
+

--- a/tests/examples/snapshots/fail/lockserver_bug.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/lockserver_bug.fly.cvc5.snap
@@ -1,0 +1,22 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/lockserver_bug.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+verification errors:
+error: invariant is not inductive
+   ┌─ tests/examples/fail/lockserver_bug.fly:21:1
+   │
+21 │ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = N2)
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = counter example:
+     lock_msg(@node_0) = true
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = true
+     server_holds_lock = true
+
+

--- a/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
+++ b/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
@@ -1,0 +1,22 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/lockserver_bug.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+verification errors:
+error: invariant is not inductive
+   ┌─ tests/examples/fail/lockserver_bug.fly:21:1
+   │
+21 │ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = N2)
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = counter example:
+     lock_msg(@node_0) = true
+     grant_msg(@node_0) = false
+     unlock_msg(@node_0) = false
+     holds_lock(@node_0) = false
+     server_holds_lock = true
+
+


### PR DESCRIPTION
Correctly handles some z3 models where the definition of one model function relies on another.

The test added in this PR has a model that looks like this:

```smt2
(
  ;; universe for node:
  ;;   node!val!0 
  ;; -----------
  ;; definitions for universe elements:
  (declare-fun node!val!0 () node)
  ;; cardinality constraint:
  (forall ((x node)) (= x node!val!0))
  ;; -----------
  (define-fun |server_holds_lock'| () Bool
    false)
  (define-fun server_holds_lock () Bool
    true)
  (define-fun grant_msg ((x!0 node)) Bool
    false)
  (define-fun unlock_msg ((x!0 node)) Bool
    false)
  (define-fun holds_lock ((x!0 node)) Bool
    false)
  (define-fun |unlock_msg'| ((x!0 node)) Bool
    (unlock_msg x!0))
  (define-fun lock_msg ((x!0 node)) Bool
    true)
  (define-fun |lock_msg'| ((x!0 node)) Bool
    false)
  (define-fun |holds_lock'| ((x!0 node)) Bool
    (holds_lock x!0))
  (define-fun |grant_msg'| ((x!0 node)) Bool
    true)
)
```

Notice that `holds_lock'` is defined in terms of `holds_lock`.

Signed-off-by: Tej Chajed <tchajed@vmware.com>