### PR TITLE
Sort inference docs tests and tweaks

### DIFF
--- a/src/fly/sorts.rs
+++ b/src/fly/sorts.rs
@@ -220,12 +220,20 @@ pub fn term_has_all_sort_annotations(term: &Term) -> bool {
     match term {
         Term::Literal(_) | Term::Id(_) => true,
         Term::App(_f, _p, xs) => xs.iter().all(term_has_all_sort_annotations),
-        Term::UnaryOp(UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime, x) => {
-            term_has_all_sort_annotations(x)
-        }
-        Term::BinOp(BinOp::Equals | BinOp::NotEquals | BinOp::Implies | BinOp::Iff, x, y) => {
-            term_has_all_sort_annotations(x) && term_has_all_sort_annotations(y)
-        }
+        Term::UnaryOp(
+            UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime | UOp::Next | UOp::Previously,
+            x,
+        ) => term_has_all_sort_annotations(x),
+        Term::BinOp(
+            BinOp::Equals
+            | BinOp::NotEquals
+            | BinOp::Implies
+            | BinOp::Iff
+            | BinOp::Until
+            | BinOp::Since,
+            x,
+            y,
+        ) => term_has_all_sort_annotations(x) && term_has_all_sort_annotations(y),
         Term::NAryOp(NOp::And | NOp::Or, xs) => xs.iter().all(term_has_all_sort_annotations),
         Term::Ite { cond, then, else_ } => {
             term_has_all_sort_annotations(cond)
@@ -353,8 +361,9 @@ impl Context<'_> {
         shadowing_constraint: ShadowingConstraint,
     ) -> Result<(), SortError> {
         match self.names.insert(name.clone(), sort) {
-            Some(_) if shadowing_constraint == ShadowingConstraint::Disallow =>
-                Err(SortError::RedeclaredName(name)),
+            Some(_) if shadowing_constraint == ShadowingConstraint::Disallow => {
+                Err(SortError::RedeclaredName(name))
+            }
             _ => Ok(()),
         }
     }

--- a/src/fly/sorts.rs
+++ b/src/fly/sorts.rs
@@ -270,16 +270,24 @@ impl Context<'_> {
         }
     }
 
