### PR TITLE
Speed up model evaluation by using Interpretations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime 2.1.0",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -408,6 +421,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "im"
@@ -691,7 +710,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
- "env_logger",
+ "env_logger 0.7.1",
  "log",
 ]
 
@@ -914,6 +933,7 @@ dependencies = [
  "clap 4.0.32",
  "codespan-reporting",
  "criterion",
+ "env_logger 0.10.0",
  "eyre",
  "im",
  "insta",
@@ -925,6 +945,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
+ "test-log",
  "thiserror",
  "toml",
  "walkdir",
@@ -947,6 +968,17 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,10 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 criterion = "0.4.0"
+env_logger = "0.10.0"
 insta = { version = "1.22.0", features = ["yaml", "redactions"] }
 regex = "1.7.0"
+test-log = "0.2.11"
 
 [profile.dev.package.insta]
 opt-level = 3

--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -217,6 +217,11 @@ impl Signature {
             .unwrap_or_else(|| panic!("invalid relation {name}"))
     }
 
+    pub fn contains_name(&self, name: &str) -> bool {
+        let symbol_no_primes = name.trim_end_matches(|c| c == '\'');
+        return self.relations.iter().any(|r| r.name == symbol_no_primes);
+    }
+
     /// Compute all terms up to a certain nesting depth (optional), using the given variable names.
     /// If include_eq is true, include equality terms between any two same-sorted, non-Bool terms.
     ///

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -127,7 +127,7 @@ impl FOModule {
                     return Some(states.into_iter().collect_tuple().unwrap());
                 }
                 SatResp::Unsat => (),
-                SatResp::Unknown(_) => panic!(),
+                SatResp::Unknown(reason) => panic!("sat solver returned unknown: {reason}"),
             }
         }
 

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -218,4 +218,27 @@ mod tests {
         // auxilliary definition in Z3's model
         assert!(!fo_model.interp.contains_key("k!1058"));
     }
