### PR TITLE
Move inference config to command-line arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +975,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
+ "shell-words",
  "test-log",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ criterion = "0.4.0"
 env_logger = "0.10.0"
 insta = { version = "1.28.0", features = ["yaml", "redactions"] }
 regex = "1.7.1"
+shell-words = "1.1.0"
 test-log = "0.2.11"
 toml = "0.7.2"
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ correctness properties, including safety and liveness.
 
 `cargo run -- verify examples/lockserver.fly`
 
-`echo -e "1\nF node n1 n2\n0\n3" | cargo run -- infer examples/lockserver.fly`
+`cargo run -- infer examples/lockserver.fly --quantifier "F node n1 n2" --kpdnf-lit 3`
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ correctness properties, including safety and liveness.
 
 ## Try it out
 
-`cargo run -- verify examples/lockserver.fly`
+```sh
+cargo run -- verify examples/lockserver.fly`
 
-`cargo run -- infer examples/lockserver.fly --quantifier "F node n1 n2" --kpdnf-lit 3`
+cargo run -- infer examples/lockserver.fly --quantifier "F node n1 n2" --kpdnf-lit 3
+
+cargo run --release -- \
+  infer examples/consensus_epr.fly --time \
+  --quantifier "E quorum q" --quantifier "F node n1 n2 n3" --quantifier "F value v" \
+  --kpdnf-lit 3
+# note: this last example takes about 2min to run
+```
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@ correctness properties, including safety and liveness.
 
 ## Try it out
 
+Run `./tools/download-solvers.sh` to get compatible versions of the supported SMT solvers (Z3, CVC5, and CVC4).
+
 ```sh
 cargo run -- verify examples/lockserver.fly`
 
 cargo run -- infer examples/lockserver.fly --quantifier "F node n1 n2" --kpdnf-lit 3
 
-cargo run --release -- \
+env RUST_LOG=info cargo run --release -- \
   infer examples/consensus_epr.fly --time \
   --quantifier "E quorum q" --quantifier "F node n1 n2 n3" --quantifier "F value v" \
   --kpdnf-lit 3
-# note: this last example takes about 2min to run
+# note: this last example takes about two minutes to run
 ```
 
 ### Prerequisites

--- a/examples/lockserver.fly
+++ b/examples/lockserver.fly
@@ -3,6 +3,8 @@
 
 # Lock server example, translated from mypyvy
 # TEST --all-solvers -- verify
+# TEST --name infer-z3 -- infer --quantifier "F node n1 n2" --kpdnf-lit 3
+# TEST --name infer-cvc5 -- infer --solver cvc5 --quantifier "F node n1 n2" --kpdnf-lit 3
 
 sort node
 

--- a/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
+++ b/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
@@ -3,19 +3,20 @@ source: tests/test_examples.rs
 description: "--name=infer-cvc5.2 -- infer --solver cvc5 --quantifier 'F node n1 n2' --kpdnf-lit 3 examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
-Fixpoint:
-    forall n1:node, n2:node. !grant_msg(n1) | !server_holds_lock
-    forall n1:node, n2:node. !grant_msg(n1) | n1 = n2 | !grant_msg(n2)
-    forall n1:node, n2:node. !holds_lock(n1) | !server_holds_lock
-    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n1)
-    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n2)
-    forall n1:node, n2:node. !holds_lock(n1) | n1 = n2 | !holds_lock(n2)
-    forall n1:node, n2:node. !unlock_msg(n1) | !server_holds_lock
-    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n1)
-    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n2)
-    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n1)
-    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n2)
-    forall n1:node, n2:node. !unlock_msg(n1) | n1 = n2 | !unlock_msg(n2)
+proof {
+  invariant forall n1:node, n2:node. !grant_msg(n1) | !server_holds_lock
+  invariant forall n1:node, n2:node. !grant_msg(n1) | n1 = n2 | !grant_msg(n2)
+  invariant forall n1:node, n2:node. !holds_lock(n1) | !server_holds_lock
+  invariant forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n1)
+  invariant forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n2)
+  invariant forall n1:node, n2:node. !holds_lock(n1) | n1 = n2 | !holds_lock(n2)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !server_holds_lock
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n1)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n2)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n1)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n2)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | n1 = n2 | !unlock_msg(n2)
+}
 
 ======== STDERR: ===========
 