-    // all sorts must be declared in the module signature
-    // this function checks that, assuming that it gets called on all sorts
-    fn check_sort_exists_internal(&self, sort: &Sort, empty_allowed: bool) -> Result<(), SortError> {
+    // if the given sort is uninterpreted, check that it is declared in the module and report an error if not.
+    // if empty_allowed is true, then Sort("") does not cause an error.
+    // callers should not call this function directly, but rather [check_sort_exists] or [check_sort_exists_or_empty]
+    fn check_sort_exists_internal(
+        &self,
+        sort: &Sort,
+        empty_allowed: bool,
+    ) -> Result<(), SortError> {
         match sort {
             Sort::Bool => Ok(()),
             Sort::Id(a) if a.is_empty() && empty_allowed => Ok(()),
-            Sort::Id(a) => match self.sorts.contains(a) {
-                true => Ok(()),
-                false => Err(SortError::UnknownSort(a.clone())),
-            },
+            Sort::Id(a) => {
+                if !self.sorts.contains(a) {
+                    Err(SortError::UnknownSort(a.clone()))
+                } else {
+                    Ok(())
+                }
+            }
         }
     }
 

--- a/src/fly/sorts.rs
+++ b/src/fly/sorts.rs
@@ -22,12 +22,12 @@ pub enum SortError {
     UnificationFail(Sort, Sort),
     #[error("expected {expected} but found {found}")]
     ExpectedButFoundSorts { expected: Sort, found: Sort },
-    #[error("expected {expected} args but found {found} args")]
-    ExpectedButFoundArity { expected: usize, found: usize },
+    #[error("function {function_name} expected {expected} args but found {found} args")]
+    ExpectedButFoundArity { function_name: String, expected: usize, found: usize },
 
-    #[error("{0} expected args but didn't get them")]
+    #[error("{0} is a function/definition that takes arguments, but no arguments were passed")]
     Uncalled(String),
-    #[error("{0} was called but didn't take any args")]
+    #[error("{0} was called but it is not a function/definition")]
     Uncallable(String),
 
     #[error("could not solve for the sort of {0}")]
@@ -372,6 +372,7 @@ impl Context<'_> {
                 Some(NamedSort::Known(args, ret)) => {
                     if args.len() != xs.len() {
                         return Err(SortError::ExpectedButFoundArity {
+                            function_name: f.clone(),
                             expected: args.len(),
                             found: xs.len(),
                         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub mod bounded;
 mod command;
-mod fly;
+pub mod fly;
 mod inference;
 pub mod smtlib;
 pub mod solver;

--- a/tests/examples/fail/sorts/redeclared_def.fly
+++ b/tests/examples/fail/sorts/redeclared_def.fly
@@ -1,0 +1,8 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+sort s
+immutable f(bool): s
+def f(x: s) -> bool {
+    true
+}

--- a/tests/examples/fail/sorts/redeclared_function.fly
+++ b/tests/examples/fail/sorts/redeclared_function.fly
@@ -1,0 +1,6 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+sort s
+immutable f(s): bool
+immutable f(bool):s

--- a/tests/examples/fail/sorts/redeclared_sort.fly
+++ b/tests/examples/fail/sorts/redeclared_sort.fly
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+sort s
+sort s

--- a/tests/examples/fail/sorts/undeclared_sort.fly
+++ b/tests/examples/fail/sorts/undeclared_sort.fly
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+immutable f(bool): s
+

--- a/tests/examples/fail/sorts/unknown_function.fly
+++ b/tests/examples/fail/sorts/unknown_function.fly
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+sort s
+assert forall y:s. f(y) = f(y)

--- a/tests/examples/fail/sorts/unknown_variable.fly
+++ b/tests/examples/fail/sorts/unknown_variable.fly
@@ -1,0 +1,5 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+sort s
+assert forall y:s. x = y

--- a/tests/examples/snapshots/fail/sorts/arg_count_mismatch.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/arg_count_mismatch.fly.cvc4.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: expected 1 args but found 2 args
+error: function r expected 1 args but found 2 args
   ┌─ tests/examples/fail/sorts/arg_count_mismatch.fly:7:1
   │
 7 │ assert forall x:s. r(x, false)

--- a/tests/examples/snapshots/fail/sorts/arg_count_mismatch.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/arg_count_mismatch.fly.cvc5.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: expected 1 args but found 2 args
+error: function r expected 1 args but found 2 args
   ┌─ tests/examples/fail/sorts/arg_count_mismatch.fly:7:1
   │
 7 │ assert forall x:s. r(x, false)

--- a/tests/examples/snapshots/fail/sorts/arg_count_mismatch.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/arg_count_mismatch.fly.z3.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: expected 1 args but found 2 args
+error: function r expected 1 args but found 2 args
   ┌─ tests/examples/fail/sorts/arg_count_mismatch.fly:7:1
   │
 7 │ assert forall x:s. r(x, false)

--- a/tests/examples/snapshots/fail/sorts/def_arg_count.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/def_arg_count.fly.cvc4.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: expected 2 args but found 1 args
+error: function f expected 2 args but found 1 args
    ┌─ tests/examples/fail/sorts/def_arg_count.fly:10:1
    │
 10 │ assert forall x:s, y:s. f(x)

--- a/tests/examples/snapshots/fail/sorts/def_arg_count.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/def_arg_count.fly.cvc5.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: expected 2 args but found 1 args
+error: function f expected 2 args but found 1 args
    ┌─ tests/examples/fail/sorts/def_arg_count.fly:10:1
    │
 10 │ assert forall x:s, y:s. f(x)

--- a/tests/examples/snapshots/fail/sorts/def_arg_count.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/def_arg_count.fly.z3.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: expected 2 args but found 1 args
+error: function f expected 2 args but found 1 args
    ┌─ tests/examples/fail/sorts/def_arg_count.fly:10:1
    │
 10 │ assert forall x:s, y:s. f(x)

--- a/tests/examples/snapshots/fail/sorts/empty_call_def.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/empty_call_def.fly.cvc4.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: f was called but didn't take any args
+error: f was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/empty_call_def.fly:8:1
   │
 8 │ assert f()

--- a/tests/examples/snapshots/fail/sorts/empty_call_def.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/empty_call_def.fly.cvc5.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: f was called but didn't take any args
+error: f was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/empty_call_def.fly:8:1
   │
 8 │ assert f()

--- a/tests/examples/snapshots/fail/sorts/empty_call_def.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/empty_call_def.fly.z3.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: f was called but didn't take any args
+error: f was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/empty_call_def.fly:8:1
   │
 8 │ assert f()

--- a/tests/examples/snapshots/fail/sorts/empty_calls.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/empty_calls.fly.cvc4.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: x was called but didn't take any args
+error: x was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/empty_calls.fly:6:1
   │
 6 │ assert x()

--- a/tests/examples/snapshots/fail/sorts/empty_calls.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/empty_calls.fly.cvc5.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: x was called but didn't take any args
+error: x was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/empty_calls.fly:6:1
   │
 6 │ assert x()

--- a/tests/examples/snapshots/fail/sorts/empty_calls.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/empty_calls.fly.z3.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: x was called but didn't take any args
+error: x was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/empty_calls.fly:6:1
   │
 6 │ assert x()

--- a/tests/examples/snapshots/fail/sorts/redeclared_def.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_def.fly.cvc4.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_def.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: f was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_def.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_def.fly.cvc5.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_def.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: f was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_def.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_def.fly.z3.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_def.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: f was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_function.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_function.fly.cvc4.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_function.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: f was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_function.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_function.fly.cvc5.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_function.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: f was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_function.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_function.fly.z3.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_function.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: f was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_sort.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_sort.fly.cvc4.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_sort.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: sort s was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_sort.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_sort.fly.cvc5.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_sort.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: sort s was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/redeclared_sort.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/redeclared_sort.fly.z3.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/redeclared_sort.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: sort s was declared multiple times
+
+

--- a/tests/examples/snapshots/fail/sorts/uncallable.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/uncallable.fly.cvc4.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: x was called but didn't take any args
+error: x was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/uncallable.fly:7:1
   │
 7 │ assert forall x:s. x(true) = x

--- a/tests/examples/snapshots/fail/sorts/uncallable.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/uncallable.fly.cvc5.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: x was called but didn't take any args
+error: x was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/uncallable.fly:7:1
   │
 7 │ assert forall x:s. x(true) = x

--- a/tests/examples/snapshots/fail/sorts/uncallable.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/uncallable.fly.z3.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: x was called but didn't take any args
+error: x was called but it is not a function/definition
   ┌─ tests/examples/fail/sorts/uncallable.fly:7:1
   │
 7 │ assert forall x:s. x(true) = x

--- a/tests/examples/snapshots/fail/sorts/uncalled.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/uncalled.fly.cvc4.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: r expected args but didn't get them
+error: r is a function/definition that takes arguments, but no arguments were passed
   ┌─ tests/examples/fail/sorts/uncalled.fly:7:1
   │
 7 │ assert forall x:s. r = x

--- a/tests/examples/snapshots/fail/sorts/uncalled.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/uncalled.fly.cvc5.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: r expected args but didn't get them
+error: r is a function/definition that takes arguments, but no arguments were passed
   ┌─ tests/examples/fail/sorts/uncalled.fly:7:1
   │
 7 │ assert forall x:s. r = x

--- a/tests/examples/snapshots/fail/sorts/uncalled.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/uncalled.fly.z3.snap
@@ -6,7 +6,7 @@ expression: combined_stdout_stderr
 
 ======== STDERR: ===========
 sort checking error:
-error: r expected args but didn't get them
+error: r is a function/definition that takes arguments, but no arguments were passed
   ┌─ tests/examples/fail/sorts/uncalled.fly:7:1
   │
 7 │ assert forall x:s. r = x

--- a/tests/examples/snapshots/fail/sorts/undeclared_sort.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/undeclared_sort.fly.cvc4.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/undeclared_sort.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: sort s was not declared
+
+

--- a/tests/examples/snapshots/fail/sorts/undeclared_sort.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/undeclared_sort.fly.cvc5.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/undeclared_sort.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: sort s was not declared
+
+

--- a/tests/examples/snapshots/fail/sorts/undeclared_sort.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/undeclared_sort.fly.z3.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/undeclared_sort.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: sort s was not declared
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_function.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_function.fly.cvc4.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_function.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown function/definition f
+  ┌─ tests/examples/fail/sorts/unknown_function.fly:5:1
+  │
+5 │ assert forall y:s. f(y) = f(y)
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_function.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_function.fly.cvc5.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_function.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown function/definition f
+  ┌─ tests/examples/fail/sorts/unknown_function.fly:5:1
+  │
+5 │ assert forall y:s. f(y) = f(y)
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_function.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_function.fly.z3.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_function.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown function/definition f
+  ┌─ tests/examples/fail/sorts/unknown_function.fly:5:1
+  │
+5 │ assert forall y:s. f(y) = f(y)
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_name.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_name.fly.cvc4.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_name.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown variable/constant x
+  ┌─ tests/examples/fail/sorts/unknown_name.fly:5:1
+  │
+5 │ assert forall y:s. x = y
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_name.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_name.fly.cvc5.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_name.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown variable/constant x
+  ┌─ tests/examples/fail/sorts/unknown_name.fly:5:1
+  │
+5 │ assert forall y:s. x = y
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_name.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_name.fly.z3.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_name.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown variable/constant x
+  ┌─ tests/examples/fail/sorts/unknown_name.fly:5:1
+  │
+5 │ assert forall y:s. x = y
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_variable.fly.cvc4.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_variable.fly.cvc4.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_variable.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown variable/constant x
+  ┌─ tests/examples/fail/sorts/unknown_variable.fly:5:1
+  │
+5 │ assert forall y:s. x = y
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_variable.fly.cvc5.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_variable.fly.cvc5.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_variable.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown variable/constant x
+  ┌─ tests/examples/fail/sorts/unknown_variable.fly:5:1
+  │
+5 │ assert forall y:s. x = y
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/tests/examples/snapshots/fail/sorts/unknown_variable.fly.z3.snap
+++ b/tests/examples/snapshots/fail/sorts/unknown_variable.fly.z3.snap
@@ -1,0 +1,15 @@
+---
+source: tests/test_examples.rs
+description: "--expect-fail --all-solvers -- verify tests/examples/fail/sorts/unknown_variable.fly"
+expression: combined_stdout_stderr
+---
+
+======== STDERR: ===========
+sort checking error:
+error: unknown variable/constant x
+  ┌─ tests/examples/fail/sorts/unknown_variable.fly:5:1
+  │
+5 │ assert forall y:s. x = y
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+
+


### PR DESCRIPTION
In this PR I try to demonstrate what I had in mind with #51 about documentation and testing by applying those ideas to the sort inference module. I also made a few material improvements to the code.

In addition, I implemented a checker for the AST invariant that says that after the sort inference pass runs, there are no AST nodes with unannotated sorts. I assert that this function returns true at the end of sort inference. I think this is a good way to handle these kinds of situations throughout the flyvy codebase.

Edit: converted this to a draft because (1) I want to add some internal documentation as well, and (2) after that I want to get a review from Alex.