### PR TITLE
Add primes to App constructor

### DIFF
--- a/src/fly/defs.rs
+++ b/src/fly/defs.rs
@@ -14,8 +14,7 @@ fn subst(t: &mut Term, repl: &HashMap<String, &Term>) {
                 *t = y.clone();
             }
         }
-        Term::App(f, xs) => {
-            go(f);
+        Term::App(_f, _p, xs) => {
             for t in xs {
                 go(t);
             }
@@ -56,16 +55,12 @@ fn inline_def_term(def: &Definition, t: &mut Term) {
                 *t = body.clone();
             }
         }
-        Term::App(f, ts) => {
-            if let Term::Id(s) = f.as_ref() {
-                if s == &def.name {
-                    // substitute ts for def.binders in body before doing the replacement
-                    let mut body = body.clone();
-                    subst_binders(&mut body, &def.binders, ts);
-                    *t = body;
-                }
-            } else {
-                unimplemented!("inlining into application of complex term {f}");
+        Term::App(f, _p, ts) => {
+            if f == &def.name {
+                // substitute ts for def.binders in body before doing the replacement
+                let mut body = body.clone();
+                subst_binders(&mut body, &def.binders, ts);
+                *t = body;
             }
         }
         Term::UnaryOp(_, x) => go(x),

--- a/src/fly/parser.rs
+++ b/src/fly/parser.rs
@@ -63,7 +63,7 @@ grammar parser() for str {
         --
         // note that no space is allowed between relation name and args, so p (q)
         // doesn't parse as a relation call
-        t:(@) "(" args:(term() ** (_ "," _)) ")" { Term::App(Box::new(t), args) }
+        f:ident() ps:("\'"*) "(" args:(term() ** (_ "," _)) ")" { Term::App(f, ps.len(), args) }
         s:ident() { match s.as_str() {
             "false" => Term::Literal(false),
             "true" => Term::Literal(true),
@@ -194,13 +194,6 @@ mod tests {
 
         term("p(x, y)").unwrap();
         term("p(x,y)").unwrap();
-
-        // not first order (but eventually f might be a meta abstraction that
-        // reduces to a relation)
-        term("(f(x))(a, b)").unwrap();
-
-        // non-sensical but does parse
-        term("(!p)(a)").unwrap();
 
         // & and | at the same level are grouped into a single NAry
         assert_eq!(term("(p & q) & r").unwrap(), term("p & q & r").unwrap());

--- a/src/fly/printer.rs
+++ b/src/fly/printer.rs
@@ -21,7 +21,7 @@ fn precedence(t: &Term) -> usize {
         BinOp(Equals | NotEquals, _, _) => 60,
         UnaryOp(Not, _) => 70,
         UnaryOp(Prime, _) => 80,
-        Literal(_) | Id(_) | App(_, _) => 1000,
+        Literal(_) | Id(_) | App(_, _, _) => 1000,
     }
 }
 
@@ -56,9 +56,10 @@ pub fn term(t: &Term) -> String {
         Term::Literal(false) => "false".to_string(),
         Term::Literal(true) => "true".to_string(),
         Term::Id(i) => i.to_string(),
-        Term::App(f, args) => format!(
-            "{}({})",
-            term(f),
+        Term::App(f, p, args) => format!(
+            "{}{}({})",
+            f,
+            "\'".repeat(*p),
             args.iter().map(term).collect::<Vec<_>>().join(", ")
         ),
         Term::UnaryOp(op, arg) => {

--- a/src/fly/semantics.rs
+++ b/src/fly/semantics.rs
@@ -201,13 +201,12 @@ impl Model {
                 );
                 self.interp[i].get(&[])
             }
-            Term::App(f, args) => {
+            Term::App(f, p, args) => {
                 let args: Vec<Element> = args.iter().map(|x| self.eval(x, assignment)).collect();
-                // ODED: is `&**f` really the right/idomatic thing here?
-                match &**f {
-                    Term::Id(name) => self.interp[self.signature.relation_idx(name)].get(&args),
-                    _ => panic!("tried to apply {f}"),
+                if *p != 0 {
+                    panic!("tried to eval {t}")
                 }
+                self.interp[self.signature.relation_idx(f)].get(&args)
             }
             Term::UnaryOp(Not, t) => {
                 let v = self.eval(t, assignment);
@@ -585,8 +584,8 @@ mod tests {
 
         let f = Literal(false);
         let t = Literal(true);
-        let r1 = Id("r1".to_string());
-        let r2 = Id("r2".to_string());
+        let r1 = "r1".to_string();
+        let r2 = "r2".to_string();
         let c1 = Id("c1".to_string());
         let c2 = Id("c2".to_string());
 
@@ -703,8 +702,8 @@ mod tests {
             (BinOp(Equals, b(&c1), b(&c1)), 1),
             (BinOp(NotEquals, b(&c1), b(&c1)), 0),
             //
-            (App(b(&r1), vec![c2.clone(), c1.clone()]), 0),
-            (App(b(&r2), vec![c1.clone()]), 2),
+            (App(r1, 0, vec![c2.clone(), c1.clone()]), 0),
+            (App(r2, 0, vec![c1.clone()]), 2),
         ]);
 
         for (t, v) in tests.iter() {

--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -47,8 +47,7 @@ pub struct Binder {
 pub enum Term {
     Literal(bool),
     Id(String),
-    // ODED: I think we should have App(String, Vec<Term>), since we're not high-order (yet)
-    App(Box<Term>, Vec<Term>),
+    App(String, usize, Vec<Term>),
     UnaryOp(UOp, Box<Term>),
     BinOp(BinOp, Box<Term>, Box<Term>),
     NAryOp(NOp, Vec<Term>),
@@ -299,7 +298,8 @@ impl Signature {
                         {
                             let term_vec = args.iter().map(|&x| x.clone()).collect();
                             new_new_terms[sort_idx(&rel_decl.typ)].push(Term::App(
-                                Box::new(Term::Id(rel_decl.name.clone())),
+                                rel_decl.name.clone(),
+                                0,
                                 term_vec,
                             ));
                         }

--- a/src/solver/sexp.rs
+++ b/src/solver/sexp.rs
@@ -31,8 +31,8 @@ fn term_primes(t: &Term, num_primes: usize) -> Sexp {
         Term::Literal(false) => atom_s("false"),
         Term::Literal(true) => atom_s("true"),
         Term::Id(s) => atom_s(format!("{s}{}", "'".repeat(num_primes))),
-        Term::App(f, args) => {
-            let head = vec![term(f)].into_iter();
+        Term::App(f, p, args) => {
+            let head = vec![term_primes(&Term::Id(f.clone()), p + num_primes)].into_iter();
             let args = args.iter().map(term);
             sexp_l(head.chain(args))
         }

--- a/src/term/fo.rs
+++ b/src/term/fo.rs
@@ -61,7 +61,7 @@ fn unrolling(t: &Term) -> Unrolling {
     use Unrolling::Finite;
     match t {
         Term::Literal(_) | Term::Id(_) => Finite(0),
-        Term::App(f, x) => unrolling(f) & max_unrolling(x),
+        Term::App(_f, p, x) => Finite(*p) & max_unrolling(x),
         Term::UnaryOp(Always | Eventually, _) => Unrolling::Infinite,
         Term::UnaryOp(Not, t) => unrolling(t),
         Term::UnaryOp(Prime, t) => Finite(1) + unrolling(t),

--- a/src/term/prime.rs
+++ b/src/term/prime.rs
@@ -27,7 +27,7 @@ fn with_next(t: &Term, bound: im::HashSet<String>, next: usize) -> Term {
             if bound.contains(s) { 0 } else { next },
         ),
         // TODO: we do not add primes to arguments; this is just a heuristic
-        Term::App(f, xs) => Term::App(go_box(f), xs.iter().map(go).collect()),
+        Term::App(f, p, xs) => Term::App(f.clone(), p + next, xs.iter().map(go).collect()),
 
         // boring recursive cases
         Term::Literal(b) => Term::Literal(*b),

--- a/src/term/subst.rs
+++ b/src/term/subst.rs
@@ -20,8 +20,9 @@ pub fn substitute_qf(term: &Term, substitution: &Substitution) -> Term {
             }
         }
 
-        Term::App(f, args) => Term::App(
+        Term::App(f, p, args) => Term::App(
             f.clone(),
+            *p,
             args.iter()
                 .map(|a| substitute_qf(a, substitution))
                 .collect(),


### PR DESCRIPTION
@Alex-Fischman and I refactored this commit out of the sort checking PR.

This commit adds support for terms like `f'(x)`, which previously was only supported in a half-higher-order-lambda-calculus way by parsing as "the expression `f'` applied to `x`". 

It leaves the code in a somewhat inconsistent intermediate state where the `Id` constructor still exists but does not support primes. But it seems better to merge this now and then refactor `Id` (replacing it by `App(f, p, [])`, or by adding primes to `Id` and forbidding `[]` as an argument to `App`) later.

Feedback welcome!