### PR TITLE
Track and report global timing statistics

### DIFF
--- a/src/bin/temporal-verifier.rs
+++ b/src/bin/temporal-verifier.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 use clap::Parser;
-use temporal_verifier::App;
+use temporal_verifier::{timing, App};
 
 fn main() {
     pretty_env_logger::init();
     let app = App::parse();
+    timing::TIMES.init();
     app.exec();
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,6 +7,7 @@ use std::{fs, path::PathBuf, process};
 
 use crate::inference::houdini;
 use crate::solver::solver_path;
+use crate::timing;
 use crate::{
     fly::{self, parser::parse_error_diagonistic, printer, sorts},
     inference::run_fixpoint,
@@ -57,6 +58,10 @@ struct VerifyArgs {
     #[command(flatten)]
     solver: SolverArgs,
 
+    #[arg(long)]
+    /// Print timing statistics
+    time: bool,
+
     /// File name for a .fly file
     file: String,
 }
@@ -69,6 +74,10 @@ struct InferArgs {
     #[arg(long)]
     /// Run the Houdini algorithm to infer invariants
     houdini: bool,
+
+    #[arg(long)]
+    /// Print timing statistics
+    time: bool,
 
     #[arg(long)]
     /// Try to extend model traces before looking for CEX in the frame
@@ -208,6 +217,9 @@ impl App {
             Command::Verify(ref args) => {
                 let conf = args.get_solver_conf();
                 let r = verify_module(&conf, &m);
+                if args.time {
+                    timing::report();
+                }
                 match r {
                     Ok(()) => println!("verifies!"),
                     Err(err) => {
@@ -227,6 +239,9 @@ impl App {
                 if houdini {
                     let conf = args.get_solver_conf();
                     let r = houdini::infer_module(&conf, &m);
+                    if args.time {
+                        timing::report();
+                    }
                     match r {
                         Ok(()) => println!("verifies!"),
                         Err(err) => {
@@ -244,6 +259,9 @@ impl App {
                 } else {
                     let conf = Rc::new(args.get_solver_conf());
                     run_fixpoint(conf, &m, args.extend_models, args.disj);
+                    if args.time {
+                        timing::report();
+                    }
                 }
             }
             Command::Inline { .. } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod inference;
 pub mod smtlib;
 pub mod solver;
 mod term;
+pub mod timing;
 mod verify;
 
 #[doc(hidden)]

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,129 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+use std::{
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+
+use itertools::Itertools;
+use lazy_static::lazy_static;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum TimeType {
+    CheckSatCall { sat: bool },
+    GetModel,
+    GetMinimalModel,
+}
+
+impl TimeType {
+    fn name(&self) -> &'static str {
+        match self {
+            TimeType::CheckSatCall { sat: false } => "check-sat (unsat)",
+            TimeType::CheckSatCall { sat: true } => "check-sat (sat)",
+            TimeType::GetModel => "get-model",
+            TimeType::GetMinimalModel => "get-minimal-model",
+        }
+    }
+}
+
+/// A single timing event.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct TimeInfo {
+    typ: TimeType,
+    dur: Duration,
+}
+
+#[derive(Clone, Debug)]
+struct TimingVec {
+    times: Vec<TimeInfo>,
+}
+
+/// A record of timing measurements.
+///
+/// `Sync` to support concurrent time recording.
+pub struct Timings(Mutex<TimingVec>, Instant);
+
+impl Timings {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Timings(Mutex::new(TimingVec { times: vec![] }), Instant::now())
+    }
+
+    /// Hack to make sure start time is initialized
+    pub fn init(&self) {}
+
+    fn record_duration(&self, typ: TimeType, dur: Duration) {
+        let mut times = self.0.lock().unwrap();
+        times.times.push(TimeInfo { typ, dur })
+    }
+
+    /// Record a timing elapsed since `start`.
+    pub fn elapsed(&self, typ: TimeType, start: Instant) {
+        let dur = start.elapsed();
+        self.record_duration(typ, dur);
+    }
+
+    /// Print a full timing report to stdout.
+    pub fn report(&self) {
+        if cfg!(debug_assertions) {
+            eprintln!("warning: this is a debug build, non-solver time will be worse");
+        }
+        let total_time = self.1.elapsed().as_secs_f64();
+        println!("{:<22}: {total_time:.1}s", "total");
+
+        let times = {
+            let times = self.0.lock().unwrap();
+            times.times.clone()
+        };
+        let count = times.len();
+        let solver_total = times
+            .iter()
+            .map(|info| info.dur)
+            .sum::<Duration>()
+            .as_secs_f64();
+        println!("  {:<20}: {:.1}s", "non-solver", total_time - solver_total);
+        println!(
+            "  {:<20}: {solver_total:.1}s {count:>4} calls",
+            "solver total",
+        );
+
+        let totals = times
+            .iter()
+            .into_grouping_map_by(|info| info.typ)
+            .fold((Duration::ZERO, 0), |(dur, count), _key, t| {
+                (dur + t.dur, count + 1)
+            });
+        for typ in [
+            TimeType::CheckSatCall { sat: false },
+            TimeType::CheckSatCall { sat: true },
+            TimeType::GetModel,
+            TimeType::GetMinimalModel,
+        ] {
+            let (time, count) = totals.get(&typ).unwrap_or(&(Duration::ZERO, 0));
+            if *count > 0 {
+                println!(
+                    "    {:<18}: {:.1}s {count:>4} calls ",
+                    typ.name(),
+                    time.as_secs_f64()
+                );
+            }
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref TIMES: Timings = Timings::new();
+}
+
+pub fn start() -> Instant {
+    Instant::now()
+}
+
+pub fn elapsed(typ: TimeType, start: Instant) {
+    TIMES.elapsed(typ, start)
+}
+
+pub fn report() {
+    TIMES.report()
+}


### PR DESCRIPTION
Track and report global timing statistics

The timing reports look like this:

```
total                 : 103.6s
  non-solver          : 39.1s
  solver total        : 64.5s 1342 calls
    check-sat (unsat) : 28.2s 1132 calls
    check-sat (sat)   : 22.1s  105 calls
    get-minimal-model : 14.2s  105 calls
```

The timing for each call is recorded so it would be easy to add some
distribution info here (for example, maybe the 90th percentile of
timings for check-sat calls).

For now, the focus is on breaking down time spent in the solver. For
convenience we also report total time spent elsewhere to make it easy to
tell if optimization effort should be put into solver usage vs. pure
Rust.

The implementation uses a global static variable in a `Mutex`, purely
for convenience. Eventually we could pass the `Timings` struct around to
eliminate the global variable, but for now this is good enough and still
useful.

Fixes #44.