--- a/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
+++ b/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_examples.rs
+description: "--name=infer-cvc5.2 -- infer --solver cvc5 --quantifier 'F node n1 n2' --kpdnf-lit 3 examples/lockserver.fly"
+expression: combined_stdout_stderr
+---
+Fixpoint:
+    forall n1:node, n2:node. !grant_msg(n1) | !server_holds_lock
+    forall n1:node, n2:node. !grant_msg(n1) | n1 = n2 | !grant_msg(n2)
+    forall n1:node, n2:node. !holds_lock(n1) | !server_holds_lock
+    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n1)
+    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n2)
+    forall n1:node, n2:node. !holds_lock(n1) | n1 = n2 | !holds_lock(n2)
+    forall n1:node, n2:node. !unlock_msg(n1) | !server_holds_lock
+    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n1)
+    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n2)
+    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n1)
+    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n2)
+    forall n1:node, n2:node. !unlock_msg(n1) | n1 = n2 | !unlock_msg(n2)
+
+======== STDERR: ===========
+

--- a/examples/snapshots/lockserver.fly.infer-z3.1.snap
+++ b/examples/snapshots/lockserver.fly.infer-z3.1.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_examples.rs
+description: "--name=infer-z3.1 -- infer --quantifier 'F node n1 n2' --kpdnf-lit 3 examples/lockserver.fly"
+expression: combined_stdout_stderr
+---
+Fixpoint:
+    forall n1:node, n2:node. !grant_msg(n1) | !server_holds_lock
+    forall n1:node, n2:node. !grant_msg(n1) | n1 = n2 | !grant_msg(n2)
+    forall n1:node, n2:node. !holds_lock(n1) | !server_holds_lock
+    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n1)
+    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n2)
+    forall n1:node, n2:node. !holds_lock(n1) | n1 = n2 | !holds_lock(n2)
+    forall n1:node, n2:node. !unlock_msg(n1) | !server_holds_lock
+    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n1)
+    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n2)
+    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n1)
+    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n2)
+    forall n1:node, n2:node. !unlock_msg(n1) | n1 = n2 | !unlock_msg(n2)
+
+======== STDERR: ===========
+

--- a/examples/snapshots/lockserver.fly.infer-z3.1.snap
+++ b/examples/snapshots/lockserver.fly.infer-z3.1.snap
@@ -3,19 +3,20 @@ source: tests/test_examples.rs
 description: "--name=infer-z3.1 -- infer --quantifier 'F node n1 n2' --kpdnf-lit 3 examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
-Fixpoint:
-    forall n1:node, n2:node. !grant_msg(n1) | !server_holds_lock
-    forall n1:node, n2:node. !grant_msg(n1) | n1 = n2 | !grant_msg(n2)
-    forall n1:node, n2:node. !holds_lock(n1) | !server_holds_lock
-    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n1)
-    forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n2)
-    forall n1:node, n2:node. !holds_lock(n1) | n1 = n2 | !holds_lock(n2)
-    forall n1:node, n2:node. !unlock_msg(n1) | !server_holds_lock
-    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n1)
-    forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n2)
-    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n1)
-    forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n2)
-    forall n1:node, n2:node. !unlock_msg(n1) | n1 = n2 | !unlock_msg(n2)
+proof {
+  invariant forall n1:node, n2:node. !grant_msg(n1) | !server_holds_lock
+  invariant forall n1:node, n2:node. !grant_msg(n1) | n1 = n2 | !grant_msg(n2)
+  invariant forall n1:node, n2:node. !holds_lock(n1) | !server_holds_lock
+  invariant forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n1)
+  invariant forall n1:node, n2:node. !holds_lock(n1) | !grant_msg(n2)
+  invariant forall n1:node, n2:node. !holds_lock(n1) | n1 = n2 | !holds_lock(n2)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !server_holds_lock
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n1)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !grant_msg(n2)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n1)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | !holds_lock(n2)
+  invariant forall n1:node, n2:node. !unlock_msg(n1) | n1 = n2 | !unlock_msg(n2)
+}
 
 ======== STDERR: ===========
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,7 +5,7 @@ use codespan_reporting::diagnostic::{Diagnostic, Label};
 use std::rc::Rc;
 use std::{fs, path::PathBuf, process};
 
