### PR TITLE
Report non-solver run time using getrusage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +957,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +994,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "log",
+ "nix",
  "path-slash",
  "peg",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ im = "15.1.0"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
 log = "0.4.17"
+nix = { version = "0.26.2", default-features = false, features = ["resource"] }
 path-slash = "0.2.1"
 peg = "0.8.1"
 pretty_env_logger = "0.4.0"


### PR DESCRIPTION
When running with `--time`, previously we would calculate the "non-solver" time by taking the total end-to-end time and subtracting the solver time. This isn't accurate when the solver is called concurrently.

This PR directly uses the `getrusage` system call to get time spent in the process, excluding children. This isn't quite the same as real time (it excludes time spent in other processes for example), but it much better accounts for concurrency. It's the same thing that the Linux `time` utility would report. (Actually I wanted to know how `time` worked so I read the source code and that's how I discovered this syscall in the first place.)