### PR TITLE
Be careful about solver versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  TEST_STRICT_VERSIONS: true
 
 jobs:
   build:
@@ -20,7 +21,7 @@ jobs:
     env:
       Z3_VERSION: "4.11.2"
       CVC4_BINARY_URL: "https://github.com/CVC4/CVC4/releases/download/1.8/cvc4-1.8-x86_64-linux-opt"
-      CVC5_BINARY_URL: "https://github.com/cvc5/cvc5/releases/latest/download/cvc5-Linux" # this is the latest release
+      CVC5_BINARY_URL: "https://github.com/cvc5/cvc5/releases/download/cvc5-1.0.4/cvc5-Linux"
     steps:
       - uses: actions/checkout@v3
       - name: Install Z3
@@ -48,5 +49,5 @@ jobs:
           rustup set auto-self-update disable
           rustup toolchain install ${{ matrix.toolchain }} --profile minimal
       - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo test --verbose -- --nocapture
       - run: cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 insta = { version = "1.22.0", features = ["yaml", "redactions"] }
+regex = "1.7.0"
 
 [profile.dev.package.insta]
 opt-level = 3


### PR DESCRIPTION
- Check each solver's version (using --version) and compare against known good versions in the source code.
- On mismatch, normally print an error and skip the test. This makes local tests resilient. However, to notice this you have to run `cargo test -- --nocapture` at some point.
- In CI, use the environment variable `TEST_STRICT_VERSIONS` to make the tests instead fail on version mismatch. This just makes sure that the CI config matches the code for what solvers are installed.

A solver not being installed is treated as a version mismatch.