### PR TITLE
Examples of using solvers concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "log",
  "peg",
  "pretty_env_logger",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ lazy_static = "1.4.0"
 log = "0.4.17"
 peg = "0.8.1"
 pretty_env_logger = "0.4.0"
+rayon = "1.7.0"
 regex = "1.7.1"
 serde = { version = "1.0.154", features = ["derive"] }
 serde_derive = "1.0.154"

--- a/src/fly/concurrent.rs
+++ b/src/fly/concurrent.rs
@@ -1,9 +1,21 @@
 // Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
+//! Example of using solvers concurrently using rayon.
+//!
+//! The solver code itself is largely unaware of concurrency. The `conf` from
+//! which a solver can be created is shared among threads via a reference, and
+//! then each thread creates an owned `Solver` instance to operate on (which is
+//! not thread-safe).
+//!
+//! The example uses rayon's `par_map` to simplify spawning and joining all the
+//! tasks, but adds a bit of complexity by implementing a form of task
+//! cancellation if one of the parallel operations gets a Sat response from the
+//! solver.
+
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs};
+    use std::{collections::HashMap, fs, sync::Mutex};
 
     use rayon::prelude::*;
 
@@ -20,6 +32,29 @@ mod tests {
         term::Next,
         verify::{safety::InvariantAssertion, SolverConf},
     };