-use crate::inference::houdini;
+use crate::inference::{houdini, input_cfg};
 use crate::solver::solver_path;
 use crate::timing;
 use crate::{
@@ -260,7 +260,8 @@ impl App {
                     }
                 } else {
                     let conf = Rc::new(args.get_solver_conf());
-                    run_fixpoint(conf, &m, args.extend_models, args.disj);
+                    let infer_cfg = input_cfg(&m.signature);
+                    run_fixpoint(infer_cfg, conf, &m, args.extend_models, args.disj);
                     if args.time {
                         timing::report();
                     }

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -3,8 +3,6 @@
 
 use itertools::Itertools;
 use std::collections::HashMap;
-use std::io::BufRead;
-use std::io::Write;
 use std::rc::Rc;
 
 use crate::{
@@ -340,9 +338,9 @@ impl<T: LemmaQF> Frame<T> {
             self.entries.retain(|e| !e.weakened.is_empty());
         } else if let Some(index) = prog_index {
             let entry = self.entries.remove(index);
-            println!("    Replacing {} with", &entry.lemma.to_term());
+            log::info!("    Replacing {} with", &entry.lemma.to_term());
             for w in entry.weakened {
-                println!("        {}", &w.to_term());
+                log::info!("        {}", &w.to_term());
                 self.entries.push(FrameEntry {
                     lemma: w.clone(),
                     weakened: vec![w],
@@ -370,88 +368,26 @@ pub struct InferenceConfig {
     pub kpdnf_lit: Option<usize>,
 }
 
-/// Create a quantifier configuration using user input.
-// TODO: replace with config file or command-line arguments
-pub fn input_cfg(sig: &Signature) -> InferenceConfig {
-    let mut quantifiers = vec![];
-    let mut sorts = vec![];
-    let mut names = vec![];
+pub fn parse_quantifier(
+    sig: &Signature,
+    s: &str,
+) -> Result<(Option<Quantifier>, Sort, Vec<String>), String> {
+    let mut parts = s.split_whitespace();
 
-    let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout();
-
-    print!("Prefix length: ");
-    stdout.flush().unwrap();
-    let length = stdin
-        .lock()
-        .lines()
-        .next()
-        .unwrap()
-        .unwrap()
-        .parse::<usize>()
-        .unwrap();
-
-    println!();
-
-    println!("Please enter each quantifier on a separate line, in the form");
-    println!("<quantifier: F/E/*> <sort> <first var name> <second var name> ...");
-    for _ in 0..length {
-        let line = stdin.lock().lines().next().unwrap().unwrap();
-        let mut parts = line.split_whitespace();
-
-        quantifiers.push(match parts.next().unwrap() {
-            "*" => None,
-            "F" => Some(Quantifier::Forall),
-            "E" => Some(Quantifier::Exists),
-            _ => panic!("Invalid quantifier entered."),
-        });
-
-        let sort_id = parts.next().unwrap().to_string();
-        if sig.sorts.contains(&sort_id) {
-            sorts.push(Sort::Id(sort_id));
-        } else {
-            panic!("Invalid sort entered.");
-        }
-
-        names.push(parts.map(|s| s.to_string()).collect_vec());
-    }
-
-    println!();
-
-    print!("k-pDNF # of cubes: ");
-    stdout.flush().unwrap();
-    let kpdnf = stdin
-        .lock()
-        .lines()
-        .next()
-        .unwrap()
-        .unwrap()
-        .parse::<usize>()
-        .unwrap();
-
-    println!();
-
-    print!("k-pDNF # of literals: ");
-    stdout.flush().unwrap();
-    let kpdnf_lit = stdin
-        .lock()
-        .lines()
-        .next()
-        .unwrap()
-        .unwrap()
-        .parse::<usize>()
-        .unwrap();
-
-    let cfg = QuantifierConfig {
-        quantifiers,
-        sorts,
-        names,
-        depth: None,
-        include_eq: true,
+    let quantifier = match parts.next().unwrap() {
+        "*" => None,
+        "F" => Some(Quantifier::Forall),
+        "E" => Some(Quantifier::Exists),
+        _ => return Err("invalid quantifier (choose F/E/*)".to_string()),
     };
-    InferenceConfig {
-        cfg,
-        kpdnf_cubes: kpdnf,
-        kpdnf_lit: Some(kpdnf_lit),
-    }
+
+    let sort_id = parts.next().unwrap().to_string();
+    let sort = if sig.sorts.contains(&sort_id) {
+        Sort::Id(sort_id)
+    } else {
+        return Err(format!("invalid sort {sort_id}"));
+    };
+
+    let names = parts.map(|s| s.to_string()).collect_vec();
+    Ok((quantifier, sort, names))
 }

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -364,9 +364,15 @@ impl<T: LemmaQF> Frame<T> {
     }
 }
 
+pub struct InferenceConfig {
+    pub cfg: QuantifierConfig,
+    pub kpdnf_cubes: usize,
+    pub kpdnf_lit: Option<usize>,
+}
+
 /// Create a quantifier configuration using user input.
 // TODO: replace with config file or command-line arguments
-pub fn input_cfg(sig: &Signature) -> (QuantifierConfig, usize, Option<usize>) {
+pub fn input_cfg(sig: &Signature) -> InferenceConfig {
     let mut quantifiers = vec![];
     let mut sorts = vec![];
     let mut names = vec![];
@@ -436,15 +442,16 @@ pub fn input_cfg(sig: &Signature) -> (QuantifierConfig, usize, Option<usize>) {
         .parse::<usize>()
         .unwrap();
 
-    (
-        QuantifierConfig {
-            quantifiers,
-            sorts,
-            names,
-            depth: None,
-            include_eq: true,
-        },
-        kpdnf,
-        Some(kpdnf_lit),
-    )
+    let cfg = QuantifierConfig {
+        quantifiers,
+        sorts,
+        names,
+        depth: None,
+        include_eq: true,
+    };
+    InferenceConfig {
+        cfg,
+        kpdnf_cubes: kpdnf,
+        kpdnf_lit: Some(kpdnf_lit),
+    }
 }

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -9,14 +9,26 @@ use std::rc::Rc;
 use crate::{
     fly::{semantics::Model, syntax::Module},
     inference::{
-        basics::{input_cfg, FOModule, Frame},
+        basics::{FOModule, Frame, InferenceConfig},
         pdnf::PDNF,
     },
     verify::SolverConf,
 };
 
 /// Run a simple fixpoint algorithm on the configured lemma domain.
-pub fn run_fixpoint(conf: Rc<SolverConf>, m: &Module, extend_models: bool, disj: bool) {
+pub fn run_fixpoint(
+    infer_cfg: InferenceConfig,
+    conf: Rc<SolverConf>,
+    m: &Module,
+    extend_models: bool,
+    disj: bool,
+) {
+    let InferenceConfig {
+        cfg,
+        kpdnf_cubes: kpdnf,
+        kpdnf_lit,
+    } = infer_cfg;
+    let cfg = Rc::new(cfg);
     let fo = Rc::new(FOModule::new(m, disj));
 
     println!("Axioms:");
@@ -32,9 +44,6 @@ pub fn run_fixpoint(conf: Rc<SolverConf>, m: &Module, extend_models: bool, disj:
         println!("    {a}");
     }
     println!();
-
-    let (cfg, kpdnf, kpdnf_lit) = input_cfg(&m.signature);
-    let cfg = Rc::new(cfg);
 
     let mut frame = Frame::new(
         vec![cfg.quantify_false(PDNF::get_false(kpdnf, kpdnf_lit))],

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -31,19 +31,18 @@ pub fn run_fixpoint(
     let cfg = Rc::new(cfg);
     let fo = Rc::new(FOModule::new(m, disj));
 
-    println!("Axioms:");
+    log::debug!("Axioms:");
     for a in fo.axioms.iter() {
-        println!("    {a}");
+        log::debug!("    {a}");
     }
-    println!("Initial states:");
+    log::debug!("Initial states:");
     for a in fo.inits.iter() {
-        println!("    {a}");
+        log::debug!("    {a}");
     }
-    println!("Transitions:");
+    log::debug!("Transitions:");
     for a in fo.transitions.iter() {
-        println!("    {a}");
+        log::debug!("    {a}");
     }
-    println!();
 
     let mut frame = Frame::new(
         vec![cfg.quantify_false(PDNF::get_false(kpdnf, kpdnf_lit))],
@@ -55,13 +54,12 @@ pub fn run_fixpoint(
     let mut models: Vec<Model> = vec![];
 
     let print = |frame: &Frame<_>, s: &str| {
-        println!("[{}, {}] {}", frame.len(), frame.len_weakened(), s);
+        log::info!("[{}, {}] {}", frame.len(), frame.len_weakened(), s);
     };
 
     let atoms = cfg.atoms(&m.signature);
-    println!();
-    println!("Atoms in configuration: {}", atoms.len());
-    println!();
+    log::debug!("Atoms in configuration: {}", atoms.len());
+    log::debug!("");
 
     // Begin by overapproximating the initial states.
     let mut i_init = (0, 0);
@@ -114,13 +112,11 @@ pub fn run_fixpoint(
 
         // Verify safety of updated frame.
         if fo.trans_safe_cex(&conf, &frame_t).is_some() {
-            println!();
-            println!("Frame is unsafe! Aborting.");
+            log::warn!("Frame is unsafe! Aborting.");
             return;
         }
     }
 
-    println!();
     println!("Fixpoint:");
     for lemma in &frame_t {
         println!("    {lemma}");

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -117,8 +117,9 @@ pub fn run_fixpoint(
         }
     }
 
-    println!("Fixpoint:");
+    println!("proof {{");
     for lemma in &frame_t {
-        println!("    {lemma}");
+        println!("  invariant {lemma}");
     }
+    println!("}}");
 }

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -9,8 +9,8 @@
 mod basics;
 mod fixpoint;
 pub mod houdini;
-mod lemma;
+pub mod lemma;
 mod pdnf;
 
-pub use basics::input_cfg;
+pub use basics::{parse_quantifier, InferenceConfig};
 pub use fixpoint::run_fixpoint;

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -12,4 +12,5 @@ pub mod houdini;
 mod lemma;
 mod pdnf;
 
+pub use basics::input_cfg;
 pub use fixpoint::run_fixpoint;


### PR DESCRIPTION
The two current examples can now be run more simply as, for example:
```
cargo run -- infer examples/lockserver.fly --quantifier "F node n1 n2" --kpdnf-lit 3
env RUST_LOG=info cargo run --release -- \
  infer examples/consensus_epr.fly --time \
  --quantifier "E quorum q" --quantifier "F node n1 n2 n3" --quantifier "F value v" \
  --kpdnf-lit 3
```

By making inference self-contained to command line arguments we can also
add inference for the lockserver invariant as a snapshot test to CI.