### PR TITLE
Add a term() convenience for parsing in tests

### DIFF
--- a/src/fly/printer.rs
+++ b/src/fly/printer.rs
@@ -131,10 +131,10 @@ impl fmt::Display for Term {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fly::parser::parse_term;
+    use crate::fly::parser;
 
     fn parse(s: &str) -> Term {
-        parse_term(s).expect("invalid term in test")
+        parser::term(s)
     }
 
     fn reprint(s: &str) -> String {
@@ -145,7 +145,7 @@ mod tests {
     fn test_printer_basic() {
         let e = parse("a & b | c");
         insta::assert_display_snapshot!(term(&e), @"a & b | c");
-        assert_eq!(parse_term(&term(&e)), Ok(e));
+        assert_eq!(parse(&term(&e)), e);
     }
 
     #[test]
@@ -192,7 +192,7 @@ mod tests {
            @"(always a)' & (eventually (c = d)')");
 
         let s = "(p until q) since (always r)";
-        assert_eq!(parse_term(s), parse_term(&reprint(s)));
+        assert_eq!(parse(s), parse(&reprint(s)));
     }
 }
 

--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -390,7 +390,7 @@ mod tests {
     use std::vec;
 
     use super::{RelationDecl, Signature, Sort};
-    use crate::fly::parser::parse_term;
+    use crate::fly::parser::term;
 
     #[test]
     fn test_terms_by_sort() {
@@ -441,21 +441,9 @@ mod tests {
         assert_eq!(
             terms,
             vec![
-                vec![
-                    parse_term("a1").expect("parser error"),
-                    parse_term("a2").expect("parser error"),
-                    parse_term("c1").expect("parser error"),
-                ],
-                vec![
-                    parse_term("b").expect("parser error"),
-                    parse_term("c2").expect("parser error"),
-                ],
-                vec![
-                    parse_term("a1=a2").expect("parser error"),
-                    parse_term("a1=c1").expect("parser error"),
-                    parse_term("a2=c1").expect("parser error"),
-                    parse_term("b=c2").expect("parser error"),
-                ]
+                vec![term("a1"), term("a2"), term("c1"),],
+                vec![term("b"), term("c2"),],
+                vec![term("a1=a2"), term("a1=c1"), term("a2=c1"), term("b=c2"),]
             ]
         );
 
@@ -464,50 +452,50 @@ mod tests {
             terms,
             vec![
                 vec![
-                    parse_term("a1").expect("parser error"),
-                    parse_term("a2").expect("parser error"),
-                    parse_term("c1").expect("parser error"),
-                    parse_term("f21(b)").expect("parser error"),
-                    parse_term("f21(c2)").expect("parser error"),
-                    parse_term("f21(f12(a1))").expect("parser error"),
-                    parse_term("f21(f12(a2))").expect("parser error"),
-                    parse_term("f21(f12(c1))").expect("parser error"),
+                    term("a1"),
+                    term("a2"),
+                    term("c1"),
+                    term("f21(b)"),
+                    term("f21(c2)"),
+                    term("f21(f12(a1))"),
+                    term("f21(f12(a2))"),
+                    term("f21(f12(c1))"),
                 ],
                 vec![
-                    parse_term("b").expect("parser error"),
-                    parse_term("c2").expect("parser error"),
-                    parse_term("f12(a1)").expect("parser error"),
-                    parse_term("f12(a2)").expect("parser error"),
-                    parse_term("f12(c1)").expect("parser error"),
-                    parse_term("f12(f21(b))").expect("parser error"),
-                    parse_term("f12(f21(c2))").expect("parser error"),
+                    term("b"),
+                    term("c2"),
+                    term("f12(a1)"),
+                    term("f12(a2)"),
+                    term("f12(c1)"),
+                    term("f12(f21(b))"),
+                    term("f12(f21(c2))"),
                 ],
                 vec![
-                    parse_term("r(b, a1)").expect("parser error"),
-                    parse_term("r(b, a2)").expect("parser error"),
-                    parse_term("r(b, c1)").expect("parser error"),
-                    parse_term("r(c2, a1)").expect("parser error"),
-                    parse_term("r(c2, a2)").expect("parser error"),
-                    parse_term("r(c2, c1)").expect("parser error"),
-                    parse_term("r(b, f21(b))").expect("parser error"),
-                    parse_term("r(b, f21(c2))").expect("parser error"),
-                    parse_term("r(c2, f21(b))").expect("parser error"),
-                    parse_term("r(c2, f21(c2))").expect("parser error"),
-                    parse_term("r(f12(a1), a1)").expect("parser error"),
-                    parse_term("r(f12(a1), a2)").expect("parser error"),
-                    parse_term("r(f12(a1), c1)").expect("parser error"),
-                    parse_term("r(f12(a2), a1)").expect("parser error"),
-                    parse_term("r(f12(a2), a2)").expect("parser error"),
-                    parse_term("r(f12(a2), c1)").expect("parser error"),
-                    parse_term("r(f12(c1), a1)").expect("parser error"),
-                    parse_term("r(f12(c1), a2)").expect("parser error"),
-                    parse_term("r(f12(c1), c1)").expect("parser error"),
-                    parse_term("r(f12(a1), f21(b))").expect("parser error"),
-                    parse_term("r(f12(a1), f21(c2))").expect("parser error"),
-                    parse_term("r(f12(a2), f21(b))").expect("parser error"),
-                    parse_term("r(f12(a2), f21(c2))").expect("parser error"),
-                    parse_term("r(f12(c1), f21(b))").expect("parser error"),
-                    parse_term("r(f12(c1), f21(c2))").expect("parser error"),
+                    term("r(b, a1)"),
+                    term("r(b, a2)"),
+                    term("r(b, c1)"),
+                    term("r(c2, a1)"),
+                    term("r(c2, a2)"),
+                    term("r(c2, c1)"),
+                    term("r(b, f21(b))"),
+                    term("r(b, f21(c2))"),
+                    term("r(c2, f21(b))"),
+                    term("r(c2, f21(c2))"),
+                    term("r(f12(a1), a1)"),
+                    term("r(f12(a1), a2)"),
+                    term("r(f12(a1), c1)"),
+                    term("r(f12(a2), a1)"),
+                    term("r(f12(a2), a2)"),
+                    term("r(f12(a2), c1)"),
+                    term("r(f12(c1), a1)"),
+                    term("r(f12(c1), a2)"),
+                    term("r(f12(c1), c1)"),
+                    term("r(f12(a1), f21(b))"),
+                    term("r(f12(a1), f21(c2))"),
+                    term("r(f12(a2), f21(b))"),
+                    term("r(f12(a2), f21(c2))"),
+                    term("r(f12(c1), f21(b))"),
+                    term("r(f12(c1), f21(c2))"),
                 ]
             ]
         );
@@ -546,34 +534,30 @@ mod tests {
         assert_eq!(
             terms,
             vec![
+                vec![term("a1"), term("a2"), term("c1"),],
                 vec![
-                    parse_term("a1").expect("parser error"),
-                    parse_term("a2").expect("parser error"),
-                    parse_term("c1").expect("parser error"),
+                    term("b"),
+                    term("c2"),
+                    term("f12(a1)"),
+                    term("f12(a2)"),
+                    term("f12(c1)"),
                 ],
                 vec![
-                    parse_term("b").expect("parser error"),
-                    parse_term("c2").expect("parser error"),
-                    parse_term("f12(a1)").expect("parser error"),
-                    parse_term("f12(a2)").expect("parser error"),
-                    parse_term("f12(c1)").expect("parser error"),
-                ],
-                vec![
-                    parse_term("r(b, a1)").expect("parser error"),
-                    parse_term("r(b, a2)").expect("parser error"),
-                    parse_term("r(b, c1)").expect("parser error"),
-                    parse_term("r(c2, a1)").expect("parser error"),
-                    parse_term("r(c2, a2)").expect("parser error"),
-                    parse_term("r(c2, c1)").expect("parser error"),
-                    parse_term("r(f12(a1), a1)").expect("parser error"),
-                    parse_term("r(f12(a1), a2)").expect("parser error"),
-                    parse_term("r(f12(a1), c1)").expect("parser error"),
-                    parse_term("r(f12(a2), a1)").expect("parser error"),
-                    parse_term("r(f12(a2), a2)").expect("parser error"),
-                    parse_term("r(f12(a2), c1)").expect("parser error"),
-                    parse_term("r(f12(c1), a1)").expect("parser error"),
-                    parse_term("r(f12(c1), a2)").expect("parser error"),
-                    parse_term("r(f12(c1), c1)").expect("parser error"),
+                    term("r(b, a1)"),
+                    term("r(b, a2)"),
+                    term("r(b, c1)"),
+                    term("r(c2, a1)"),
+                    term("r(c2, a2)"),
+                    term("r(c2, c1)"),
+                    term("r(f12(a1), a1)"),
+                    term("r(f12(a1), a2)"),
+                    term("r(f12(a1), c1)"),
+                    term("r(f12(a2), a1)"),
+                    term("r(f12(a2), a2)"),
+                    term("r(f12(a2), c1)"),
+                    term("r(f12(c1), a1)"),
+                    term("r(f12(c1), a2)"),
+                    term("r(f12(c1), c1)"),
                 ]
             ]
         );

--- a/src/inference/pdnf.rs
+++ b/src/inference/pdnf.rs
@@ -231,42 +231,26 @@ impl LemmaQF for PDNF {
 #[allow(clippy::redundant_clone)]
 mod tests {
     use super::*;
-    use crate::fly::parser::parse_term;
+    use crate::fly::parser::term;
 
     #[test]
     fn test_add_literal_add_cube() {
-        let p1 = PDNF::from_dnf(
-            2,
-            None,
-            &parse_term("a | !b | (c & d) | (!d & e & !f & g)").unwrap(),
-        );
-        let p1_add_nc = PDNF::from_dnf(
-            2,
-            None,
-            &parse_term("a | !b | !c | d | (e & !f & g)").unwrap(),
-        );
-        let p1_add_nd = PDNF::from_dnf(2, None, &parse_term("a | !b | c | !d").unwrap());
-        let p1_add_e_nf =
-            PDNF::from_dnf(2, None, &parse_term("a | !b | (c & d) | (e & !f)").unwrap());
+        let p1 = PDNF::from_dnf(2, None, &term("a | !b | (c & d) | (!d & e & !f & g)"));
+        let p1_add_nc = PDNF::from_dnf(2, None, &term("a | !b | !c | d | (e & !f & g)"));
+        let p1_add_nd = PDNF::from_dnf(2, None, &term("a | !b | c | !d"));
+        let p1_add_e_nf = PDNF::from_dnf(2, None, &term("a | !b | (c & d) | (e & !f)"));
 
-        let p2 = PDNF::from_dnf(3, None, &parse_term("a | !b | (c & d) | (!d & c)").unwrap());
-        let p2_add_nd_ne = PDNF::from_dnf(
-            3,
-            None,
-            &parse_term("a | !b | (c & d) | (!d & c) | (!d & !e)").unwrap(),
-        );
-        let p3 = PDNF::from_dnf(
-            3,
-            None,
-            &parse_term("a | !b | (c & d) | (!d & e) | (!d & !e)").unwrap(),
-        );
+        let p2 = PDNF::from_dnf(3, None, &term("a | !b | (c & d) | (!d & c)"));
+        let p2_add_nd_ne =
+            PDNF::from_dnf(3, None, &term("a | !b | (c & d) | (!d & c) | (!d & !e)"));
+        let p3 = PDNF::from_dnf(3, None, &term("a | !b | (c & d) | (!d & e) | (!d & !e)"));
 
-        let a = parse_term("a").unwrap();
-        let b = parse_term("b").unwrap();
-        let c = parse_term("c").unwrap();
-        let d = parse_term("d").unwrap();
-        let e = parse_term("e").unwrap();
-        let f = parse_term("f").unwrap();
+        let a = term("a");
+        let b = term("b");
+        let c = term("c");
+        let d = term("d");
+        let e = term("e");
+        let f = term("f");
 
         assert!(p1.add_literal(a.clone()).unwrap().equiv(&p1));
         assert_eq!(p1.add_literal(a.flip()), None);
@@ -311,25 +295,17 @@ mod tests {
 
     #[test]
     fn test_subsumes_weaken() {
-        let p1 = PDNF::from_dnf(
-            2,
-            None,
-            &parse_term("a | b | (c & d) | (e & f & g)").unwrap(),
-        );
-        let p2 = PDNF::from_dnf(
-            2,
-            None,
-            &parse_term("a | b | d | (!e & f) | (f & g)").unwrap(),
-        );
+        let p1 = PDNF::from_dnf(2, None, &term("a | b | (c & d) | (e & f & g)"));
+        let p2 = PDNF::from_dnf(2, None, &term("a | b | d | (!e & f) | (f & g)"));
 
         let c1 = vec![
-            parse_term("!a").unwrap(),
-            parse_term("!b").unwrap(),
-            parse_term("!c").unwrap(),
-            parse_term("d").unwrap(),
-            parse_term("e").unwrap(),
-            parse_term("f").unwrap(),
-            parse_term("!g").unwrap(),
+            term("!a"),
+            term("!b"),
+            term("!c"),
+            term("d"),
+            term("e"),
+            term("f"),
+            term("!g"),
         ];
         let mut p_c1 = PDNF::get_false(2, None);
         p_c1.cubes.push(c1.to_vec());

--- a/src/term/cnf.rs
+++ b/src/term/cnf.rs
@@ -85,40 +85,37 @@ impl Cnf {
 
 #[cfg(test)]
 mod tests {
-    use crate::fly::parser::parse_term;
+    use crate::fly::parser::term;
     use crate::fly::syntax::{NOp, Term};
 
     use super::{cnf, Cnf};
 
     #[test]
     fn test_already_cnf() {
-        cnf(&parse_term("p & q & r & (a | b)").unwrap());
-        cnf(&parse_term("always p & q & r & (a | b)").unwrap());
+        cnf(&term("p & q & r & (a | b)"));
+        cnf(&term("always p & q & r & (a | b)"));
     }
 
     #[test]
     fn test_cnf_and() {
-        let t = Term::NAryOp(
-            NOp::And,
-            vec![parse_term("a").unwrap(), parse_term("b & c").unwrap()],
-        );
+        let t = Term::NAryOp(NOp::And, vec![term("a"), term("b & c")]);
         let cnf = Cnf::new(t.clone());
         // make sure this test is non-trivial
         assert_ne!(t, cnf.0);
-        assert_eq!(cnf.0, parse_term("a & b & c").unwrap());
+        assert_eq!(cnf.0, term("a & b & c"));
     }
 
     #[test]
     fn test_cnf_always() {
-        let t = parse_term("always (always (always p & q))").unwrap();
+        let t = term("always (always (always p & q))");
         let cnf = Cnf::new(t.clone());
         assert_ne!(t, cnf.0);
-        assert_eq!(cnf.0, parse_term("always p & q").unwrap());
+        assert_eq!(cnf.0, term("always p & q"));
     }
 
     #[test]
     fn test_cnf_single() {
-        let t = parse_term("p | q").unwrap();
+        let t = term("p | q");
         let cnf = Cnf::new(t.clone());
         assert_eq!(cnf.0, Term::NAryOp(NOp::And, vec![t]));
     }

--- a/src/term/fo.rs
+++ b/src/term/fo.rs
@@ -96,14 +96,9 @@ impl FirstOrder {
 
 #[cfg(test)]
 mod tests {
-    use crate::fly::parser::parse_term;
-    use crate::fly::syntax::Term;
+    use crate::fly::parser::term;
 
     use super::FirstOrder;
-
-    fn term(s: &str) -> Term {
-        parse_term(s).unwrap()
-    }
 
     #[test]
     fn test_fo() {

--- a/src/term/prime.rs
+++ b/src/term/prime.rs
@@ -73,14 +73,9 @@ impl Next {
 
 #[cfg(test)]
 mod tests {
-    use crate::fly::parser::parse_term;
-    use crate::fly::syntax::Term;
+    use crate::fly::parser::term;
 
     use super::Next;
-
-    fn term(s: &str) -> Term {
-        parse_term(s).unwrap()
-    }
 
     #[test]
     fn test_normalize() {

--- a/src/term/subst.rs
+++ b/src/term/subst.rs
@@ -57,17 +57,17 @@ pub fn substitute_qf(term: &Term, substitution: &Substitution) -> Term {
 #[allow(clippy::redundant_clone)]
 mod tests {
     use super::*;
-    use crate::fly::parser::parse_term;
+    use crate::fly::parser::term;
 
     #[test]
     fn test_subst_qf() {
         let x = Term::Id("x".to_string());
         let y = Term::Id("y".to_string());
 
-        let t1 = parse_term("(x | z) -> !y").expect("parser error.");
-        let t1_subx = parse_term("(y | z) -> !y").expect("parser error.");
-        let t1_suby = parse_term("(x | z) -> !x").expect("parser error.");
-        let t1_subt = parse_term("(((x | z) -> !y) | y) -> !x").expect("parser error.");
+        let t1 = term("(x | z) -> !y");
+        let t1_subx = term("(y | z) -> !y");
+        let t1_suby = term("(x | z) -> !x");
+        let t1_subt = term("(((x | z) -> !y) | y) -> !x");
 
         let mut subx = Substitution::new();
         subx.insert("x".to_string(), y.clone());


### PR DESCRIPTION
Avoids a bunch of `.unwrap()` and `.expect()` in tests for parsing constant strings.