### PR TITLE
Remember assumptions from last check_sat in get_minimal_model

### DIFF
--- a/src/smtlib/proc.rs
+++ b/src/smtlib/proc.rs
@@ -380,7 +380,7 @@ impl SmtProc {
     /// list of terms used in the proof.
     ///
     /// Fails if the previous command wasn't a check_sat or check_sat_assuming
-    /// that returned sat.
+    /// that returned unsat.
     #[allow(dead_code)]
     pub fn get_unsat_assumptions(&mut self) -> Result<Vec<Sexp>> {
         let sexp = self.send_with_reply(&app("get-unsat-assumptions", vec![]))?;


### PR DESCRIPTION
The sequence of `check_sat(assumptions)` followed by `get_minimal_model()` on a solver was previously buggy in that the minimization acted without those assumptions, because it issued `check_sat` queries without them. In order to fix this, we remember the assumptions in any call to `check_sat` and then start with those assumptions in the minimization process if the next call is `get_minimal_model`.

I also added a regression test that fails without this fix.

Fixes #63.