### PR TITLE
ci: fix hashFiles invocation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/git/db/
             target/
             solvers/
-          key: ${{ runner.os }}-${{matrix.toolchain}}-cargo-${{ hashFiles('**/Cargo.lock,tools/solver-versions.sh') }}
+          key: ${{ runner.os }}-${{matrix.toolchain}}-cargo-${{ hashFiles('**/Cargo.lock','tools/solver-versions.sh') }}
           restore-keys: ${{ runner.os }}-${{matrix.toolchain}}-cargo-
       - name: Download solvers
         run: |


### PR DESCRIPTION
The call to `hashFiles` wasn't matching any files, which would've caused cache re-use troubles.