### PR TITLE
Move CI checks to a script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,5 @@ jobs:
         run: |
           rustup set auto-self-update disable
           rustup toolchain install ${{ matrix.toolchain }} --profile minimal
-      - run: cargo build --verbose
-      - run: cargo test --verbose -- --nocapture
-      - run: cargo test --benches
-      - run: cargo fmt --check
+      - name: CI checks
+        run: ./tools/ci-check.sh --ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ month).
   # Copyright 2022-2023 VMware, Inc.
   # SPDX-License-Identifier: BSD-2-Clause
   ```
-* Before creating a commit, make sure the following tests pass (these are run by CI on GitHub, so the commit will get a :x: if they don't):
+* Before creating a commit, make sure the following tests pass (these are run by CI on GitHub, so the commit will get a :x: if they don't). You can run `./tools/ci-check.sh` to run all of these automatically.
   * `cargo test`
   * Use `cargo fmt` to format the code. You can use the "format on save" setting in VS Code to have this done automatically.
 * Commit messages should generally follow this [style guide](http://chris.beams.io/posts/git-commit/). In short:

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+## This script runs the checks that we use in CI.
+##
+## When run locally without arguments, command are run with less verbose output.
+## In CI we pass the --ci flag to produce verbose output from the build and test
+## steps.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+cd "$SCRIPT_DIR/.."
+
+blue=$(tput setaf 4 2>/dev/null || printf "")
+red=$(tput setaf 1 2>/dev/null || printf "")
+reset=$(tput sgr0 2>/dev/null || printf "")
+
+info() {
+  echo -e "${blue}$1${reset}"
+}
+error() {
+  echo -e "${red}$1${reset}"
+}
+
+usage() {
+  echo "$0 [--ci]"
+  echo "--ci adds verbosity and some commands for GitHub actions"
+}
+
+ci=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --ci)
+    shift
+    ci=true
+    ;;
+  -h | -help | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "unknown option/argument" 1>&2
+    exit 1
+    ;;
+  esac
+done
+
+start_group() {
+  if [ "$ci" = true ]; then
+    echo "::group::$1"
+  fi
+  info "$1"
+}
+
+end_group() {
+  if [ "$ci" = true ]; then
+    echo "::endgroup::"
+  fi
+}
+
+start_group "cargo build"
+if [ "$ci" = true ]; then
+  cargo build --tests --verbose
+else
+  cargo build --tests --quiet
+fi
+end_group
+
+start_group "cargo test"
+if [ "$ci" = true ]; then
+  cargo test --tests --benches --verbose -- --nocapture
+else
+  cargo test --tests --benches --quiet
+fi
+end_group
+
+info "cargo fmt --check"
+if [ "$ci" = true ]; then
+  cargo fmt --check
+else
+  ## locally we check but also apply the diff
+
+  # run the usual check, print a diff if needed, and remember if it succeeded
+  if cargo fmt --check; then
+    fmt_good=true
+  else
+    fmt_good=false
+  fi
+  # actually apply the diff locally
+  cargo fmt
+  if [ "$fmt_good" = false ]; then
+    error "cargo fmt made some changes"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
`./tools/ci-check.sh` does a build, runs the tests, and runs `cargo fmt`. In CI we run `./tools/ci-check.sh --ci` which is basically the same but more verbose. (Note that this does make the script itself implement each check twice, which need to be kept in sync.)

There are a few improvements compared to the commands used earlier, from more closely inspecting the code. First, we use `cargo build --tests` to also compile the dev dependencies (this is a separate phase mainly so the test output is cleaner and easier to read). Second, it turns out that `cargo test --benches` also runs the unit tests, so we were running them twice; the correct invocation is `cargo test --tests --benches` to run unit tests + integration tests + benches.
