### PR TITLE
Replace solver CLI arguments with SMT2 options

### DIFF
--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -66,11 +66,13 @@ impl Backend for &GenericBackend {
             SolverType::Cvc4 => {
                 let mut conf = CvcConf::new_cvc4(&self.bin);
                 conf.finite_models();
+                conf.interleave_enumerative_instantiation();
                 conf.done()
             }
             SolverType::Cvc5 => {
                 let mut conf = CvcConf::new_cvc5(&self.bin);
                 conf.finite_models();
+                conf.interleave_enumerative_instantiation();
                 conf.done()
             }
         }

--- a/tests/examples/snapshots/fail/relations.fly.z3.snap
+++ b/tests/examples/snapshots/fail/relations.fly.z3.snap
@@ -13,12 +13,12 @@ error: assertion failure
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
-     p(@A_0) = true
-     p(@A_1) = false
+     p(@A_0) = false
+     p(@A_1) = true
      q(@A_0,@A_0) = true
-     q(@A_0,@A_1) = true
+     q(@A_0,@A_1) = false
      q(@A_1,@A_0) = true
      q(@A_1,@A_1) = true
-     a0 = @A_0
+     a0 = @A_1
 
 


### PR DESCRIPTION
It's better to just use the SMT2 file as much as possible, and not try to use command line arguments. We were already redundantly passing options and setting options, now we just commit to using SMT options.