### PR TITLE
Handle let bindings in model evaluation

### DIFF
--- a/examples/consensus.fly
+++ b/examples/consensus.fly
@@ -1,0 +1,51 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+# TEST --expect-fail -- verify
+#
+
+# sorts:
+sort node
+sort quorum
+sort value
+
+# constants:
+
+
+# functions:
+
+
+# relations:
+mutable member(node, quorum): bool
+mutable vote_request_msg(node, node): bool
+mutable voted(node): bool
+mutable vote_msg(node, node): bool
+mutable votes(node, node): bool
+mutable leader(node): bool
+mutable decided(node, value): bool
+
+# init:
+assume (forall N1:node, N2:node. !vote_request_msg(N1, N2)) & (forall N:node. !voted(N)) & (forall N1:node, N2:node. !vote_msg(N1, N2)) & (forall N1:node, N2:node. !votes(N1, N2)) & (forall N1:node. !leader(N1)) & (forall N:node, V:value. !decided(N, V))
+
+# transitions:
+assume always (exists src:node, dst:node. (forall N1:node, N2:node. (vote_request_msg(N1, N2))' <-> vote_request_msg(N1, N2) | N1 = src & N2 = dst) & (forall x0:node. (voted(x0))' = voted(x0)) & (forall x0:node, x1:node. (vote_msg(x0, x1))' = vote_msg(x0, x1)) & (forall x0:node, x1:node. (votes(x0, x1))' = votes(x0, x1)) & (forall x0:node. (leader(x0))' = leader(x0)) & (forall x0:node, x1:value. (decided(x0, x1))' = decided(x0, x1))) | (exists src:node, dst:node. (forall N1:node, N2:node, N:node. !voted(src) & vote_request_msg(dst, src) & ((vote_msg(N1, N2))' <-> vote_msg(N1, N2) | N1 = src & N2 = dst) & ((voted(N))' <-> voted(N) | N = src) & (!(N1 = dst & N2 = src) -> ((vote_request_msg(N1, N2))' <-> vote_request_msg(N1, N2)))) & (forall x0:node, x1:node. (votes(x0, x1))' = votes(x0, x1)) & (forall x0:node. (leader(x0))' = leader(x0)) & (forall x0:node, x1:value. (decided(x0, x1))' = decided(x0, x1))) | (exists n:node, sender:node. (forall N1:node, N2:node. vote_msg(sender, n) & ((votes(N1, N2))' <-> votes(N1, N2) | N1 = n & N2 = sender)) & (forall x0:node, x1:node. (vote_request_msg(x0, x1))' = vote_request_msg(x0, x1)) & (forall x0:node. (voted(x0))' = voted(x0)) & (forall x0:node, x1:node. (vote_msg(x0, x1))' = vote_msg(x0, x1)) & (forall x0:node. (leader(x0))' = leader(x0)) & (forall x0:node, x1:value. (decided(x0, x1))' = decided(x0, x1))) | (exists n:node, q:quorum. (forall N:node. (member(N, q) -> votes(n, N)) & ((leader(N))' <-> leader(N) | N = n)) & (forall x0:node, x1:node. (vote_request_msg(x0, x1))' = vote_request_msg(x0, x1)) & (forall x0:node. (voted(x0))' = voted(x0)) & (forall x0:node, x1:node. (vote_msg(x0, x1))' = vote_msg(x0, x1)) & (forall x0:node, x1:node. (votes(x0, x1))' = votes(x0, x1)) & (forall x0:node, x1:value. (decided(x0, x1))' = decided(x0, x1))) | (exists n:node, v:value. (forall V:value, N:node. leader(n) & !decided(n, V) & ((decided(N, V))' <-> decided(N, V) | N = n & V = v)) & (forall x0:node, x1:node. (vote_request_msg(x0, x1))' = vote_request_msg(x0, x1)) & (forall x0:node. (voted(x0))' = voted(x0)) & (forall x0:node, x1:node. (vote_msg(x0, x1))' = vote_msg(x0, x1)) & (forall x0:node, x1:node. (votes(x0, x1))' = votes(x0, x1)) & (forall x0:node. (leader(x0))' = leader(x0)))
+
+# added by hand
+# axiom
+assume always (forall Q1:quorum, Q2:quorum. exists N:node. member(N, Q1) & member(N, Q2))
+# immutable relation (transition)
+assume always (forall N:node, Q:quorum. member(N, Q) = (member(N, Q))')
+
+# safety:
+assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & decided(N2, V2) -> V1 = V2)
+proof {
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !vote_request_msg(n1, n1)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !vote_request_msg(n1, n2)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !voted(n1)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !vote_msg(n1, n1)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !vote_msg(n1, n2)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !votes(n1, n1)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !votes(n1, n2)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !leader(n1)
+    invariant exists q:quorum. forall n1:node, n2:node, n3:node. forall v:value. !decided(n1, v)
+}

--- a/examples/snapshots/consensus.fly.snap
+++ b/examples/snapshots/consensus.fly.snap
@@ -1,0 +1,24 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail -- verify examples/consensus.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+verification errors:
+error: invariant is not inductive
+   ┌─ examples/consensus.fly:40:1
+   │
+40 │ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & decided(N2, V2) -> V1 = V2)
+   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = counter example:
+     member(@node_0,@quorum_0) = true
+     vote_request_msg(@node_0,@node_0) = false
+     voted(@node_0) = false
+     vote_msg(@node_0,@node_0) = false
+     votes(@node_0,@node_0) = false
+     leader(@node_0) = false
+     decided(@node_0,@value_0) = false
+
+

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -130,7 +130,7 @@ impl Backend for &GenericBackend {
                         }
                     })
                     .collect::<Vec<_>>();
-                let repl = zip(binders.iter(), args).collect::<Vec<_>>();
+                let repl = zip(binders.iter().map(|s| s.as_str()), args).collect::<Vec<_>>();
                 let body = subst(&repl, &body);
                 let e = model
                     .smt_eval(&body)


### PR DESCRIPTION
Fixes handling of Z3 in a more complex example from Eden.

Signed-off-by: Tej Chajed <tchajed@vmware.com>