+
+    #[test]
+    fn test_parse_test_model() {
+        let sig = parser::parse_signature(
+            r#"
+        sort node
+        mutable votes(node, node): bool
+        "#
+            .trim(),
+        );
+
+        let backend = GenericBackend {
+            solver_type: SolverType::Z3,
+            bin: "z3".to_string(),
+        };
+
+        let model_text =
+            fs::read_to_string("tests/test_model.sexp").expect("could not find model file");
+        let model_sexp = sexp::parse(&model_text).expect("test model does not parse");
+
+        let fo_model = (&backend).parse(&sig, 0, &HashSet::new(), &model_sexp);
+        assert!(fo_model.interp.contains_key("votes"));
+    }
 }

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -202,7 +202,6 @@ mod tests {
     use test_log::test;
 
     #[test]
-    #[ignore]
     fn test_issue_5_parse_model_with_auxilliary_defs() {
         let _ = pretty_env_logger::try_init();
         let sig = parser::parse_signature(

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -179,6 +179,7 @@ mod tests {
     #[test]
     #[ignore] // parsing this model takes too long
     fn test_issue_5_parse_model_with_auxilliary_defs() {
+        let _ = pretty_env_logger::try_init();
         let sig = parser::parse_signature(
             r#"
         sort node
@@ -221,6 +222,7 @@ mod tests {
 
     #[test]
     fn test_parse_test_model() {
+        let _ = pretty_env_logger::try_init();
         let sig = parser::parse_signature(
             r#"
         sort node

--- a/src/solver/models.rs
+++ b/src/solver/models.rs
@@ -8,12 +8,33 @@ use thiserror::Error;
 
 use regex::Regex;
 
-use crate::smtlib::sexp::{atom_s, sexp_l, Atom, Sexp};
+use crate::{
+    fly::{
+        semantics::{Element, Interpretation},
+        syntax::Sort,
+    },
+    smtlib::sexp::{atom_s, sexp_l, Atom, Sexp},
+};
+
+#[derive(Debug, Clone)]
+pub struct PartialInterp {
+    universes: HashMap<String, Vec<String>>,
+    // reverse of universes
+    term_to_element: HashMap<String, Element>,
+    pub interps: HashMap<String, (Interpretation, Sort)>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ModelSymbol {
+    pub binders: Vec<(String, Sort)>,
+    pub body: Sexp,
+    pub ret_sort: Sort,
+}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct Model {
     pub universes: HashMap<String, Vec<String>>,
-    pub symbols: HashMap<String, (Vec<String>, Sexp)>,
+    pub symbols: HashMap<String, ModelSymbol>,
 }
 
 #[derive(Debug, Error)]
@@ -43,7 +64,16 @@ pub fn subst(repl: &[(&str, Sexp)], e: &Sexp) -> Sexp {
     subst_hashmap(&repl_map, e)
 }
 
-fn parse_binders(binders: &Sexp) -> Vec<String> {
+fn parse_sort(sort: &Sexp) -> Sort {
+    let sort_name = sort.atom_s().unwrap();
+    if sort_name == "Bool" {
+        Sort::Bool
+    } else {
+        Sort::Id(sort_name.to_string())
+    }
+}
+
+fn parse_binders(binders: &Sexp) -> Vec<(String, Sort)> {
     let binder_sexps = binders.list().unwrap();
     binder_sexps
         .iter()
@@ -51,14 +81,16 @@ fn parse_binders(binders: &Sexp) -> Vec<String> {
             // b should be a list of (name type)
             let ss = b.list().unwrap();
             assert!(ss.len() == 2, "binder is ill-formed");
-            ss[0].atom_s().unwrap().to_string()
+            let name = ss[0].atom_s().unwrap().to_string();
+            let sort = parse_sort(&ss[1]);
+            (name, sort)
         })
         .collect()
 }
 
 pub(crate) fn parse_z3(model: &Sexp) -> Model {
     let mut universes: HashMap<String, Vec<String>> = HashMap::new();
-    let mut symbols: HashMap<String, (Vec<String>, Sexp)> = HashMap::new();
+    let mut symbols: HashMap<String, ModelSymbol> = HashMap::new();
     if let Some(ss) = model.list() {
         // remove a leading "model" for older versions
         let ss = if !ss.is_empty() && ss[0] == atom_s("model") {
@@ -88,9 +120,14 @@ pub(crate) fn parse_z3(model: &Sexp) -> Model {
                     );
                     let name = args[0].atom_s().unwrap().to_string();
                     let binders = parse_binders(&args[1]);
-                    // let sort = args[2].atom_s().unwrap();
+                    let ret_sort = parse_sort(&args[2]);
                     let body = args[3].clone();
-                    symbols.insert(name, (binders, body));
+                    let sym = ModelSymbol {
+                        binders,
+                        body,
+                        ret_sort,
+                    };
+                    symbols.insert(name, sym);
                 } else if head == "forall" {
                     // ignore, cardinality constraint
                 } else {
@@ -105,7 +142,7 @@ pub(crate) fn parse_z3(model: &Sexp) -> Model {
 pub(crate) fn parse_cvc(model: &Sexp, version5: bool) -> Model {
     let version4 = !version5;
     let mut universe_cardinalities: HashMap<String, usize> = HashMap::new();
-    let mut symbols: HashMap<String, (Vec<String>, Sexp)> = HashMap::new();
+    let mut symbols: HashMap<String, ModelSymbol> = HashMap::new();
     lazy_static! {
         static ref CARDINALITY_RE: Regex = Regex::new("cardinality of (.*) is ([0-9]+)$").unwrap();
     }
@@ -138,9 +175,14 @@ pub(crate) fn parse_cvc(model: &Sexp, version5: bool) -> Model {
                     );
                     let name = args[0].atom_s().unwrap().to_string();
                     let binders = parse_binders(&args[1]);
-                    // let sort = args[2].atom_s().unwrap();
+                    let ret_sort = parse_sort(&args[2]);
                     let body = args[3].clone();
-                    symbols.insert(name, (binders, body));
+                    let sym = ModelSymbol {
+                        binders,
+                        body,
+                        ret_sort,
+                    };
+                    symbols.insert(name, sym);
                 } else if version4 && head == "declare-sort" {
                     // cvc4 only
                     continue;
@@ -166,9 +208,61 @@ pub(crate) fn parse_cvc(model: &Sexp, version5: bool) -> Model {
     Model { universes, symbols }
 }
 
+impl PartialInterp {
+    pub fn for_model(model: &Model) -> Self {
+        let mut term_to_element = HashMap::new();
+        // the sort doesn't matter here (universe element names are already
+        // distinct between sorts)
+        for elements in model.universes.values() {
+            for (e_idx, term) in elements.iter().enumerate() {
+                term_to_element.insert(term.to_string(), e_idx);
+            }
+        }
+        Self {
+            term_to_element,
+            universes: model.universes.clone(),
+            interps: HashMap::new(),
+        }
+    }
+
+    fn has_eval(&self, f: &str) -> bool {
+        self.interps.contains_key(f)
+    }
+
+    fn eval(&self, f: &str, args: &[Atom]) -> String {
+        let (interp, ret_sort) = &self.interps[f];
+        let args = args
+            .iter()
+            .map(|atom| match atom {
+                Atom::I(_) => panic!("cannot evaluate on integers"),
+                Atom::S(name) => {
+                    if name == "true" {
+                        1
+                    } else if name == "false" {
+                        0
+                    } else {
+                        self.term_to_element[name]
+                    }
+                }
+            })
+            .collect::<Vec<usize>>();
+        let result_el = interp.get(&args);
+        match ret_sort {
+            Sort::Bool => {
+                if result_el == 1 {
+                    "true".to_string()
+                } else {
+                    "false".to_string()
+                }
+            }
+            Sort::Id(sort) => self.universes[sort][result_el].clone(),
+        }
+    }
+}
+
 impl Model {
-    fn eval_bool(&self, e: &Sexp) -> Result<bool, EvalError> {
-        let a = self.smt_eval(e)?;
+    fn eval_bool(&self, part_eval: &PartialInterp, e: &Sexp) -> Result<bool, EvalError> {
+        let a = self.smt_eval(part_eval, e)?;
         match a {
             Atom::S(s) if s == "true" => Ok(true),
             Atom::S(s) if s == "false" => Ok(false),
@@ -178,7 +272,10 @@ impl Model {
 
     /// Evaluate an SMT expression, reducing constants with known semantics. Fails
     /// if this does not result in an Atom.
-    pub fn smt_eval(&self, e: &Sexp) -> Result<Atom, EvalError> {
+    pub fn smt_eval(&self, part_eval: &PartialInterp, e: &Sexp) -> Result<Atom, EvalError> {
+        // println!("evaluating {e}");
+        let go_bool = |e: &Sexp| self.eval_bool(part_eval, e);
+        let go = |e: &Sexp| self.smt_eval(part_eval, e);
         match e {
             Sexp::Atom(a) => Ok(a.clone()),
             Sexp::Comment(_) => Err(EvalError("comment".to_string())),
@@ -198,36 +295,36 @@ impl Model {
                 if head == "and" {
                     let args = args
                         .iter()
-                        .map(|s| self.eval_bool(s))
+                        .map(|s| go_bool(s))
                         .collect::<Result<Vec<_>, _>>()?;
                     let v = args.iter().all(|x| *x);
                     Ok(bool_atom(v))
                 } else if head == "or" {
                     let args = args
                         .iter()
-                        .map(|s| self.eval_bool(s))
+                        .map(|s| go_bool(s))
                         .collect::<Result<Vec<_>, _>>()?;
                     let v = args.iter().any(|x| *x);
                     Ok(bool_atom(v))
                 } else if head == "not" || head == "!" {
                     assert_eq!(args.len(), 1);
-                    let x = self.eval_bool(args[0])?;
+                    let x = go_bool(args[0])?;
                     Ok(bool_atom(!x))
                 } else if head == "as" {
                     // type cast (basically ignored)
-                    self.smt_eval(args[0])
+                    go(args[0])
                 } else if head == "=" {
                     assert_eq!(args.len(), 2);
-                    let lhs = self.smt_eval(args[0])?;
-                    let rhs = self.smt_eval(args[1])?;
+                    let lhs = go(args[0])?;
+                    let rhs = go(args[1])?;
                     Ok(bool_atom(lhs == rhs))
                 } else if head == "ite" {
                     assert_eq!(args.len(), 3);
-                    let cond = self.eval_bool(args[0])?;
+                    let cond = go_bool(args[0])?;
                     if cond {
-                        self.smt_eval(args[1])
+                        go(args[1])
                     } else {
-                        self.smt_eval(args[2])
+                        go(args[2])
                     }
                 } else if head == "let" {
                     // (let ((x1 e1) (x2 e2)) e)
@@ -244,18 +341,30 @@ impl Model {
                         })
                         .collect();
                     let e = subst(&repl, args[1]);
-                    self.smt_eval(&e)
+                    go(&e)
                 } else if self.symbols.contains_key(head) {
-                    let (binders, body) = &self.symbols[head];
+                    if part_eval.has_eval(head) {
+                        let args = args.iter().flat_map(|e| go(e)).collect::<Vec<_>>();
+                        let res = part_eval.eval(head, &args);
+                        return Ok(Atom::S(res));
+                    }
+                    let ModelSymbol { binders, body, .. } = &self.symbols[head];
                     assert_eq!(
                         binders.len(),
                         args.len(),
                         "wrong number of arguments to {head}"
                     );
+                    let args = args
+                        .iter()
+                        .flat_map(|e| -> Result<Sexp, EvalError> {
+                            let a = go(e)?;
+                            Ok(Sexp::Atom(a))
+                        })
+                        .collect::<Vec<_>>();
                     let repl: Vec<(&str, Sexp)> = iter::zip(binders, args.iter().cloned())
-                        .map(|(name, e)| (name.as_str(), e.clone()))
+                        .map(|(binder, e)| (binder.0.as_str(), e))
                         .collect();
-                    self.smt_eval(&subst(&repl, body))
+                    go(&subst(&repl, body))
                 } else {
                     Err(EvalError(format!("unexpected function {head}")))
                 }

--- a/tests/test_model.sexp
+++ b/tests/test_model.sexp
@@ -1,0 +1,252 @@
+(
+  ;; universe for node:
+  ;;   node!val!52 node!val!41 node!val!4 node!val!22 node!val!36 node!val!51 node!val!15 node!val!23 node!val!16 node!val!69 node!val!37 node!val!20 node!val!9 node!val!12 node!val!29 node!val!1 node!val!5 node!val!30 node!val!19 node!val!21 node!val!24 node!val!7 node!val!27 node!val!48 node!val!53 node!val!62 node!val!46 node!val!42 node!val!40 node!val!50 node!val!31 node!val!45 node!val!57 node!val!58 node!val!11 node!val!34 node!val!13 node!val!47 node!val!61 node!val!18 node!val!35 node!val!49 node!val!25 node!val!54 node!val!14 node!val!43 node!val!32 node!val!33 node!val!28 node!val!55 node!val!38 node!val!8 node!val!2 node!val!60 node!val!66 node!val!65 node!val!26 node!val!70 node!val!71 node!val!10 node!val!68 node!val!59 node!val!6 node!val!17 node!val!44 node!val!0 node!val!64 node!val!72 node!val!39 node!val!3 node!val!56 node!val!63 node!val!67 
+  ;; -----------
+  ;; definitions for universe elements:
+  (declare-fun node!val!52 () node)
+  (declare-fun node!val!41 () node)
+  (declare-fun node!val!4 () node)
+  (declare-fun node!val!22 () node)
+  (declare-fun node!val!36 () node)
+  (declare-fun node!val!51 () node)
+  (declare-fun node!val!15 () node)
+  (declare-fun node!val!23 () node)
+  (declare-fun node!val!16 () node)
+  (declare-fun node!val!69 () node)
+  (declare-fun node!val!37 () node)
+  (declare-fun node!val!20 () node)
+  (declare-fun node!val!9 () node)
+  (declare-fun node!val!12 () node)
+  (declare-fun node!val!29 () node)
+  (declare-fun node!val!1 () node)
+  (declare-fun node!val!5 () node)
+  (declare-fun node!val!30 () node)
+  (declare-fun node!val!19 () node)
+  (declare-fun node!val!21 () node)
+  (declare-fun node!val!24 () node)
+  (declare-fun node!val!7 () node)
+  (declare-fun node!val!27 () node)
+  (declare-fun node!val!48 () node)
+  (declare-fun node!val!53 () node)
+  (declare-fun node!val!62 () node)
+  (declare-fun node!val!46 () node)
+  (declare-fun node!val!42 () node)
+  (declare-fun node!val!40 () node)
+  (declare-fun node!val!50 () node)
+  (declare-fun node!val!31 () node)
+  (declare-fun node!val!45 () node)
+  (declare-fun node!val!57 () node)
+  (declare-fun node!val!58 () node)
+  (declare-fun node!val!11 () node)
+  (declare-fun node!val!34 () node)
+  (declare-fun node!val!13 () node)
+  (declare-fun node!val!47 () node)
+  (declare-fun node!val!61 () node)
+  (declare-fun node!val!18 () node)
+  (declare-fun node!val!35 () node)
+  (declare-fun node!val!49 () node)
+  (declare-fun node!val!25 () node)
+  (declare-fun node!val!54 () node)
+  (declare-fun node!val!14 () node)
+  (declare-fun node!val!43 () node)
+  (declare-fun node!val!32 () node)
+  (declare-fun node!val!33 () node)
+  (declare-fun node!val!28 () node)
+  (declare-fun node!val!55 () node)
+  (declare-fun node!val!38 () node)
+  (declare-fun node!val!8 () node)
+  (declare-fun node!val!2 () node)
+  (declare-fun node!val!60 () node)
+  (declare-fun node!val!66 () node)
+  (declare-fun node!val!65 () node)
+  (declare-fun node!val!26 () node)
+  (declare-fun node!val!70 () node)
+  (declare-fun node!val!71 () node)
+  (declare-fun node!val!10 () node)
+  (declare-fun node!val!68 () node)
+  (declare-fun node!val!59 () node)
+  (declare-fun node!val!6 () node)
+  (declare-fun node!val!17 () node)
+  (declare-fun node!val!44 () node)
+  (declare-fun node!val!0 () node)
+  (declare-fun node!val!64 () node)
+  (declare-fun node!val!72 () node)
+  (declare-fun node!val!39 () node)
+  (declare-fun node!val!3 () node)
+  (declare-fun node!val!56 () node)
+  (declare-fun node!val!63 () node)
+  (declare-fun node!val!67 () node)
+  ;; cardinality constraint:
+  (forall ((x node))
+          (or (= x node!val!52)
+              (= x node!val!41)
+              (= x node!val!4)
+              (= x node!val!22)
+              (= x node!val!36)
+              (= x node!val!51)
+              (= x node!val!15)
+              (= x node!val!23)
+              (= x node!val!16)
+              (= x node!val!69)
+              (= x node!val!37)
+              (= x node!val!20)
+              (= x node!val!9)
+              (= x node!val!12)
+              (= x node!val!29)
+              (= x node!val!1)
+              (= x node!val!5)
+              (= x node!val!30)
+              (= x node!val!19)
+              (= x node!val!21)
+              (= x node!val!24)
+              (= x node!val!7)
+              (= x node!val!27)
+              (= x node!val!48)
+              (= x node!val!53)
+              (= x node!val!62)
+              (= x node!val!46)
+              (= x node!val!42)
+              (= x node!val!40)
+              (= x node!val!50)
+              (= x node!val!31)
+              (= x node!val!45)
+              (= x node!val!57)
+              (= x node!val!58)
+              (= x node!val!11)
+              (= x node!val!34)
+              (= x node!val!13)
+              (= x node!val!47)
+              (= x node!val!61)
+              (= x node!val!18)
+              (= x node!val!35)
+              (= x node!val!49)
+              (= x node!val!25)
+              (= x node!val!54)
+              (= x node!val!14)
+              (= x node!val!43)
+              (= x node!val!32)
+              (= x node!val!33)
+              (= x node!val!28)
+              (= x node!val!55)
+              (= x node!val!38)
+              (= x node!val!8)
+              (= x node!val!2)
+              (= x node!val!60)
+              (= x node!val!66)
+              (= x node!val!65)
+              (= x node!val!26)
+              (= x node!val!70)
+              (= x node!val!71)
+              (= x node!val!10)
+              (= x node!val!68)
+              (= x node!val!59)
+              (= x node!val!6)
+              (= x node!val!17)
+              (= x node!val!44)
+              (= x node!val!0)
+              (= x node!val!64)
+              (= x node!val!72)
+              (= x node!val!39)
+              (= x node!val!3)
+              (= x node!val!56)
+              (= x node!val!63)
+              (= x node!val!67)))
+  ;; -----------
+  (define-fun k!1058 ((x!0 node)) node
+    (ite (= x!0 node!val!54) node!val!54
+    (ite (= x!0 node!val!14) node!val!14
+    (ite (= x!0 node!val!7) node!val!7
+    (ite (= x!0 node!val!22) node!val!22
+    (ite (= x!0 node!val!35) node!val!35
+    (ite (= x!0 node!val!16) node!val!16
+    (ite (= x!0 node!val!59) node!val!59
+    (ite (= x!0 node!val!34) node!val!34
+    (ite (= x!0 node!val!24) node!val!24
+    (ite (= x!0 node!val!20) node!val!20
+    (ite (= x!0 node!val!10) node!val!10
+    (ite (= x!0 node!val!26) node!val!26
+    (ite (= x!0 node!val!39) node!val!39
+    (ite (= x!0 node!val!38) node!val!38
+    (ite (= x!0 node!val!30) node!val!30
+    (ite (= x!0 node!val!58) node!val!58
+    (ite (= x!0 node!val!19) node!val!19
+    (ite (= x!0 node!val!52) node!val!52
+    (ite (= x!0 node!val!49) node!val!49
+    (ite (= x!0 node!val!45) node!val!45
+    (ite (= x!0 node!val!60) node!val!60
+    (ite (= x!0 node!val!9) node!val!9
+    (ite (= x!0 node!val!15) node!val!15
+    (ite (= x!0 node!val!43) node!val!43
+    (ite (= x!0 node!val!1) node!val!1
+    (ite (= x!0 node!val!71) node!val!71
+    (ite (= x!0 node!val!47) node!val!47
+    (ite (= x!0 node!val!70) node!val!70
+    (ite (= x!0 node!val!29) node!val!29
+    (ite (= x!0 node!val!12) node!val!12
+    (ite (= x!0 node!val!8) node!val!8
+    (ite (= x!0 node!val!51) node!val!51
+    (ite (= x!0 node!val!53) node!val!53
+    (ite (= x!0 node!val!65) node!val!65
+    (ite (= x!0 node!val!66) node!val!66
+    (ite (= x!0 node!val!62) node!val!62
+    (ite (= x!0 node!val!40) node!val!40
+    (ite (= x!0 node!val!3) node!val!3
+    (ite (= x!0 node!val!56) node!val!56
+    (ite (= x!0 node!val!13) node!val!13
+    (ite (= x!0 node!val!42) node!val!42
+    (ite (= x!0 node!val!61) node!val!61
+    (ite (= x!0 node!val!68) node!val!68
+    (ite (= x!0 node!val!72) node!val!72
+    (ite (= x!0 node!val!28) node!val!28
+    (ite (= x!0 node!val!57) node!val!57
+    (ite (= x!0 node!val!0) node!val!0
+    (ite (= x!0 node!val!63) node!val!63
+    (ite (= x!0 node!val!21) node!val!21
+    (ite (= x!0 node!val!2) node!val!2
+    (ite (= x!0 node!val!5) node!val!5
+    (ite (= x!0 node!val!33) node!val!33
+    (ite (= x!0 node!val!44) node!val!44
+    (ite (= x!0 node!val!6) node!val!6
+    (ite (= x!0 node!val!41) node!val!41
+    (ite (= x!0 node!val!23) node!val!23
+    (ite (= x!0 node!val!17) node!val!17
+    (ite (= x!0 node!val!4) node!val!4
+    (ite (= x!0 node!val!27) node!val!27
+    (ite (= x!0 node!val!11) node!val!11
+    (ite (= x!0 node!val!37) node!val!37
+    (ite (= x!0 node!val!18) node!val!18
+    (ite (= x!0 node!val!48) node!val!48
+    (ite (= x!0 node!val!25) node!val!25
+    (ite (= x!0 node!val!31) node!val!31
+    (ite (= x!0 node!val!67) node!val!67
+    (ite (= x!0 node!val!46) node!val!46
+    (ite (= x!0 node!val!36) node!val!36
+    (ite (= x!0 node!val!55) node!val!55
+    (ite (= x!0 node!val!64) node!val!64
+    (ite (= x!0 node!val!50) node!val!50
+    (ite (= x!0 node!val!69) node!val!69
+      node!val!32)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+  (define-fun votes ((x!0 node) (x!1 node)) Bool
+    (or (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!22))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!11))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!7))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!8))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!60))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!65))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!28))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!30))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!26))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!10))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!39))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!49))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!54))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!51))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!35))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!33))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!38))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!36))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!34))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!16))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!19))
+        (and (= (k!1058 x!0) node!val!0) (= (k!1058 x!1) node!val!59))))
+)


### PR DESCRIPTION
Model evaluation could be very slow for Z3 models because it sometimes uses large auxilliary functions, which are evaluated over and over again while enumerating all the inputs for other functions. This is exacerbated by the fact that its models aren't minimized, so the universes are large - see #37 for some notes on that.

In order to speed up evaluation, this PR first constructs an `Interpretation` for every model symbol (not just the ones in the signature), and then it evaluates calls to previously evaluated functions using their `Interpretation` rather than by substituting their definition.

I added a new test which is just one auxilliary definition and one additional symbol, extracted from the large model. This test used to take 13s and now takes about 0.1s (both in release mode). Even in a debug build (which is the default for tests) this test takes under a second.

The old test now takes 5s in debug mode and has been un-ignored.

This PR isn't perfect because the model symbols aren't evaluated on demand. In order to get any performance benefit, a symbol has to be interpreted before it's used in other definitions, which requires evaluating in topological order. In order to make this code work at all I added a hack that sorts the auxilliary definitions first (those that aren't in the signature and only in the model), which makes these examples fast and deterministic compared to HashMap iteration order. Ultimately we should evaluate on demand, though, which is much more robust.

Fixes #26.