### PR TITLE
Minimize models from below, without intermediate models

### DIFF
--- a/src/smtlib/proc.rs
+++ b/src/smtlib/proc.rs
@@ -107,7 +107,7 @@ impl Z3Conf {
         cmd.args(["-in", "-smt2"]);
         cmd.option("model.completion", "true");
         let mut conf = Self(cmd);
-        conf.timeout_ms(10000);
+        conf.timeout_ms(20000);
         conf
     }
 

--- a/tests/examples/snapshots/fail/relations.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/relations.fly.cvc4.snap
@@ -13,12 +13,12 @@ error: assertion failure
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
-     p(@A_0) = true
-     p(@A_1) = false
+     p(@A_0) = false
+     p(@A_1) = true
      q(@A_0,@A_0) = true
      q(@A_0,@A_1) = true
      q(@A_1,@A_0) = true
      q(@A_1,@A_1) = true
-     a0 = @A_0
+     a0 = @A_1
 
 

--- a/tests/examples/snapshots/fail/relations.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/relations.fly.cvc5.snap
@@ -13,12 +13,12 @@ error: assertion failure
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
-     p(@A_0) = true
-     p(@A_1) = false
+     p(@A_0) = false
+     p(@A_1) = true
      q(@A_0,@A_0) = true
      q(@A_0,@A_1) = true
      q(@A_1,@A_0) = true
      q(@A_1,@A_1) = true
-     a0 = @A_0
+     a0 = @A_1
 
 

--- a/tests/examples/snapshots/fail/relations.fly.z3.snap
+++ b/tests/examples/snapshots/fail/relations.fly.z3.snap
@@ -16,8 +16,8 @@ error: assertion failure
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true
-     q(@A_0,@A_1) = false
-     q(@A_1,@A_0) = true
+     q(@A_0,@A_1) = true
+     q(@A_1,@A_0) = false
      q(@A_1,@A_1) = true
      a0 = @A_1
 

--- a/tests/examples/snapshots/fail/relations.fly.z3.snap
+++ b/tests/examples/snapshots/fail/relations.fly.z3.snap
@@ -13,12 +13,12 @@ error: assertion failure
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
-     p(@A_0) = false
-     p(@A_1) = true
+     p(@A_0) = true
+     p(@A_1) = false
      q(@A_0,@A_0) = true
      q(@A_0,@A_1) = true
      q(@A_1,@A_0) = false
      q(@A_1,@A_1) = true
-     a0 = @A_1
+     a0 = @A_0
 
 


### PR DESCRIPTION
The algorithm is now to find the "min max" cardinality; that is, the smallest cardinality such that every universe can be at most that size. Then, we use the old greedy minimization to reduce the sizes of the universes individually. This algorithm has been adapted slightly to not require getting intermediate models and to only rely on sat/unsat responses.

This is sufficient to make inference work on the consensus_epr example. The following now completes in about 3min on my laptop (compared to 30min before):
```sh
echo -e "3\nE quorum q\nF node n1 n2 n3\nF value v\n0\n3" | \
  cargo run --release -- infer examples/consensus_epr.fly --solver z3
```

Fixes #37.