+
+    struct Task {
+        cancelled_m: Mutex<bool>,
+    }
+
+    impl Task {
+        /// Create a new tracker for a task.
+        pub fn new() -> Self {
+            return Self {
+                cancelled_m: Mutex::new(false),
+            };
+        }
+
+        /// Mark this task cancelled.
+        pub fn cancel(&self) {
+            *self.cancelled_m.lock().unwrap() = true;
+        }
+
+        /// Check if the task
+        pub fn is_cancelled(&self) -> bool {
+            *self.cancelled_m.lock().unwrap()
+        }
+    }
 
     #[test]
     fn test_concurrent_verify() {
@@ -55,12 +90,27 @@ mod tests {
         // to prove Next::prime(inv) in the post state for each proof invariant
         // separately
         let proof_inv = Term::and(inv_assert.proof_invs);
+        let task = Task::new();
         // rayon provides .par_iter(), which performs the invariant checks in
         // parallel; then we gather up a Vec of all the results due to the
         // `.collect()`.
+        //
+        // The `task` tracking above allows one of the parallel checks, if it
+        // finds that some invariant is not inductive, to cancel other checks.
+        // Note that this cannot terminate `solver.check_sat` calls that have
+        // already started (we don't track any handle to the solver for
+        // cancellation), but it can prevent checks that haven't started yet.
+        //
+        // Note that this particular form of cancellation is really only useful
+        // for automated usage, not for verifying user-provided invariants; it's
+        // useful to provide the user with feedback on all the invariants that
+        // are incorrect (or at least to wait a while for these results).
         let results = pf_invs
             .par_iter()
             .map(|inv| {
+                if task.is_cancelled() {
+                    return None;
+                }
                 // not bothering to check initiation
                 let mut solver = conf.solver(&m.signature, 2);
                 solver.assert(&inv_assert.next);
@@ -68,9 +118,16 @@ mod tests {
                 solver.assert(&Next::prime(&inv_assert.assumed_inv));
                 solver.assert(&proof_inv);
                 solver.assert(&Term::negate(Next::prime(inv)));
-                return solver.check_sat(HashMap::new());
+                let resp = solver.check_sat(HashMap::new());
+                // if this check fails, don't start new checks
+                if matches!(resp, Ok(SatResp::Unsat) | Err(_)) {
+                    task.cancel();
+                }
+                return Some(resp);
             })
-            .collect::<Vec<_>>();
+            // eliminate the `None` results from cancelled tasks
+            .flatten()
+            .collect::<Vec<Result<_, _>>>();
         for r in results {
             match r {
                 Ok(resp) => assert!(resp == SatResp::Unsat, "invariant is not inductive"),

--- a/src/fly/concurrent.rs
+++ b/src/fly/concurrent.rs
@@ -1,3 +1,6 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, fs};

--- a/src/fly/concurrent.rs
+++ b/src/fly/concurrent.rs
@@ -1,0 +1,72 @@
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, fs};
+
+    use crate::{
+        fly::{
+            self,
+            syntax::{Proof, Term, ThmStmt},
+        },
+        smtlib::proc::SatResp,
+        solver::{
+            backends::{GenericBackend, SolverType},
+            solver_path,
+        },
+        term::Next,
+        verify::{safety::InvariantAssertion, SolverConf},
+    };
+
+    #[test]
+    fn test_concurrent_verify() {
+        let file =
+            fs::read_to_string("examples/consensus_epr.fly").expect("could not find test file");
+        let m = fly::parse(&file).expect("could not parse test file");
+
+        let assumes: Vec<&Term> = m
+            .statements
+            .iter()
+            .filter_map(|s| match s {
+                ThmStmt::Assume(t) => Some(t),
+                _ => None,
+            })
+            .collect();
+        let pf: &Proof = m
+            .statements
+            .iter()
+            .filter_map(|s| match s {
+                ThmStmt::Assert(pf) => Some(pf),
+                _ => None,
+            })
+            .next()
+            .expect("should have one assertion");
+        let pf_invs = pf.invariants.iter().map(|inv| &inv.x).collect::<Vec<_>>();
+        let inv_assert = InvariantAssertion::for_assert(&assumes, &pf.assert.x, &pf_invs)
+            .expect("should be an invariant assertion");
+
+        let backend = GenericBackend::new(SolverType::Z3, &solver_path("z3"));
+        let conf = SolverConf { backend, tee: None };
+
+        // we'll assume proof_inv (all the invariants) in the pre state and try
+        // to prove Next::prime(inv) in the post state for each proof invariant
+        // separately
+        let proof_inv = Term::and(inv_assert.proof_invs);
+        let mut results = vec![];
+        for inv in &pf_invs {
+            // not bothering to check initiation
+            let mut solver = conf.solver(&m.signature, 2);
+            solver.assert(&inv_assert.next);
+            solver.assert(&inv_assert.assumed_inv);
+            solver.assert(&Next::prime(&inv_assert.assumed_inv));
+            solver.assert(&proof_inv);
+            solver.assert(&Term::negate(Next::prime(inv)));
+            results.push(solver.check_sat(HashMap::new()));
+            println!("{inv} {:?}", results.last().unwrap());
+        }
+        for r in results {
+            match r {
+                Ok(resp) => assert!(resp == SatResp::Unsat, "invariant is not inductive"),
+                Err(err) => panic!("something went wrong in solver: {err}"),
+            }
+        }
+    }
+}

--- a/src/fly/mod.rs
+++ b/src/fly/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
+mod concurrent;
 mod defs;
 pub mod parser;
 pub mod printer;

--- a/src/inference/houdini.rs
+++ b/src/inference/houdini.rs
@@ -11,7 +11,7 @@ use rayon::prelude::*;
 use crate::{
     fly::{
         semantics::Model,
-        syntax::{Module, Signature, Span, Term, ThmStmt},
+        syntax::{Module, Signature, Term, ThmStmt},
     },
     smtlib::proc::SatResp,
     term::Next,
@@ -26,41 +26,54 @@ use crate::{
 // user. The code currently overloads AssertionFailure which was only intended
 // for failures that are the direct result of checking a user assertion.
 
+struct Houdini {
+    conf: SolverConf,
+    sig: Signature,
+    assert: InvariantAssertion,
+    invs: Vec<Term>,
+}
+
+#[derive(Debug, Clone)]
+pub enum HoudiniError {
+    InitInvUnknown(String),
+    InductiveInvUnknown(String),
+    NotInductive,
+}
+
 enum SatResult {
     Sat(Vec<Model>),
     Unsat,
     Unknown(String),
 }
 
-/// Attempt to infer inductive invariants to prove `assert`.
-///
-/// On success, returns a list of invariants which are together inductive and
-/// include `assert.inv`.
-pub fn infer<'a>(
-    conf: &SolverConf,
-    sig: &Signature,
-    span: Span,
-    assert: &'a InvariantAssertion,
-) -> Result<Vec<&'a Term>, AssertionFailure> {
-    let mut invs = vec![&assert.inv];
-    invs.extend(assert.proof_invs.iter());
-    log::info!("Running Houdini, candidate invariants are:");
-    for &p in &invs {
-        log::info!("    {p}")
+impl Houdini {
+    fn new(conf: SolverConf, sig: &Signature, assert: InvariantAssertion) -> Self {
+        let mut invs = vec![assert.inv.clone()];
+        // TODO: support customization of initial candidate invariants
+        invs.extend(assert.proof_invs.iter().cloned());
+        log::info!("Running Houdini, candidate invariants are:");
+        for p in &invs {
+            log::info!("    {p}")
+        }
+        log::info!("");
+        Self {
+            conf,
+            sig: sig.clone(),
+            assert,
+            invs,
+        }
     }
-    log::info!("");
 
-    {
-        // filter based on initiation
+    fn initiation_filter(&mut self) -> Result<(), HoudiniError> {
         log::info!("Checking initiation:");
-        let mut not_implied: HashSet<&Term> = HashSet::new();
-        for &q in &invs {
+        let mut not_implied: HashSet<Term> = HashSet::new();
+        for q in &self.invs {
             if not_implied.contains(q) {
                 continue;
             };
             log::info!("    Checking {q}");
-            let mut solver = conf.solver(sig, 1);
-            solver.assert(&assert.init);
+            let mut solver = self.conf.solver(&self.sig, 1);
+            solver.assert(&self.assert.init);
             solver.assert(&Term::negate(q.clone()));
             let resp = solver.check_sat(HashMap::new()).expect("error in solver");
             match resp {
@@ -69,47 +82,38 @@ pub fn infer<'a>(
                     let states = solver.get_model();
                     assert_eq!(states.len(), 1);
                     // TODO(oded): make 0 and 1 special constants for this use
-                    assert_eq!(states[0].eval(&assert.init, None), 1);
+                    assert_eq!(states[0].eval(&self.assert.init, None), 1);
                     assert_eq!(states[0].eval(q, None), 0);
-                    for &qq in &invs {
+                    for qq in &self.invs {
                         if states[0].eval(qq, None) == 0 {
                             log::info!("        Pruning {qq}");
-                            not_implied.insert(qq);
+                            not_implied.insert(qq.clone());
                         }
                     }
                 }
                 SatResp::Unsat => (),
                 SatResp::Unknown(m) => {
-                    return Err(AssertionFailure {
-                        loc: span,
-                        reason: FailureType::InitInv,
-                        error: QueryError::Unknown(m),
-                    });
+                    return Err(HoudiniError::InitInvUnknown(m));
                 }
             }
         }
-        invs.retain(|q| !not_implied.contains(q));
+        self.invs.retain(|q| !not_implied.contains(q));
+        Ok(())
     }
-    log::info!("Candidate invariants are:");
-    for &p in &invs {
-        log::info!("    {p}")
-    }
-    log::info!("");
 
-    // compute fixed point
-    log::info!("Computing fixed point:");
-    loop {
-        let mut not_implied: HashSet<&Term> = HashSet::new();
-        let inv_checks = invs
+    fn inductive_iteration(&mut self) -> Result<bool, HoudiniError> {
+        let mut not_implied: HashSet<Term> = HashSet::new();
+        let inv_checks = self
+            .invs
             .par_iter()
             .filter(|q| !not_implied.contains(*q))
             .map(|q| {
                 log::info!("    Checking {q}");
-                let mut solver = conf.solver(sig, 2);
-                for &p in &invs {
+                let mut solver = self.conf.solver(&self.sig, 2);
+                for p in &self.invs {
                     solver.assert(p);
                 }
-                solver.assert(&assert.next);
+                solver.assert(&self.assert.next);
                 solver.assert(&Term::negate(Next::prime(q)));
                 let resp = solver.check_sat(HashMap::new()).expect("error in solver");
                 (
@@ -132,42 +136,62 @@ pub fn infer<'a>(
                 SatResult::Sat(states) => {
                     // TODO(oded): make 0 and 1 special constants for their use as Booleans
                     assert_eq!(states[1].eval(q, None), 0);
-                    for &qq in &invs {
+                    for qq in &self.invs {
                         if states[1].eval(qq, None) == 0 {
                             log::info!("        Pruning {qq}");
-                            not_implied.insert(qq);
+                            not_implied.insert(qq.clone());
                         }
                     }
                 }
                 SatResult::Unsat => (),
-                SatResult::Unknown(m) => {
-                    return Err(AssertionFailure {
-                        loc: span,
-                        reason: FailureType::NotInductive,
-                        error: QueryError::Unknown(m),
-                    });
-                }
+                SatResult::Unknown(m) => return Err(HoudiniError::InductiveInvUnknown(m)),
             }
         }
         if not_implied.is_empty() {
             log::info!("Fixed point reached");
+            return Ok(true);
+        }
+        self.invs.retain(|q| !not_implied.contains(q));
+        Ok(false)
+    }
+}
+
+/// Attempt to infer inductive invariants to prove `assert`.
+///
+/// On success, returns a list of invariants which are together inductive and
+/// include `assert.inv`.
+pub fn infer(
+    conf: &SolverConf,
+    sig: &Signature,
+    assert: &InvariantAssertion,
+) -> Result<Vec<Term>, HoudiniError> {
+    let mut state = Houdini::new(conf.clone(), sig, assert.clone());
+    state.initiation_filter()?;
+
+    log::info!("Candidate invariants are:");
+    for p in &state.invs {
+        log::info!("    {p}")
+    }
+    log::info!("");
+
+    // compute fixed point
+    log::info!("Computing fixed point:");
+    loop {
+        let done = state.inductive_iteration()?;
+        if done {
+            log::info!("Fixed point reached");
             break;
         }
-        invs.retain(|q| !not_implied.contains(q));
         log::info!("Candidate invariants are:");
-        for &p in &invs {
+        for p in &state.invs {
             log::info!("    {p}")
         }
         log::info!("");
     }
-    if invs.is_empty() || invs[0] != &assert.inv {
-        return Err(AssertionFailure {
-            loc: span,
-            reason: FailureType::NotInductive,
-            error: QueryError::Unknown("assertion not in fixed point".to_string()), // TODO(oded): better error reporting
-        });
+    if state.invs.is_empty() || state.invs[0] != assert.inv {
+        return Err(HoudiniError::NotInductive);
     }
-    Ok(invs)
+    Ok(state.invs)
 }
 
 /// Prove the assertions in a module using Houdini invariant inference.
@@ -187,7 +211,7 @@ pub fn infer_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
                 if let Ok(assert) =
                     InvariantAssertion::for_assert(&assumes, &pf.assert.x, &proof_invariants)
                 {
-                    let res = infer(conf, &m.signature, pf.assert.span, &assert);
+                    let res = infer(conf, &m.signature, &assert);
                     match res {
                         Ok(invs) => {
                             println!("# inferred invariant:");
@@ -199,7 +223,24 @@ pub fn infer_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
                             println!("}}");
                         }
 
-                        Err(err) => errors.push(err),
+                        Err(err) => errors.push(match err {
+                            HoudiniError::InitInvUnknown(m) => AssertionFailure {
+                                loc: pf.assert.span,
+                                reason: FailureType::InitInv,
+                                error: QueryError::Unknown(m),
+                            },
+                            HoudiniError::InductiveInvUnknown(m) => AssertionFailure {
+                                loc: pf.assert.span,
+                                reason: FailureType::NotInductive,
+                                error: QueryError::Unknown(m),
+                            },
+                            HoudiniError::NotInductive => AssertionFailure {
+                                loc: pf.assert.span,
+                                reason: FailureType::NotInductive,
+                                // TODO(oded): better error reporting here
+                                error: QueryError::Unknown("assertion not in fixed point".to_string()),
+                            },
+                        }),
                     }
                 } else {
                     errors.push(AssertionFailure {

--- a/src/smtlib/proc.rs
+++ b/src/smtlib/proc.rs
@@ -31,7 +31,7 @@ pub struct SmtProc {
 /// SatResp is a solver's response to a `(check-sat)` or similar command.
 ///
 /// For unknown it also returns the reason the solver provides.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SatResp {
     /// The query is satisfiable.
     Sat,

--- a/src/verify/module.rs
+++ b/src/verify/module.rs
@@ -17,6 +17,7 @@ use crate::{
     term::FirstOrder,
 };
 
+#[derive(Debug, Clone)]
 pub struct SolverConf {
     pub backend: GenericBackend,
     pub tee: Option<PathBuf>,


### PR DESCRIPTION
Adds a test that does something like `temporal-verifier verify`, but checks each proof invariant separately and concurrently (in each test the whole proof invariant is assumed in the pre state but only one conjunct is proven in the post state).

This PR also makes Houdini's checking concurrent over the candidate invariants. In the process I refactored the code to make the state more explicit; this can be reviewed by reading just the relevant commit. Unfortunately I did this only after starting the concurrency work so it isn't a completely separate PR.

These examples use rayon's parallel map feature. The example in `src/fly/concurrent.rs` also implements a simple form of task cancellation (see the comments in that file for details).

These particular examples are already too fast to measure any performance difference.