### PR TITLE
Add Next, Until, Previously, and Since to grammar

### DIFF
--- a/src/fly/semantics.rs
+++ b/src/fly/semantics.rs
@@ -293,7 +293,10 @@ impl Model {
                     0
                 }
             }
-            Term::UnaryOp(Always | Eventually | Prime, _) => panic!("tried to eval {t}"),
+            Term::UnaryOp(Always | Eventually | Prime | Next | Previously, _)
+            | Term::BinOp(Until | Since, _, _) => {
+                panic!("tried to eval temporal {t}")
+            }
         }
     }
 

--- a/src/fly/sorts.rs
+++ b/src/fly/sorts.rs
@@ -287,10 +287,20 @@ impl Context<'_> {
                 }
                 Ok(())
             }
-            Term::UnaryOp(UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime, x) => {
-                self.fix_sorts_in_term(x)
-            }
-            Term::BinOp(BinOp::Equals | BinOp::NotEquals | BinOp::Implies | BinOp::Iff, x, y) => {
+            Term::UnaryOp(
+                UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime | UOp::Next | UOp::Previously,
+                x,
+            ) => self.fix_sorts_in_term(x),
+            Term::BinOp(
+                BinOp::Equals
+                | BinOp::NotEquals
+                | BinOp::Implies
+                | BinOp::Iff
+                | BinOp::Until
+                | BinOp::Since,
+                x,
+                y,
+            ) => {
                 self.fix_sorts_in_term(x)?;
                 self.fix_sorts_in_term(y)?;
                 Ok(())
@@ -368,7 +378,10 @@ impl Context<'_> {
                 Some(NamedSort::Unknown(_)) => unreachable!("function sorts are always known"),
                 None => Err(SortError::UnknownName(f.clone())),
             },
-            Term::UnaryOp(UOp::Not | UOp::Always | UOp::Eventually, x) => {
+            Term::UnaryOp(
+                UOp::Not | UOp::Always | UOp::Eventually | UOp::Next | UOp::Previously,
+                x,
+            ) => {
                 let x = self.sort_of_term(x)?;
                 self.unify_var_value(&Sort::Bool, &x)?;
                 Ok(AbstractSort::Known(Sort::Bool))
@@ -380,7 +393,7 @@ impl Context<'_> {
                 self.unify_var_var(&a, &b)?;
                 Ok(AbstractSort::Known(Sort::Bool))
             }
-            Term::BinOp(BinOp::Implies | BinOp::Iff, x, y) => {
+            Term::BinOp(BinOp::Implies | BinOp::Iff | BinOp::Until | BinOp::Since, x, y) => {
                 let x = self.sort_of_term(x)?;
                 self.unify_var_value(&Sort::Bool, &x)?;
                 let y = self.sort_of_term(y)?;

--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -12,6 +12,10 @@ pub enum UOp {
     Prime,
     Always,
     Eventually,
+    /// Used for the l2s construction (may end up replaced with just Prime)
+    Next,
+    /// Past operator, used only for the l2s construction
+    Previously,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
@@ -20,6 +24,10 @@ pub enum BinOp {
     NotEquals,
     Implies,
     Iff,
+    /// Used for the l2s construction
+    Until,
+    /// Past operator, used only for the l2s construction
+    Since,
 }
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
@@ -48,7 +56,6 @@ pub enum Term {
     UnaryOp(UOp, Box<Term>),
     BinOp(BinOp, Box<Term>, Box<Term>),
     NAryOp(NOp, Vec<Term>),
-    #[allow(dead_code)]
     Ite {
         cond: Box<Term>,
         then: Box<Term>,

--- a/src/solver/sexp.rs
+++ b/src/solver/sexp.rs
@@ -45,7 +45,7 @@ fn term_primes(t: &Term, num_primes: usize) -> Sexp {
                     term_primes(arg, num_primes + 1)
                 }
                 // TODO: temporal stuff should be eliminated before here
-                UOp::Always | UOp::Eventually => {
+                UOp::Always | UOp::Eventually | UOp::Next | UOp::Previously => {
                     panic!("attempt to encode a temporal formula for smt")
                 }
             }
@@ -57,6 +57,9 @@ fn term_primes(t: &Term, num_primes: usize) -> Sexp {
                 BinOp::NotEquals => app("distinct", args),
                 BinOp::Implies => app("=>", args),
                 BinOp::Iff => app("=", args),
+                BinOp::Until | BinOp::Since => {
+                    panic!("attempt to encode a temporal formula for smt")
+                }
             }
         }
         Term::NAryOp(op, args) => {

--- a/src/term/fo.rs
+++ b/src/term/fo.rs
@@ -7,7 +7,7 @@
 
 use std::cmp::max;
 
-use crate::fly::syntax::{Term, UOp};
+use crate::fly::syntax::{BinOp, Term, UOp};
 
 use UOp::*;
 
@@ -64,7 +64,11 @@ fn unrolling(t: &Term) -> Unrolling {
         Term::App(_f, p, x) => Finite(*p) & max_unrolling(x),
         Term::UnaryOp(Always | Eventually, _) => Unrolling::Infinite,
         Term::UnaryOp(Not, t) => unrolling(t),
-        Term::UnaryOp(Prime, t) => Finite(1) + unrolling(t),
+        Term::UnaryOp(Prime, t) | Term::UnaryOp(Next, t) => Finite(1) + unrolling(t),
+        Term::UnaryOp(Previously, _) | Term::BinOp(BinOp::Since, _, _) => {
+            panic!("attempt to get unrolling of past operator")
+        }
+        Term::BinOp(BinOp::Until, _, _) => Unrolling::Infinite,
         Term::BinOp(_, lhs, rhs) => unrolling(lhs) & unrolling(rhs),
         Term::NAryOp(_, ts) => max_unrolling(ts),
         Term::Ite { cond, then, else_ } => unrolling(cond) & unrolling(then) & unrolling(else_),


### PR DESCRIPTION
These are some additional operators useful for the l2s construction. Next and Until are the primitive "future" temporal operators (which we can translate the current prime/always/eventually into), and Previously and Since are their past analogues that will only be used for the construction.

The Next and Previously modalities are written `X` and `X^-1`, as prefix operators. Until and Since are infix `until` and `since`.