### PR TITLE
Don't expose assignment in Model::eval

### DIFF
--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -278,7 +278,7 @@ impl<T: LemmaQF> Frame<T> {
         let mut i = start_at.unwrap_or((0, 0));
         while i.0 < self.entries.len() {
             while i.1 < self.entries[i.0].weakened.len() {
-                if model.eval(&self.entries[i.0].weakened[i.1].to_term(), None) == 0 {
+                if model.eval(&self.entries[i.0].weakened[i.1].to_term()) == 0 {
                     self.entries[i.0].progress = true;
                     let lemma = self.entries[i.0].weakened.remove(i.1);
                     let mut new_lemmas = lemma.weaken(model, &self.cfg, Some(atoms));

--- a/src/inference/houdini.rs
+++ b/src/inference/houdini.rs
@@ -80,10 +80,10 @@ impl Houdini {
                     let states = solver.get_model();
                     assert_eq!(states.len(), 1);
                     // TODO(oded): make 0 and 1 special constants for this use
-                    assert_eq!(states[0].eval(&self.init, None), 1);
-                    assert_eq!(states[0].eval(q, None), 0);
+                    assert_eq!(states[0].eval(&self.init), 1);
+                    assert_eq!(states[0].eval(q), 0);
                     for qq in &self.invs {
-                        if states[0].eval(qq, None) == 0 {
+                        if states[0].eval(qq) == 0 {
                             log::info!("        Pruning {qq}");
                             not_implied.insert(qq.clone());
                         }
@@ -129,9 +129,9 @@ impl Houdini {
                     let states = solver.get_model();
                     assert_eq!(states.len(), 2);
                     // TODO(oded): make 0 and 1 special constants for their use as Booleans
-                    assert_eq!(states[1].eval(q, None), 0);
+                    assert_eq!(states[1].eval(q), 0);
                     for qq in &self.invs {
-                        if states[1].eval(qq, None) == 0 {
+                        if states[1].eval(qq) == 0 {
                             log::info!("        Pruning {qq}");
                             let mut not_implied = not_implied.lock().unwrap();
                             not_implied.insert(qq.clone());


### PR DESCRIPTION
Rather than having an `Option<Assignment>`, split `Model::eval` into a public
interface with no assignment and an internal one that takes an assignment.

In order to avoid dealing with `&Assignment`s, I also switched to
`im::HashMap` for assignments. This seems to have no performance impact
on running inference on the `consensus_epr.fly` example (as expected;
the hashmaps involved are extremely small, and the tradeoff between the
two is not large).
