### PR TITLE
Temporarily retain only one CI config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - nightly
+          # - nightly
         os:
           - ubuntu-latest
-          - macos-latest
+          # - macos-latest
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
While we have a fixed CI budget we'll just run in the simplest config (Rust stable on Ubuntu).