### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-  # no CI on pull request (already on runs on all branches)
+    branches:
+      - "main"
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This is needed to trigger on pull requests from forks.

Unfortunately it also means that CI no longer runs automatically for branches in the repo, and you'll need to create a PR.