### PR TITLE
Address some of Oded's comments

### DIFF
--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -40,7 +40,6 @@ pub struct Binder {
     pub sort: Sort,
 }
 
-// ODED: maybe Term should be Copy? (see test_eval in semantics.rs)
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub enum Term {
     Literal(bool),


### PR DESCRIPTION
These were some small ones I wanted to take care of.

There are a couple big renames I didn't do here: `Relation` to `Function`, and `typ` to `sort`. I agree with both of them, but let's hold off until the sort checking is merged.