### PR TITLE
Handle immutable symbols correctly

### DIFF
--- a/examples/fast_paxos_epr.fly
+++ b/examples/fast_paxos_epr.fly
@@ -13,6 +13,8 @@
 ## invariant to be inductive assuming the prior invariants, but the mypyvy proof
 ## already had this property.
 
+# TEST -- verify
+
 # sorts:
 sort node
 sort value

--- a/examples/fast_paxos_epr.fly
+++ b/examples/fast_paxos_epr.fly
@@ -1,0 +1,64 @@
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+## This file was generated from mypyvy.
+##
+## ./src/mypyvy.py --print-program=fly typecheck examples/pd/fast_paxos_epr.pyv
+##
+## Manually added "always" to axiom.
+##
+## Manually converted proof invariants to a sequence of assertions (at the time,
+## flyvy would check the conjunction of all proof invariants, which was not
+## efficient for this example). This changes semantics since it requires each
+## invariant to be inductive assuming the prior invariants, but the mypyvy proof
+## already had this property.
+
+# sorts:
+sort node
+sort value
+sort quorum_c
+sort quorum_f
+sort round
+
+# constants:
+immutable none: round
+
+# functions:
+
+
+# relations:
+immutable le(round, round): bool
+immutable fast(round): bool
+immutable member_c(node, quorum_c): bool
+immutable member_f(node, quorum_f): bool
+mutable one_a(round): bool
+mutable one_b(node, round): bool
+mutable left_round(node, round): bool
+mutable proposal(round, value): bool
+mutable vote(node, round, value): bool
+mutable decision(round, value): bool
+mutable any_msg(round): bool
+
+# axioms:
+assume always (forall X:round. le(X, X)) & (forall X:round, Y:round, Z:round. le(X, Y) & le(Y, Z) -> le(X, Z)) & (forall X:round, Y:round. le(X, Y) & le(Y, X) -> X = Y) & (forall X:round, Y:round. le(X, Y) | le(Y, X)) & (forall Q1:quorum_c, Q2:quorum_c. exists N:node. member_c(N, Q1) & member_c(N, Q2)) & (forall Q1:quorum_c, Q2:quorum_f, Q3:quorum_f. exists N:node. member_c(N, Q1) & member_f(N, Q2) & member_f(N, Q3))
+
+# init:
+assume (forall R:round. !one_a(R)) & (forall N:node, R:round. !one_b(N, R)) & (forall N:node, R:round. !left_round(N, R)) & (forall R:round, V:value. !proposal(R, V)) & (forall N:node, R:round, V:value. !vote(N, R, V)) & (forall R:round, V:value. !decision(R, V)) & (forall R:round. !any_msg(R))
+
+# transitions:
+assume always (exists r:round. r != none & (forall R:round. (one_a(R))' <-> one_a(R) | R = r) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:round, x1:value. (proposal(x0, x1))' = proposal(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists n:node, r:round. r != none & one_a(r) & !left_round(n, r) & (forall N:node, R:round. (one_b(N, R))' <-> one_b(N, R) | N = n & R = r) & (forall N:node, R:round. (left_round(N, R))' <-> left_round(N, R) | N = n & !le(r, R)) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:round, x1:value. (proposal(x0, x1))' = proposal(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists r:round, q:quorum_c, maxr:round, v:value, v2:value. r != none & (forall V:value. !proposal(r, V)) & !any_msg(r) & (forall N:node. member_c(N, q) -> one_b(N, r)) & maxr != none & (exists N:node. member_c(N, q) & !le(r, maxr) & vote(N, maxr, v)) & (forall N:node, MAXR:round, V:value. member_c(N, q) & !le(r, MAXR) & vote(N, MAXR, V) -> le(MAXR, maxr)) & (exists F:quorum_f. forall N:node. !(member_f(N, F) & member_c(N, q) & !vote(N, maxr, v2))) & (forall R:round, V:value. (proposal(R, V))' <-> proposal(R, V) | R = r & V = v2) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists r:round, q:quorum_c, maxr:round, v:value. r != none & (forall V:value. !proposal(r, V)) & !any_msg(r) & (forall N:node. member_c(N, q) -> one_b(N, r)) & maxr != none & (exists N:node. member_c(N, q) & !le(r, maxr) & vote(N, maxr, v)) & (forall N:node, MAXR:round, V:value. member_c(N, q) & !le(r, MAXR) & vote(N, MAXR, V) -> le(MAXR, maxr)) & (forall V2:value, F:quorum_f. exists N:node. member_f(N, F) & member_c(N, q) & !vote(N, maxr, V2)) & (forall R:round, V:value. (proposal(R, V))' <-> proposal(R, V) | R = r & V = v) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists r:round, q:quorum_c, v:value. r != none & (forall V:value. !proposal(r, V)) & !any_msg(r) & (forall N:node. member_c(N, q) -> one_b(N, r)) & (forall N:node, MAXR:round, V:value. !(member_c(N, q) & !le(r, MAXR) & vote(N, MAXR, V))) & fast(r) & (forall R:round. (any_msg(R))' <-> any_msg(R) | R = r) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:round, x1:value. (proposal(x0, x1))' = proposal(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1))) | (exists r:round, q:quorum_c, v:value. r != none & (forall V:value. !proposal(r, V)) & !any_msg(r) & (forall N:node. member_c(N, q) -> one_b(N, r)) & (forall N:node, MAXR:round, V:value. !(member_c(N, q) & !le(r, MAXR) & vote(N, MAXR, V))) & !fast(r) & (forall R:round, V:value. (proposal(R, V))' <-> proposal(R, V) | R = r & V = v) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists n:node, v:value, r:round. r != none & !left_round(n, r) & (forall V:value. !vote(n, r, V)) & (proposal(r, v) | any_msg(r)) & (forall N:node, R:round, V:value. (vote(N, R, V))' <-> vote(N, R, V) | N = n & R = r & V = v) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:round, x1:value. (proposal(x0, x1))' = proposal(x0, x1)) & (forall x0:round, x1:value. (decision(x0, x1))' = decision(x0, x1)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists r:round, v:value, q:quorum_c. r != none & !fast(r) & (forall N:node. member_c(N, q) -> vote(N, r, v)) & (forall R:round, V:value. (decision(R, V))' <-> decision(R, V) | R = r & V = v) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:round, x1:value. (proposal(x0, x1))' = proposal(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round. (any_msg(x0))' = any_msg(x0))) | (exists r:round, v:value, q:quorum_f. r != none & fast(r) & (forall N:node. member_f(N, q) -> vote(N, r, v)) & (forall R:round, V:value. (decision(R, V))' <-> decision(R, V) | R = r & V = v) & (forall x0:round. (one_a(x0))' = one_a(x0)) & (forall x0:node, x1:round. (one_b(x0, x1))' = one_b(x0, x1)) & (forall x0:node, x1:round. (left_round(x0, x1))' = left_round(x0, x1)) & (forall x0:round, x1:value. (proposal(x0, x1))' = proposal(x0, x1)) & (forall x0:node, x1:round, x2:value. (vote(x0, x1, x2))' = vote(x0, x1, x2)) & (forall x0:round. (any_msg(x0))' = any_msg(x0)))
+
+assert always forall R:round, V1:value, V2:value. proposal(R, V1) & proposal(R, V2) -> V1 = V2
+assert always forall R:round. any_msg(R) -> fast(R)
+assert always forall R:round, N:node, V:value. !fast(R) & vote(N, R, V) -> proposal(R, V)
+assert always forall R:round, N:node, V:value. fast(R) & vote(N, R, V) -> proposal(R, V) | any_msg(R)
+assert always forall R:round, V:value. !(any_msg(R) & proposal(R, V))
+assert always forall R:round, N:node, V1:value, V2:value. fast(R) & vote(N, R, V1) & vote(N, R, V2) -> V1 = V2
+assert always forall R:round, V:value. !fast(R) & decision(R, V) -> (exists Q:quorum_c. forall N:node. member_c(N, Q) -> vote(N, R, V))
+assert always forall R:round, V:value. fast(R) & decision(R, V) -> (exists Q:quorum_f. forall N:node. member_f(N, Q) -> vote(N, R, V))
+assert always forall N:node, R2:round, R1:round. one_b(N, R2) & !le(R2, R1) -> left_round(N, R1)
+assert always forall R1:round, R2:round, V1:value, V2:value, Q:quorum_c. !fast(R1) & !le(R2, R1) & (proposal(R2, V2) & V1 != V2 | any_msg(R2)) -> (exists N:node. member_c(N, Q) & left_round(N, R1) & !vote(N, R1, V1))
+assert always forall R1:round, R2:round, V1:value, V2:value, Q:quorum_f. fast(R1) & !le(R2, R1) & (proposal(R2, V2) & V1 != V2 | any_msg(R2)) -> (exists N:node. member_f(N, Q) & left_round(N, R1) & !vote(N, R1, V1))
+
+# safety:
+assert always (forall R1:round, V1:value, R2:round, V2:value. decision(R1, V1) & decision(R2, V2) -> V1 = V2)

--- a/examples/snapshots/fast_paxos_epr.fly.snap
+++ b/examples/snapshots/fast_paxos_epr.fly.snap
@@ -1,0 +1,9 @@
+---
+source: tests/test_examples.rs
+description: "-- verify examples/fast_paxos_epr.fly"
+expression: combined_stdout_stderr
+---
+verifies!
+
+======== STDERR: ===========
+

--- a/src/fly/concurrent.rs
+++ b/src/fly/concurrent.rs
@@ -80,8 +80,9 @@ mod tests {
             .next()
             .expect("should have one assertion");
         let pf_invs = pf.invariants.iter().map(|inv| &inv.x).collect::<Vec<_>>();
-        let inv_assert = InvariantAssertion::for_assert(&assumes, &pf.assert.x, &pf_invs)
-            .expect("should be an invariant assertion");
+        let inv_assert =
+            InvariantAssertion::for_assert(&m.signature, &assumes, &pf.assert.x, &pf_invs)
+                .expect("should be an invariant assertion");
 
         let backend = GenericBackend::new(SolverType::Z3, &solver_path("z3"));
         let conf = SolverConf { backend, tee: None };
@@ -115,9 +116,9 @@ mod tests {
                 let mut solver = conf.solver(&m.signature, 2);
                 solver.assert(&inv_assert.next);
                 solver.assert(&inv_assert.assumed_inv);
-                solver.assert(&Next::prime(&inv_assert.assumed_inv));
+                solver.assert(&Next::new(&m.signature).prime(&inv_assert.assumed_inv));
                 solver.assert(&proof_inv);
-                solver.assert(&Term::negate(Next::prime(inv)));
+                solver.assert(&Term::negate(Next::new(&m.signature).prime(inv)));
                 let resp = solver.check_sat(HashMap::new());
                 // if this check fails, don't start new checks
                 if matches!(resp, Ok(SatResp::Unsat) | Err(_)) {

--- a/src/fly/parser.rs
+++ b/src/fly/parser.rs
@@ -325,7 +325,7 @@ pub fn term(s: &str) -> Term {
 #[cfg(test)]
 /// Parse a signature. Only used for testing.
 pub fn parse_signature(s: &str) -> Signature {
-    parser::signature(s).expect("invalid signature in test")
+    parser::signature(s.trim()).expect("invalid signature in test")
 }
 
 /// Parse a fly module, reporting a human-readable error on failure.

--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -216,6 +216,15 @@ impl Signature {
             .unwrap_or_else(|| panic!("could not find relation {name}"))
     }
 
+    /// Returns true if name is an immutable relation, or a primed version of one.
+    pub fn is_immutable(&self, name: &str) -> bool {
+        let name = name.trim_end_matches('\'');
+        match self.relations.iter().find(|x| x.name == name) {
+            Some(decl) => !decl.mutable,
+            None => false,
+        }
+    }
+
     pub fn relation_idx(&self, name: &str) -> usize {
         self.relations
             .iter()
@@ -223,6 +232,8 @@ impl Signature {
             .unwrap_or_else(|| panic!("invalid relation {name}"))
     }
 
+    /// Check if `name` is a relation in the signature, or a primed version of
+    /// one.
     pub fn contains_name(&self, name: &str) -> bool {
         let symbol_no_primes = name.trim_end_matches(|c| c == '\'');
         return self.relations.iter().any(|r| r.name == symbol_no_primes);

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -48,7 +48,9 @@ impl FOModule {
                     } else if let Term::UnaryOp(UOp::Always, t) = t {
                         match FirstOrder::unrolling(t) {
                             Some(0) => fo.axioms.push(t.as_ref().clone()),
-                            Some(1) => fo.transitions.push(Next::normalize(t.as_ref())),
+                            Some(1) => fo
+                                .transitions
+                                .push(Next::new(&m.signature).normalize(t.as_ref())),
                             _ => (),
                         }
                     }
@@ -112,9 +114,9 @@ impl FOModule {
                 solver.assert(a);
             }
             for a in self.axioms.iter() {
-                solver.assert(&Next::prime(a));
+                solver.assert(&Next::new(&self.signature).prime(a));
             }
-            solver.assert(&Term::negate(Next::prime(t)));
+            solver.assert(&Term::negate(Next::new(&self.signature).prime(t)));
 
             let resp = solver.check_sat(HashMap::new()).expect("error in solver");
             match resp {

--- a/src/inference/houdini.rs
+++ b/src/inference/houdini.rs
@@ -122,7 +122,7 @@ impl Houdini {
                     solver.assert(p);
                 }
                 solver.assert(&self.next);
-                solver.assert(&Term::negate(Next::prime(q)));
+                solver.assert(&Term::negate(Next::new(&self.sig).prime(q)));
                 let resp = solver.check_sat(HashMap::new()).expect("error in solver");
                 if matches!(resp, SatResp::Sat) {
                     log::info!("        Got model");
@@ -215,9 +215,12 @@ pub fn infer_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
             ThmStmt::Assume(e) => assumes.push(e),
             ThmStmt::Assert(pf) => {
                 let proof_invariants: Vec<&Term> = pf.invariants.iter().map(|s| &s.x).collect();
-                if let Ok(assert) =
-                    InvariantAssertion::for_assert(&assumes, &pf.assert.x, &proof_invariants)
-                {
+                if let Ok(assert) = InvariantAssertion::for_assert(
+                    &m.signature,
+                    &assumes,
+                    &pf.assert.x,
+                    &proof_invariants,
+                ) {
                     let res = infer(conf, &m.signature, &assert);
                     match res {
                         Ok(invs) => {

--- a/src/inference/lemma.rs
+++ b/src/inference/lemma.rs
@@ -330,8 +330,7 @@ sort T2
 sort T3
 mutable r(T1, T2, T3, T3): bool
 mutable c(): T2
-"#
-            .trim(),
+"#,
         );
 
         // First model, has elements x:1 y:2 z:3, c = y and r(x,y,z) = true

--- a/src/smtlib/proc.rs
+++ b/src/smtlib/proc.rs
@@ -118,9 +118,8 @@ impl Z3Conf {
         };
         cmd.args(["-in", "-smt2"]);
         cmd.option("model.completion", "true");
-        let mut conf = Self(cmd);
-        conf.timeout_ms(20000);
-        conf
+        Self(cmd)
+        // conf.timeout_ms(20000);
     }
 
     /// Enable model compaction

--- a/src/smtlib/proc.rs
+++ b/src/smtlib/proc.rs
@@ -118,8 +118,9 @@ impl Z3Conf {
         };
         cmd.args(["-in", "-smt2"]);
         cmd.option("model.completion", "true");
-        Self(cmd)
-        // conf.timeout_ms(20000);
+        let mut conf = Self(cmd);
+        conf.timeout_ms(20000);
+        conf
     }
 
     /// Enable model compaction

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -232,8 +232,7 @@ mod tests {
         mutable votes(node, node): bool
         mutable leader(node): bool
         mutable decided(node, value): bool
-        "#
-            .trim(),
+        "#,
         );
 
         let backend = GenericBackend {
@@ -259,8 +258,7 @@ mod tests {
             r#"
         sort node
         mutable votes(node, node): bool
-        "#
-            .trim(),
+        "#,
         );
 
         let backend = GenericBackend {

--- a/src/solver/imp.rs
+++ b/src/solver/imp.rs
@@ -434,6 +434,7 @@ impl FOModel {
                 .relations
                 .iter()
                 .map(|r| {
+                    let n = if r.mutable { n } else { 0 };
                     let relation = format!("{r}{primes}", r = &r.name, primes = "'".repeat(n));
                     self.interp[&relation].clone()
                 })

--- a/src/term/prime.rs
+++ b/src/term/prime.rs
@@ -96,8 +96,7 @@ mod tests {
         sort s
         mutable z: bool
         mutable r(s): bool
-    "#
-            .trim(),
+    "#,
         );
         assert_eq!(
             Next::new(&sig).normalize(&term("r'(x) | z")),
@@ -123,8 +122,7 @@ mod tests {
         mutable z: bool
         immutable r(s): bool
         mutable p(s): bool
-    "#
-            .trim(),
+    "#,
         );
         assert!(sig.is_immutable("r"));
         assert!(!sig.is_immutable("z"));

--- a/src/term/prime.rs
+++ b/src/term/prime.rs
@@ -124,8 +124,8 @@ mod tests {
         mutable p(s): bool
     "#,
         );
-        assert!(sig.is_immutable("r"));
         assert!(!sig.is_immutable("z"));
+        assert!(sig.is_immutable("r"));
         assert_eq!(
             Next::new(&sig).normalize(&term("r'(x) | z")),
             term("r(x) | z")

--- a/src/term/prime.rs
+++ b/src/term/prime.rs
@@ -3,7 +3,7 @@
 
 //! Normalize primes (next) down to constants.
 
-use crate::fly::syntax::{Term, UOp};
+use crate::fly::syntax::{Signature, Term, UOp};
 
 /// Wrap t in `next` primes.
 fn with_primes(mut t: Term, next: usize) -> Term {
@@ -15,19 +15,25 @@ fn with_primes(mut t: Term, next: usize) -> Term {
 
 /// Push occurrences of prime inward in `t`, adding `next` primes at the bottom.
 /// Keeps track of a set of bound variables `bound` that should not be primed.
-fn with_next(t: &Term, bound: im::HashSet<String>, next: usize) -> Term {
-    let go = |t| with_next(t, bound.clone(), next);
+fn with_next(sig: &Signature, t: &Term, bound: im::HashSet<String>, next: usize) -> Term {
+    let go = |t| with_next(sig, t, bound.clone(), next);
     let go_box = |t| Box::new(go(t));
     match t {
         // increase next
-        Term::UnaryOp(UOp::Prime, t) => with_next(t, bound.clone(), next + 1),
+        Term::UnaryOp(UOp::Prime, t) => with_next(sig, t, bound.clone(), next + 1),
         // apply accumulated next
         Term::Id(s) => with_primes(
             Term::Id(s.clone()),
-            if bound.contains(s) { 0 } else { next },
+            if bound.contains(s) || sig.is_immutable(s) {
+                0
+            } else {
+                next
+            },
         ),
-        // TODO: we do not add primes to arguments; this is just a heuristic
-        Term::App(f, p, xs) => Term::App(f.clone(), p + next, xs.iter().map(go).collect()),
+        Term::App(f, p, xs) => {
+            let n_primes = if sig.is_immutable(f) { 0 } else { p + next };
+            Term::App(f.clone(), n_primes, xs.iter().map(go).collect())
+        }
 
         // boring recursive cases
         Term::Literal(b) => Term::Literal(*b),
@@ -49,45 +55,91 @@ fn with_next(t: &Term, bound: im::HashSet<String>, next: usize) -> Term {
             body: {
                 let mut bound = bound.clone();
                 bound.extend(binders.iter().map(|binder| binder.name.clone()));
-                Box::new(with_next(body, bound, next))
+                Box::new(with_next(sig, body, bound, next))
             },
         },
     }
 }
 
-pub struct Next {}
+pub struct Next<'a> {
+    sig: &'a Signature,
+}
 
-impl Next {
+impl<'a> Next<'a> {
+    pub fn new(sig: &'a Signature) -> Self {
+        Self { sig }
+    }
+
     /// Normalize any occurrences of (p)' to push the prime as deep as possible,
     /// down to terms.
-    pub fn normalize(t: &Term) -> Term {
+    pub fn normalize(&self, t: &Term) -> Term {
         let bound = im::hashset! {};
-        with_next(t, bound, 0)
+        with_next(self.sig, t, bound, 0)
     }
 
     /// Add a prime to t and push it as far as possible.
-    pub fn prime(t: &Term) -> Term {
-        Self::normalize(&Term::UnaryOp(UOp::Prime, Box::new(t.clone())))
+    pub fn prime(&self, t: &Term) -> Term {
+        self.normalize(&Term::UnaryOp(UOp::Prime, Box::new(t.clone())))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::fly::parser::term;
+    use crate::fly::parser::{parse_signature, term};
 
     use super::Next;
 
     #[test]
     fn test_normalize() {
-        assert_eq!(Next::normalize(&term("r'(x) | z")), term("r'(x) | z"));
+        let sig = parse_signature(
+            r#"
+        sort s
+        mutable z: bool
+        mutable r(s): bool
+    "#
+            .trim(),
+        );
         assert_eq!(
-            Next::normalize(&term("(r(x) | z & forall x:t. p(x)')'")),
+            Next::new(&sig).normalize(&term("r'(x) | z")),
+            term("r'(x) | z")
+        );
+        assert_eq!(
+            Next::new(&sig).normalize(&term("(r(x) | z & forall x:t. p(x)')'")),
             // this x gets primed because it's a free variable
             term("r'(x') | z' & forall x:t. p''(x)")
         );
         assert_eq!(
-            Next::prime(&term("r(x) | z & forall x:t. p(x)'")),
+            Next::new(&sig).prime(&term("r(x) | z & forall x:t. p(x)'")),
             term("r'(x') | z' & forall x:t. p''(x)")
+        );
+    }
+
+    #[test]
+    fn test_normalize_immutable() {
+        // same as above but this time r is immutable so r' should evaluate to r
+        let sig = parse_signature(
+            r#"
+        sort s
+        mutable z: bool
+        immutable r(s): bool
+        mutable p(s): bool
+    "#
+            .trim(),
+        );
+        assert!(sig.is_immutable("r"));
+        assert!(!sig.is_immutable("z"));
+        assert_eq!(
+            Next::new(&sig).normalize(&term("r'(x) | z")),
+            term("r(x) | z")
+        );
+        assert_eq!(
+            Next::new(&sig).normalize(&term("(r(x) | z & forall x:t. p(x)')'")),
+            // this x gets primed because it's a free variable
+            term("r(x') | z' & forall x:t. p''(x)")
+        );
+        assert_eq!(
+            Next::new(&sig).prime(&term("r(x) | z & forall x:t. p(x)'")),
+            term("r(x') | z' & forall x:t. p''(x)")
         );
     }
 }

--- a/src/term/prime.rs
+++ b/src/term/prime.rs
@@ -61,11 +61,14 @@ fn with_next(sig: &Signature, t: &Term, bound: im::HashSet<String>, next: usize)
     }
 }
 
+/// Context for normalizing primes in terms.
 pub struct Next<'a> {
     sig: &'a Signature,
 }
 
 impl<'a> Next<'a> {
+    /// Create a new instance of `Next` that uses `sig` to resolve mutability of
+    /// symbols.
     pub fn new(sig: &'a Signature) -> Self {
         Self { sig }
     }

--- a/src/verify/module.rs
+++ b/src/verify/module.rs
@@ -118,6 +118,7 @@ pub fn verify_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
                     &pf.assert.x,
                     &proof_invariants,
                 ) {
+                    log::info!("checking invariant {}", &pf.assert.x);
                     let res = check_invariant(pf, &assert);
                     if res.is_err() {
                         errors.push(res.err().unwrap())

--- a/src/verify/module.rs
+++ b/src/verify/module.rs
@@ -112,9 +112,12 @@ pub fn verify_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
                             error: cex,
                         });
                     }
-                } else if let Ok(assert) =
-                    InvariantAssertion::for_assert(&assumes, &pf.assert.x, &proof_invariants)
-                {
+                } else if let Ok(assert) = InvariantAssertion::for_assert(
+                    &m.signature,
+                    &assumes,
+                    &pf.assert.x,
+                    &proof_invariants,
+                ) {
                     let res = check_invariant(pf, &assert);
                     if res.is_err() {
                         errors.push(res.err().unwrap())


### PR DESCRIPTION
Previously the fact that a symbol is immutable was basically ignored. Now we respect immutability by transforming `p'` into `p` in the `Next` normalization if `p` is immutable (similarly for `p'(x)` -> `p(x)`).

There's a small unit test as well as a larger test imported from mypyvy.