### PR TITLE
Draft: Add UPDR algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cadical"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e96d3046c68b3f7dce64d48b5e8dd33d3b0160ca3d96b51cec20b7a6b7451b8"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +146,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -173,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384e169cc618c613d5e3ca6404dda77a8685a63e08660dcc64abaf7da7cb0c7a"
+checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -184,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.10"
+version = "4.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef137bbe35aab78bdb468ccfba75a5f4d8321ae011d34063770780545176af2d"
+checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -242,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -470,9 +482,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
@@ -562,6 +574,15 @@ name = "itoa"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+
+[[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -838,9 +859,21 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -849,15 +882,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
 
 [[package]]
 name = "rustix"
-version = "0.38.2"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabcb0461ebd01d6b79945797c27f8529082226cb630a9865a71870ff63532a4"
+checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -909,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1005,6 +1038,7 @@ name = "temporal-verifier"
 version = "0.1.0"
 dependencies = [
  "bitvec",
+ "cadical",
  "clap",
  "codespan-reporting",
  "criterion",
@@ -1055,18 +1089,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1085,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1106,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
  "indexmap 2.0.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ trace = ["peg/trace"]
 
 [dependencies]
 bitvec = "1.0.1"
+cadical = "0.1.14"
 clap = { version = "4.3.4", features = ["derive"] }
 codespan-reporting = "0.11.1"
 ena = "0.14.2"

--- a/src/command.rs
+++ b/src/command.rs
@@ -19,6 +19,7 @@ use crate::solver::{log_dir, solver_path, SolverConf};
 use crate::timing;
 use crate::{
     fly::{self, parser::parse_error_diagnostic, printer, sorts},
+    inference::Updr,
     inference::{fixpoint_multi, fixpoint_single, QfBody},
     solver::backends::{self, GenericBackend},
     verify::verify_module,
@@ -249,6 +250,7 @@ struct InferArgs {
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 enum Command {
     Verify(VerifyArgs),
+    UpdrVerify(VerifyArgs),
     Infer(InferArgs),
     Print {
         /// File name for a .fly file
@@ -287,6 +289,7 @@ impl Command {
         match self {
             Command::Verify(VerifyArgs { file, .. }) => file,
             Command::Infer(InferArgs { infer_cmd, .. }) => infer_cmd.file(),
+            Command::UpdrVerify(VerifyArgs { file, .. }) => file,
             Command::Print { file, .. } => file,
             Command::Inline { file, .. } => file,
             Command::SetCheck { file, .. } => file,
@@ -559,6 +562,10 @@ impl App {
                 }
 
                 crate::bounded::set::check(&mut m, &universe, depth, compress_traces.into());
+            Command::UpdrVerify(ref args @ VerifyArgs { .. }) => {
+                let conf = Arc::new(args.get_solver_conf());
+                let mut updr = Updr::new(conf);
+                let _result = updr.search(&m);
             }
         }
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -562,6 +562,7 @@ impl App {
                 }
 
                 crate::bounded::set::check(&mut m, &universe, depth, compress_traces.into());
+            }
             Command::UpdrVerify(ref args @ VerifyArgs { .. }) => {
                 let conf = Arc::new(args.get_solver_conf());
                 let mut updr = Updr::new(conf);

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -459,7 +459,7 @@ impl FOModule {
     pub fn get_pred(&self, conf: &SolverConf, hyp: &[Term], t: &TermOrModel) -> CexOrCore {
         let as_term: Term = match t {
             TermOrModel::Term(t) => t.clone(),
-            TermOrModel::Model(m) => m.to_term(),
+            TermOrModel::Model(m) => m.to_diagram(),
         };
         assert_eq!(self.transitions.len(), 1);
         if let NAryOp(NOp::Or, _) = self.transitions[0].clone() {

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -8,7 +8,7 @@ use std::{
     sync::RwLock,
 };
 
-use crate::fly::syntax::Term::{NAryOp, Quantified, UnaryOp};
+use crate::fly::syntax::Term::*;
 use crate::term::clear_next;
 use crate::{
     fly::{
@@ -537,9 +537,6 @@ impl FOModule {
                 SatResp::Unsat => {
                     // println!("adding group");
                     for (ind, b) in solver.get_unsat_core() {
-                        if let UnaryOp(UOp::Not, _) = clear_next(ind_to_term[&ind].clone()) {
-                            continue;
-                        }
                         assert!(b, "got false in core");
                         // println!("adding to core: {}", clear_next(ind_to_term[&ind].clone()));
                         core.insert(clear_next(ind_to_term[&ind].clone()), b);

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 use itertools::Itertools;
+use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
     sync::RwLock,
 };
 
+use crate::fly::syntax::Term::{NAryOp, Quantified, UnaryOp};
+use crate::term::clear_next;
 use crate::{
     fly::{
         semantics::Model,
@@ -18,7 +21,6 @@ use crate::{
     term::{FirstOrder, Next},
 };
 
-use rayon::prelude::*;
 pub enum TransCexResult {
     CTI(Model, Model),
     UnsatCore(HashSet<usize>),
@@ -116,6 +118,17 @@ impl<'a> Core<'a> {
     fn len(&self) -> usize {
         self.participants.len()
     }
+}
+
+#[derive(Debug, Clone)]
+pub enum TermOrModel {
+    Model(Model),
+    Term(Term),
+}
+
+pub enum CexOrCore {
+    Cex((Term, Model)),
+    Core(HashMap<Term, bool>),
 }
 
 /// A first-order module is represented using first-order formulas,
@@ -340,16 +353,6 @@ impl FOModule {
         TransCexResult::UnsatCore(unsat_core)
     }
 
-    pub fn trans_safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> Option<Model> {
-        for s in self.safeties.iter() {
-            if let TransCexResult::CTI(model, _) = self.trans_cex(conf, hyp, s, false, true, None) {
-                return Some(model);
-            }
-        }
-
-        None
-    }
-
     pub fn implication_cex(&self, conf: &SolverConf, hyp: &[Term], t: &Term) -> Option<Model> {
         let mut core: Core = if self.gradual {
             Core::new(hyp, HashSet::new(), self.minimal)
@@ -451,6 +454,140 @@ impl FOModule {
         }
 
         samples
+    }
+
+    pub fn get_pred(&self, conf: &SolverConf, hyp: &[Term], t: &TermOrModel) -> CexOrCore {
+        let as_term: Term = match t {
+            TermOrModel::Term(t) => t.clone(),
+            TermOrModel::Model(m) => m.to_term(),
+        };
+        assert_eq!(self.transitions.len(), 1);
+        if let NAryOp(NOp::Or, _) = self.transitions[0].clone() {
+        } else {
+            panic!("malformed transitions!")
+        }
+        let separate_trans = self
+            .transitions
+            .iter()
+            .flat_map(|t| match t {
+                NAryOp(NOp::Or, args) => args.iter().collect_vec(),
+                _ => vec![t],
+            })
+            .collect_vec();
+
+        let mut core = HashMap::new();
+        for trans in separate_trans {
+            let mut solver = conf.solver(&self.signature, 2);
+            for a in self
+                .axioms
+                .iter()
+                .chain(hyp.iter())
+                .chain(vec![trans].into_iter())
+            {
+                solver.assert(a);
+            }
+            for a in self.axioms.iter() {
+                solver.assert(&Next::new(&self.signature).prime(a));
+            }
+            let mut indicators = HashMap::new();
+            let mut ind_to_term = HashMap::new();
+            let mut new_terms = vec![];
+            if let TermOrModel::Term(term) = t {
+                // println!("got term, asserting with no core");
+                solver.assert(&Next::new(&self.signature).prime(term));
+            } else if let Quantified {
+                quantifier: Quantifier::Exists,
+                body,
+                binders,
+            } = Next::new(&self.signature).prime(&as_term)
+            {
+                if let NAryOp(NOp::And, terms) = *body {
+                    for (i, clause) in terms.into_iter().enumerate() {
+                        let ind = solver.get_indicator(&i.to_string());
+                        new_terms.push(Term::BinOp(
+                            BinOp::Equals,
+                            Box::new(ind.clone()),
+                            Box::new(clause.clone()),
+                        ));
+                        // println!("adding clause {}", &clause);
+                        indicators.insert(ind.clone(), true);
+                        ind_to_term.insert(ind, clause);
+                    }
+                    let new_term = Quantified {
+                        quantifier: Quantifier::Exists,
+                        body: Box::new(NAryOp(NOp::And, new_terms)),
+                        binders,
+                    };
+                    solver.assert(&new_term);
+                } else {
+                    panic!("bad term for pred!");
+                }
+            } else {
+                panic!("bad term for pred!");
+            }
+
+            let resp = solver.check_sat(indicators).expect("error in solver");
+            match resp {
+                SatResp::Sat => {
+                    let states = solver.get_minimal_model().expect("error in solver");
+                    assert_eq!(states.len(), 2);
+                    // println!("trans: {}", &trans);
+                    return CexOrCore::Cex((trans.clone(), states[0].clone()));
+                }
+                SatResp::Unsat => {
+                    // println!("adding group");
+                    for (ind, b) in solver.get_unsat_core() {
+                        if let UnaryOp(UOp::Not, _) = clear_next(ind_to_term[&ind].clone()) {
+                            continue;
+                        }
+                        assert!(b, "got false in core");
+                        // println!("adding to core: {}", clear_next(ind_to_term[&ind].clone()));
+                        core.insert(clear_next(ind_to_term[&ind].clone()), b);
+                    }
+                }
+                SatResp::Unknown(error) => panic!("{}", error),
+            }
+        }
+        return CexOrCore::Core(core);
+    }
+
+    pub fn implies_cex(&self, conf: &SolverConf, hyp: &[Term], t: &Term) -> Option<Model> {
+        let mut solver = conf.solver(&self.signature, 1);
+        for a in hyp {
+            solver.assert(a);
+        }
+        solver.assert(&Term::negate(t.clone()));
+
+        let resp = solver.check_sat(HashMap::new()).expect("error in solver");
+        match resp {
+            SatResp::Sat => {
+                let states = solver.get_minimal_model().expect("error in solver");
+                assert_eq!(states.len(), 1);
+                return Some(states[0].clone());
+            }
+            SatResp::Unsat => None,
+            SatResp::Unknown(_) => panic!(),
+        }
+    }
+
+    pub fn trans_safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> Option<Model> {
+        for s in self.safeties.iter() {
+            if let TransCexResult::CTI(model, _) = self.trans_cex(conf, hyp, s, false, true, None) {
+                return Some(model);
+            }
+        }
+
+        None
+    }
+
+    pub fn safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> Option<Model> {
+        for s in self.safeties.iter() {
+            if let Some(model) = self.implies_cex(conf, hyp, s) {
+                return Some(model);
+            }
+        }
+
+        None
     }
 }
 

--- a/src/inference/marco.rs
+++ b/src/inference/marco.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #[allow(dead_code)]
-pub fn marco<const N: usize, F: Fn([bool; N]) -> bool + 'static>(func: F) -> MarcoIterator<N> {
+pub fn marco<'a, const N: usize>(func: impl Fn([bool; N]) -> bool + 'a) -> MarcoIterator<'a, N> {
     MarcoIterator {
         func: Box::new(func),
         map: vec![],
     }
 }
 
-pub struct MarcoIterator<const N: usize> {
-    func: Box<dyn Fn([bool; N]) -> bool>,
+pub struct MarcoIterator<'a, const N: usize> {
+    func: Box<dyn Fn([bool; N]) -> bool + 'a>,
     map: Cnf,
 }
 
@@ -26,7 +26,7 @@ impl MarcoLiteral {
     }
 }
 
-impl<const N: usize> Iterator for MarcoIterator<N> {
+impl<const N: usize> Iterator for MarcoIterator<'_, N> {
     type Item = [bool; N];
     fn next(&mut self) -> Option<[bool; N]> {
         loop {

--- a/src/inference/marco.rs
+++ b/src/inference/marco.rs
@@ -1,0 +1,149 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+#[allow(dead_code)]
+pub fn marco<const N: usize, F: Fn([bool; N]) -> bool + 'static>(func: F) -> MarcoIterator<N> {
+    MarcoIterator {
+        func: Box::new(func),
+        map: vec![],
+    }
+}
+
+pub struct MarcoIterator<const N: usize> {
+    func: Box<dyn Fn([bool; N]) -> bool>,
+    map: Cnf,
+}
+
+type Cnf = Vec<Vec<MarcoLiteral>>;
+struct MarcoLiteral {
+    var: usize, // index into inputs for func
+    pos: bool,
+}
+
+impl MarcoLiteral {
+    fn to_solver_lit(&self) -> i32 {
+        (self.var as i32 + 1) * if self.pos { 1 } else { -1 }
+    }
+}
+
+impl<const N: usize> Iterator for MarcoIterator<N> {
+    type Item = [bool; N];
+    fn next(&mut self) -> Option<[bool; N]> {
+        loop {
+            match is_sat(&self.map) {
+                None => return None,
+                Some(seed) => match (self.func)(seed) {
+                    true => {
+                        let mss = grow(seed, &self.func);
+                        self.map.push(block_down(mss));
+                        return Some(mss);
+                    }
+                    false => {
+                        let mus = shrink(seed, &self.func);
+                        self.map.push(block_up(mus));
+                    }
+                },
+            }
+        }
+    }
+}
+
+fn is_sat<const N: usize>(cnf: &Cnf) -> Option<[bool; N]> {
+    let mut solver: cadical::Solver = Default::default();
+    for clause in cnf {
+        let clause: Vec<_> = clause.iter().map(MarcoLiteral::to_solver_lit).collect();
+        solver.add_clause(clause);
+    }
+
+    match solver.solve() {
+        None => panic!("solver failure in MARCO"),
+        Some(false) => None,
+        Some(true) => {
+            let mut out = [false; N];
+            for (var, x) in out.iter_mut().enumerate() {
+                if solver.value(MarcoLiteral { var, pos: true }.to_solver_lit()) == Some(true) {
+                    *x = true;
+                }
+            }
+            Some(out)
+        }
+    }
+}
+
+fn grow<const N: usize>(mut seed: [bool; N], func: &dyn Fn([bool; N]) -> bool) -> [bool; N] {
+    for i in 0..N {
+        if !seed[i] {
+            seed[i] = true;
+            if !func(seed) {
+                seed[i] = false;
+            }
+        }
+    }
+    seed
+}
+fn shrink<const N: usize>(mut seed: [bool; N], func: &dyn Fn([bool; N]) -> bool) -> [bool; N] {
+    for i in 0..N {
+        if seed[i] {
+            seed[i] = false;
+            if func(seed) {
+                seed[i] = true;
+            }
+        }
+    }
+    seed
+}
+
+fn block_down<const N: usize>(mss: [bool; N]) -> Vec<MarcoLiteral> {
+    (0..N)
+        .filter(|i| !mss[*i])
+        .map(|var| MarcoLiteral { var, pos: true })
+        .collect()
+}
+fn block_up<const N: usize>(mus: [bool; N]) -> Vec<MarcoLiteral> {
+    (0..N)
+        .filter(|i| mus[*i])
+        .map(|var| MarcoLiteral { var, pos: false })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn lit(var: usize, pos: bool) -> MarcoLiteral {
+        MarcoLiteral { var, pos }
+    }
+
+    #[test]
+    fn marco_basic() {
+        fn f(vars: [bool; 5]) -> bool {
+            let mut constraints = vec![];
+            if vars[0] {
+                constraints.push(vec![lit(0, true)]);
+            }
+            if vars[1] {
+                constraints.push(vec![lit(0, false)]);
+            }
+            if vars[2] {
+                constraints.push(vec![lit(1, true)]);
+            }
+            if vars[3] {
+                constraints.push(vec![lit(1, false)]);
+            }
+            if vars[4] {
+                constraints.push(vec![lit(0, true), lit(1, true)]);
+            }
+            is_sat::<5>(&constraints).is_some()
+        }
+
+        let expected = HashSet::from([
+            [false, true, true, false, true],
+            [true, false, true, false, true],
+            [true, false, false, true, true],
+            [false, true, false, true, false],
+        ]);
+        let found: HashSet<_> = marco(f).collect();
+        assert_eq!(expected, found);
+    }
+}

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -12,9 +12,12 @@ mod fixpoint;
 mod hashmap;
 pub mod houdini;
 pub mod lemma;
+mod marco;
 pub mod quant;
 pub mod subsume;
+mod updr;
 mod weaken;
 
 pub use basics::{parse_quantifier, InferenceConfig, QfBody};
 pub use fixpoint::{fixpoint_multi, fixpoint_single};
+pub use updr::Updr;

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -248,73 +248,70 @@ impl Updr {
         let prev_frame = &self.frames[frame_index];
         let out = module.get_pred(&self.solver_conf, &prev_frame.terms, term_or_model);
 
-        // run MARCO on cores without affecting UPDR
-        if let CexOrCore::Core(out) = &out {
-            let as_term: Term = match term_or_model {
-                TermOrModel::Term(t) => t.clone(),
-                TermOrModel::Model(m) => m.to_term(),
-            };
-            if let Term::Quantified {
-                quantifier,
-                binders,
-                body,
-            } = &as_term
-            {
-                if *quantifier == Quantifier::Exists {
-                    if let Term::NAryOp(NOp::And, conj) = &**body {
-                        let func = |array: [bool; 100]| {
-                            // unused array elements must be false
-                            assert!(array.len() >= conj.len());
-                            for b in array.iter().skip(conj.len()) {
+        if let TermOrModel::Model(model) = term_or_model {
+            if let CexOrCore::Core(out) = &out {
+                // run MARCO on cores without affecting UPDR
+                if let Term::Quantified {
+                    quantifier,
+                    binders,
+                    body,
+                } = &model.to_term()
+                {
+                    if *quantifier == Quantifier::Exists {
+                        if let Term::NAryOp(NOp::And, conj) = &**body {
+                            let func = |array: [bool; 100]| {
+                                // unused array elements must be false
+                                assert!(array.len() >= conj.len());
+                                for b in array.iter().skip(conj.len()) {
+                                    if *b {
+                                        return false;
+                                    }
+                                }
+                                // only enable terms in conj that match array
+                                let chosen: Vec<Term> = (0..conj.len())
+                                    .filter(|i| array[*i])
+                                    .map(|i| conj[i].clone())
+                                    .collect();
+                                let term = Term::Quantified {
+                                    quantifier: Quantifier::Exists,
+                                    binders: binders.clone(),
+                                    body: Box::new(Term::NAryOp(NOp::And, chosen)),
+                                };
+                                let term = TermOrModel::Term(term);
+                                let out =
+                                    module.get_pred(&self.solver_conf, &prev_frame.terms, &term);
+                                matches!(out, CexOrCore::Core(_))
+                            };
+
+                            use crate::inference::marco::*;
+                            // we use !func because func is monotone in the wrong direction
+                            let results: Vec<_> = marco(|array| !func(array))
+                                // therefore we also want MUS instead of MSS
+                                .filter_map(|mss_or_mus| match mss_or_mus {
+                                    MssOrMus::Mus(array) => Some(array),
+                                    MssOrMus::Mss(_) => None,
+                                })
+                                .collect();
+
+                            println!("\nunsat core:");
+                            for (term, b) in out {
                                 if *b {
-                                    return false;
+                                    println!("{}", term);
                                 }
                             }
-                            // only enable terms in conj that match array
-                            let conj: Vec<Term> = (0..conj.len())
-                                .filter(|i| array[*i])
-                                .map(|i| conj[i].clone())
-                                .collect();
-                            let term = Term::Quantified {
-                                quantifier: Quantifier::Exists,
-                                binders: binders.clone(),
-                                body: Box::new(Term::NAryOp(NOp::And, conj)),
-                            };
-                            let term = TermOrModel::Term(term);
-                            let out = module.get_pred(&self.solver_conf, &prev_frame.terms, &term);
-                            matches!(out, CexOrCore::Core(_))
-                        };
 
-                        use crate::inference::marco::*;
-                        // we use !func because func is monotone in the wrong direction
-                        let results: Vec<_> = marco(|array| !func(array))
-                            // therefore we also want MUS instead of MSS
-                            .filter_map(|mss_or_mus| match mss_or_mus {
-                                MssOrMus::Mus(array) => Some(array),
-                                MssOrMus::Mss(_) => None,
-                            })
-                            // then we map each array to a difference from the unsat core
-                            .map(|array| {
-                                (
-                                    (0..conj.len())
-                                        .filter(move |i| array[*i] && !out.contains_key(&conj[*i]))
-                                        .collect::<Vec<_>>()
-                                        .len(),
-                                    (0..conj.len())
-                                        .filter(move |i| !array[*i] && out.contains_key(&conj[*i]))
-                                        .collect::<Vec<_>>()
-                                        .len(),
-                                )
-                            })
-                            .collect();
-                        if results.len() == 1 && results[0] == (0, 0) {
-                            println!("\nMARCO: only one core, and was identical to unsat core\n");
-                        } else {
                             println!("\nMARCO: {} cores", results.len());
-                            for (x, y) in results {
-                                println!("terms in MARCO but not unsat: {}", x);
-                                println!("terms in unsat but not MARCO: {}\n", y);
+                            for (i, array) in results.iter().enumerate() {
+                                println!("core {}:", i);
+                                for (i, b) in array.iter().enumerate() {
+                                    if *b {
+                                        println!("{}", conj[i]);
+                                    }
+                                }
                             }
+                            println!("\n");
+                        } else {
+                            panic!("MARCO: bad diagram");
                         }
                     } else {
                         panic!("MARCO: bad diagram");
@@ -322,11 +319,7 @@ impl Updr {
                 } else {
                     panic!("MARCO: bad diagram");
                 }
-            } else {
-                panic!("MARCO: bad diagram");
             }
-        } else {
-            println!("MARCO: not run due to counterexample");
         }
 
         // return the actual UPDR output

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -76,7 +76,7 @@ impl Updr {
                     }
                 }
                 TermOrModel::Model(m) => {
-                    // println!("m: {}", m.to_term());
+                    // println!("m: {}", m.to_diagram());
                     if m.eval(&NAryOp(
                         NOp::And,
                         self.frames[found_state.known_absent_until_frame + 1]
@@ -105,7 +105,7 @@ impl Updr {
         }
         // println!(
         //     "counter_example: {}",
-        //     &counter_example.as_ref().unwrap().to_term()
+        //     &counter_example.as_ref().unwrap().to_diagram()
         // );
         let new_state = BackwardsReachableState {
             id: self.backwards_reachable_states.len(),
@@ -145,7 +145,7 @@ impl Updr {
     ) {
         let as_term: Term = match term_or_model {
             TermOrModel::Term(t) => t.clone(),
-            TermOrModel::Model(m) => m.to_term(),
+            TermOrModel::Model(m) => m.to_diagram(),
         };
         // println!("blocking as term: {} at index {}", as_term, frame_index);
         if frame_index == 0
@@ -255,7 +255,7 @@ impl Updr {
                     quantifier,
                     binders,
                     body,
-                } = &model.to_term()
+                } = &model.to_diagram()
                 {
                     if *quantifier == Quantifier::Exists {
                         if let Term::NAryOp(NOp::And, conj) = &**body {
@@ -440,7 +440,7 @@ impl Updr {
                 "term: {} ",
                 match state.term_or_model.clone() {
                     TermOrModel::Term(t) => t,
-                    TermOrModel::Model(m) => m.to_term(),
+                    TermOrModel::Model(m) => m.to_diagram(),
                 }
             );
             println!(

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -259,14 +259,8 @@ impl Updr {
                 {
                     if *quantifier == Quantifier::Exists {
                         if let Term::NAryOp(NOp::And, conj) = &**body {
-                            let func = |array: [bool; 100]| {
-                                // unused array elements must be false
-                                assert!(array.len() >= conj.len());
-                                for b in array.iter().skip(conj.len()) {
-                                    if *b {
-                                        return false;
-                                    }
-                                }
+                            let func = |array: &[bool]| {
+                                assert!(array.len() == conj.len());
                                 // only enable terms in conj that match array
                                 let chosen: Vec<Term> = (0..conj.len())
                                     .filter(|i| array[*i])
@@ -285,7 +279,7 @@ impl Updr {
 
                             use crate::inference::marco::*;
                             // we use !func because func is monotone in the wrong direction
-                            let results: Vec<_> = marco(|array| !func(array))
+                            let results: Vec<_> = marco(|array| !func(array), conj.len())
                                 // therefore we also want MUS instead of MSS
                                 .filter_map(|mss_or_mus| match mss_or_mus {
                                     MssOrMus::Mus(array) => Some(array),

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -1,0 +1,399 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+use im::{hashset, HashSet};
+use std::sync::Arc;
+
+use crate::fly::syntax::Term::{NAryOp, Quantified, UnaryOp};
+use crate::inference::basics::{CexOrCore, TermOrModel, TransCexResult};
+use crate::term::term_to_cnf_clauses;
+use crate::{fly::syntax::*, inference::basics::FOModule, solver::SolverConf};
+
+#[derive(Debug, Clone)]
+pub struct Frame {
+    terms: Vec<Term>,
+}
+
+impl Frame {
+    pub fn strengthen(&mut self, term: Term) {
+        self.terms.push(term);
+    }
+}
+
+pub struct BackwardsReachableState {
+    pub id: usize,
+    pub term_or_model: TermOrModel,
+    pub num_steps_to_bad: usize,
+    pub known_absent_until_frame: usize,
+}
+
+pub struct Updr {
+    pub solver_conf: Arc<SolverConf>,
+    frames: Vec<Frame>,
+    backwards_reachable_states: Vec<BackwardsReachableState>,
+    currently_blocking_id: Option<usize>,
+}
+
+impl Updr {
+    pub fn new(solver_conf: Arc<SolverConf>) -> Updr {
+        Updr {
+            solver_conf,
+            frames: vec![],
+            backwards_reachable_states: vec![],
+            currently_blocking_id: None,
+        }
+    }
+
+    pub fn find_state_to_block(&mut self, module: &FOModule) -> Option<usize> {
+        // println!("start");
+        loop {
+            // println!("loop");
+            // Search for a known state.
+            let bstate_min = self.backwards_reachable_states.iter_mut().min_by(|b1, b2| {
+                (b1.known_absent_until_frame, b1.num_steps_to_bad)
+                    .cmp(&(b2.known_absent_until_frame, b2.num_steps_to_bad))
+            });
+            if bstate_min.is_none()
+                || bstate_min.as_ref().unwrap().known_absent_until_frame == self.frames.len() - 1
+            {
+                // println!("break for no bstates");
+                break;
+            }
+            let mut found_state = bstate_min.unwrap();
+            match &found_state.term_or_model {
+                TermOrModel::Term(t) => {
+                    // println!("m: {}", t);
+                    if module
+                        .implies_cex(
+                            &self.solver_conf,
+                            &self.frames[found_state.known_absent_until_frame + 1].terms,
+                            &Term::negate(t.clone()),
+                        )
+                        .is_some()
+                    {
+                        // println!("returning for term implies");
+                        return Some(found_state.id);
+                    }
+                }
+                TermOrModel::Model(m) => {
+                    // println!("m: {}", m.to_term());
+                    if m.eval(&NAryOp(
+                        NOp::And,
+                        self.frames[found_state.known_absent_until_frame + 1]
+                            .terms
+                            .clone(),
+                    )) != 0
+                    {
+                        // println!("returning for model eval");
+                        return Some(found_state.id);
+                    }
+                }
+            }
+            // The state does not appear in this frame.
+            found_state.known_absent_until_frame += 1;
+        }
+        // println!("broke");
+
+        // Search for a new state.
+        let last_frame = self.frames.last().unwrap();
+        // println!("last_frame.terms {}", &last_frame.terms[0]);
+        let counter_example = module.safe_cex(&self.solver_conf, &last_frame.terms);
+        if module.safeties.is_empty() || counter_example.is_none() {
+            // println!("None");
+            // Nothing to block.
+            return None;
+        }
+        // println!(
+        //     "counter_example: {}",
+        //     &counter_example.as_ref().unwrap().to_term()
+        // );
+        let new_state = BackwardsReachableState {
+            id: self.backwards_reachable_states.len(),
+            term_or_model: TermOrModel::Model(counter_example.unwrap()),
+            num_steps_to_bad: 0,
+            // Was not found in the last frame, only in this one.
+            known_absent_until_frame: self.frames.len() - 2,
+        };
+        self.backwards_reachable_states.push(new_state);
+        Some(self.backwards_reachable_states.len() - 1)
+    }
+
+    fn establish_safety(&mut self, module: &FOModule) {
+        while let Some(state_index) = self.find_state_to_block(module) {
+            // println!("got ID: {}", &state_index);
+            self.currently_blocking_id = Some(state_index);
+            {
+                let bstate = &self.backwards_reachable_states[state_index];
+                let mut trace: Vec<(Term, TermOrModel)> = vec![];
+                self.block(
+                    &bstate.term_or_model.clone(),
+                    &bstate.known_absent_until_frame + 1,
+                    &mut trace,
+                    module,
+                );
+            }
+            self.backwards_reachable_states[state_index].known_absent_until_frame += 1;
+        }
+    }
+
+    fn block(
+        &mut self,
+        term_or_model: &TermOrModel,
+        frame_index: usize,
+        trace: &mut Vec<(Term, TermOrModel)>,
+        module: &FOModule,
+    ) {
+        let as_term: Term = match term_or_model {
+            TermOrModel::Term(t) => t.clone(),
+            TermOrModel::Model(m) => m.to_term(),
+        };
+        // println!("blocking as term: {} at index {}", as_term, frame_index);
+        if frame_index == 0
+            || (frame_index == 1
+                && module
+                    .implies_cex(
+                        &self.solver_conf,
+                        &self.frames[0].terms,
+                        &Term::negate(as_term.clone()),
+                    )
+                    .is_some())
+        {
+            panic!("abstract cex");
+        }
+        let core = loop {
+            match self.get_predecessor(term_or_model, frame_index - 1, module) {
+                CexOrCore::Cex((trans, pred)) => {
+                    let src = &self.backwards_reachable_states[self.currently_blocking_id.unwrap()];
+                    let steps_from_cex =
+                        src.known_absent_until_frame + 2 - frame_index + src.num_steps_to_bad;
+                    let bstate = BackwardsReachableState {
+                        id: self.backwards_reachable_states.len(),
+                        term_or_model: TermOrModel::Model(pred.clone()),
+                        known_absent_until_frame: 0,
+                        num_steps_to_bad: steps_from_cex,
+                    };
+                    if let TermOrModel::Model(m) = bstate.term_or_model.clone() {
+                        println!("managed to reach {}", m.fmt());
+                    }
+                    if let TermOrModel::Term(t) = bstate.term_or_model.clone() {
+                        println!("managed to reach {}", &t);
+                    }
+                    self.backwards_reachable_states.push(bstate);
+                    trace.push((trans.clone(), TermOrModel::Model(pred.clone())));
+                    self.block(&TermOrModel::Model(pred), frame_index - 1, trace, module);
+                    trace.pop();
+                }
+                CexOrCore::Core(core_map) => break core_map,
+            }
+        };
+        // println!("CORE");
+        let mut terms: Vec<Term> = vec![];
+        for key in core.keys() {
+            // println!("{}", key);
+            if let UnaryOp(UOp::Next, t) = key.clone() {
+                terms.push(*t);
+            } else {
+                terms.push(key.clone());
+            }
+        }
+        // println!("END CORE");
+        if let Quantified {
+            quantifier: Quantifier::Exists,
+            mut body,
+            binders,
+        } = as_term
+        {
+            if !&terms.is_empty() {
+                body = Box::new(NAryOp(NOp::And, terms));
+            }
+            let negated = Term::negate(Quantified {
+                quantifier: Quantifier::Exists,
+                body,
+                binders,
+            });
+            // println!("blocking in {} term: {}", frame_index, &negated);
+            for i in 0..(frame_index + 1) {
+                if self.frames[i].terms.contains(&negated) {
+                    continue;
+                }
+                self.frames[i].strengthen(negated.clone());
+            }
+            'push_frames: for i in frame_index..(self.frames.len() - 1) {
+                let prev_terms = self.frames[i].terms.clone();
+                if self.frames[i + 1].terms.contains(&negated) {
+                    continue;
+                }
+                if let TransCexResult::UnsatCore(_) =
+                    module.trans_cex(&self.solver_conf, &prev_terms, &negated, false, true, None)
+                {
+                    self.frames[i + 1].strengthen(negated.clone());
+                } else {
+                    break 'push_frames;
+                }
+            }
+            // println!("frames in block:");
+            // self.print_frames();
+        } else {
+            panic!()
+        }
+    }
+
+    fn get_predecessor(
+        &mut self,
+        term_or_model: &TermOrModel,
+        frame_index: usize,
+        module: &FOModule,
+    ) -> CexOrCore {
+        // let as_term: Term = match term_or_model {
+        //     TermOrModel::Term(t) => t.clone(),
+        //     TermOrModel::Model(m) => m.to_term(),
+        // };
+        // println!("pred for {}", as_term);
+        let prev_frame = &self.frames[frame_index];
+        // if let Some((prev, curr)) =
+        return module.get_pred(&self.solver_conf, &prev_frame.terms, term_or_model);
+    }
+
+    pub fn search(&mut self, m: &Module) -> Option<Frame> {
+        let module = FOModule::new(m, false, false, false);
+        self.backwards_reachable_states = Vec::new();
+        for safety in &module.safeties {
+            for clause in term_to_cnf_clauses(safety) {
+                self.backwards_reachable_states
+                    .push(BackwardsReachableState {
+                        id: self.backwards_reachable_states.len(),
+                        term_or_model: TermOrModel::Term(Term::negate_and_simplify(clause)),
+                        num_steps_to_bad: 0,
+                        known_absent_until_frame: 0,
+                    })
+            }
+        }
+        self.frames = vec![Frame {
+            terms: module
+                .inits
+                .clone()
+                .into_iter()
+                .flat_map(|t| -> Vec<Term> {
+                    match t {
+                        NAryOp(NOp::And, terms) => terms,
+                        _ => panic!("got malformed inits"),
+                    }
+                })
+                .collect(),
+        }];
+        // println!("{}", &module.safeties[0]);
+        // println!("{}", backwards_reachable_states[0].term);
+        // println!("{}", frames[0].terms[0]);
+        // Some(frames[0].clone())
+        loop {
+            // println!("establish_safety");
+            self.establish_safety(&module);
+            self.print_frames();
+            // println!("simplify");
+            self.simplify(&module);
+            let inductive_frame: Option<Frame> = self.get_inductive_frame(&module);
+            if inductive_frame.is_some() {
+                println!("inductive_frame");
+                for t in &inductive_frame.as_ref().unwrap().terms {
+                    println!("{}", t);
+                }
+                return inductive_frame;
+            }
+            // println!("add_frame_and_push");
+            self.add_frame_and_push(&module);
+            self.print_frames();
+        }
+    }
+
+    fn simplify(&mut self, module: &FOModule) {
+        for frame in self.frames.iter_mut() {
+            let mut terms: Vec<Term> = vec![];
+            let mut removed: HashSet<Term> = hashset![];
+            for term in frame.terms.iter().rev() {
+                let f_minus_t: Vec<Term> = frame
+                    .terms
+                    .clone()
+                    .into_iter()
+                    .filter(|t| t != term && !removed.contains(t))
+                    .collect();
+                if module
+                    .implies_cex(&self.solver_conf, &f_minus_t, term)
+                    .is_some()
+                    && !module.safeties.contains(term)
+                {
+                    terms.push(term.clone())
+                } else {
+                    // println!("imp cex t: {}, {}, {}", &term, f_minus_t.len(), frame.terms.len());
+                    // for h in &f_minus_t {
+                    //     print!(" {} ", h)
+                    // }
+                    // println!("");
+                    // println!("removing in {} simplify: {}", i, &term);
+                    removed.insert(term.clone());
+                }
+            }
+            frame.terms = terms.into_iter().rev().collect();
+        }
+    }
+
+    fn add_frame_and_push(&mut self, module: &FOModule) {
+        self.frames.push(Frame { terms: vec![] });
+        for i in 0..(self.frames.len() - 1) {
+            let prev_terms = self.frames[i].terms.clone();
+            for term in prev_terms.iter() {
+                if self.frames[i + 1].terms.contains(term) {
+                    continue;
+                }
+                if let TransCexResult::UnsatCore(_) =
+                    module.trans_cex(&self.solver_conf, &prev_terms, term, false, true, None)
+                {
+                    self.frames[i + 1].strengthen(term.clone());
+                }
+            }
+        }
+    }
+
+    fn print_frames(&self) {
+        println!("all frames:");
+        for frame in self.frames.iter() {
+            print!("[");
+            for term in frame.terms.iter() {
+                print!("{}, ", term);
+            }
+            println!("]");
+        }
+        println!("all BRS:");
+        for state in self.backwards_reachable_states.iter() {
+            print!(
+                "term: {} ",
+                match state.term_or_model.clone() {
+                    TermOrModel::Term(t) => t,
+                    TermOrModel::Model(m) => m.to_term(),
+                }
+            );
+            println!(
+                "known_absent_until_frame: {}, num_steps_to_bad : {}",
+                state.known_absent_until_frame, state.num_steps_to_bad
+            );
+        }
+    }
+
+    fn get_inductive_frame(&self, module: &FOModule) -> Option<Frame> {
+        for i in 0..(self.frames.len() - 1) {
+            let mut is_inductive = true;
+            // println!("checking inductiveness of frame {}", i);
+            for term in &self.frames[i].terms {
+                if module
+                    .implies_cex(&self.solver_conf, &self.frames[i + 1].terms, term)
+                    .is_some()
+                {
+                    is_inductive = false;
+                }
+            }
+            if is_inductive {
+                return Some(self.frames[i].clone());
+            }
+        }
+        return None;
+    }
+}

--- a/src/smtlib/proc.rs
+++ b/src/smtlib/proc.rs
@@ -195,7 +195,9 @@ impl Z3Conf {
         };
         cmd.args(["-in", "-smt2"]);
         cmd.option("model.completion", "true");
-        Self(cmd)
+        let mut conf = Self(cmd);
+        conf.timeout_ms(Some(30000 * 100));
+        conf
     }
 
     /// Enable model compaction

--- a/src/smtlib/snapshots/temporal_verifier__smtlib__proc__tests__z3_ill_formed.snap
+++ b/src/smtlib/snapshots/temporal_verifier__smtlib__proc__tests__z3_ill_formed.snap
@@ -3,4 +3,4 @@ source: src/smtlib/proc.rs
 expression: r.unwrap_err()
 ---
 solver returned an error:
-line 5 column 8: unknown constant p
+line 6 column 8: unknown constant p

--- a/src/solver/imp.rs
+++ b/src/solver/imp.rs
@@ -428,7 +428,6 @@ impl<B: Backend> Solver<B> {
     /// minimal set of indicator variables which still result in unsat.
     ///
     /// Not yet implemented so there is no algorithm here.
-    #[allow(dead_code)]
     pub fn get_minimal_unsat_core(&mut self) -> HashMap<Term, bool> {
         eprintln!("unsat code minimization is not yet implemented");
         self.get_unsat_core()

--- a/src/solver/sexp.rs
+++ b/src/solver/sexp.rs
@@ -64,9 +64,12 @@ fn term_primes(t: &Term, num_primes: usize) -> Sexp {
         }
         Term::NAryOp(op, args) => {
             let args = args.iter().map(term).collect::<Vec<_>>();
-            match op {
-                NOp::And => app("and", args),
-                NOp::Or => app("or", args),
+            match (op, args.is_empty()) {
+                (NOp::And, false) => app("and", args),
+                (NOp::Or, false) => app("or", args),
+                // the solver can error if no arguments are provided like `(and)`, `(or)`
+                (NOp::And, true) => atom_s("true"),
+                (NOp::Or, true) => atom_s("false"),
             }
         }
         Term::Ite { cond, then, else_ } => app("ite", vec![term(cond), term(then), term(else_)]),

--- a/src/term/cnf.rs
+++ b/src/term/cnf.rs
@@ -5,15 +5,11 @@
 //!
 //! See the documentation for [`Cnf`] for details.
 
-// turned out to not be needed (yet)
-#![allow(dead_code)]
-use crate::fly::{
-    printer,
-    syntax::{NOp, Term, UOp},
-};
-
+use crate::fly::syntax::Term::{App, Id, Quantified};
+use crate::fly::syntax::{NOp, Term, UOp};
+use crate::fly::{printer, syntax};
 use NOp::And;
-use Term::{NAryOp, UnaryOp};
+use Term::{BinOp, Literal, NAryOp, UnaryOp};
 use UOp::Always;
 
 /// Conjunctive normal form terms.
@@ -71,7 +67,120 @@ fn conjuncts(t: Term) -> Vec<Term> {
     }
 }
 
+fn cartesian_product(v: &[Vec<Term>]) -> Vec<Vec<Term>> {
+    if v.is_empty() {
+        return vec![vec![]];
+    }
+
+    let mut result: Vec<Vec<Term>> = vec![];
+
+    for i in &v[0] {
+        for rest in cartesian_product(&v[1..]) {
+            let mut prod = vec![i.clone()];
+            prod.extend(rest);
+            result.push(prod);
+        }
+    }
+
+    result
+}
+
+fn body_to_clauses(t: Term, is_negated: bool) -> Vec<Term> {
+    match t {
+        Literal(b) => vec![Term::Literal(b ^ !is_negated)],
+        UnaryOp(UOp::Not, t) => body_to_clauses(*t, !is_negated),
+        UnaryOp(..) => panic!("got UnaryOp other than Not!"),
+        BinOp(syntax::BinOp::NotEquals, lhs, rhs) => {
+            if is_negated {
+                vec![BinOp(syntax::BinOp::Equals, lhs, rhs)]
+            } else {
+                vec![BinOp(syntax::BinOp::NotEquals, lhs, rhs)]
+            }
+        }
+        BinOp(syntax::BinOp::Equals, lhs, rhs) => {
+            if !is_negated {
+                vec![BinOp(syntax::BinOp::Equals, lhs, rhs)]
+            } else {
+                vec![BinOp(syntax::BinOp::NotEquals, lhs, rhs)]
+            }
+        }
+        BinOp(syntax::BinOp::Implies, lhs, rhs) => {
+            body_to_clauses(NAryOp(NOp::Or, vec![Term::negate(*lhs), *rhs]), is_negated)
+        }
+        BinOp(syntax::BinOp::Iff, lhs, rhs) => body_to_clauses(
+            NAryOp(
+                NOp::And,
+                vec![
+                    NAryOp(NOp::Or, vec![Term::negate(*lhs.clone()), *rhs.clone()]),
+                    NAryOp(NOp::Or, vec![Term::negate(*rhs), *lhs]),
+                ],
+            ),
+            is_negated,
+        ),
+        NAryOp(NOp::And, terms) => {
+            if is_negated {
+                body_to_clauses(
+                    NAryOp(NOp::Or, terms.into_iter().map(Term::negate).collect()),
+                    !is_negated,
+                )
+            } else {
+                let mut res: Vec<Term> = Vec::new();
+                for t in terms {
+                    res.extend(body_to_clauses(t, is_negated));
+                }
+                res
+            }
+        }
+        NAryOp(NOp::Or, terms) => {
+            if is_negated {
+                body_to_clauses(
+                    NAryOp(NOp::And, terms.into_iter().map(Term::negate).collect()),
+                    !is_negated,
+                )
+            } else {
+                let sub_formulas: Vec<Vec<Term>> = terms
+                    .into_iter()
+                    .map(|t| body_to_clauses(t, false))
+                    .collect();
+                let product = cartesian_product(&sub_formulas);
+                product
+                    .into_iter()
+                    .map(|ts: Vec<Term>| NAryOp(NOp::Or, ts))
+                    .collect()
+            }
+        }
+        Id(_) | App(_, _, _) => {
+            if is_negated {
+                vec![Term::negate(t)]
+            } else {
+                vec![t]
+            }
+        }
+        _ => panic!("got illegal operator"),
+    }
+}
+
+/// Convert a quantified term to separate clauses forming a cnf term
+pub fn term_to_cnf_clauses(t: &Term) -> Vec<Term> {
+    return match t {
+        Quantified {
+            quantifier: syntax::Quantifier::Forall,
+            body,
+            binders,
+        } => body_to_clauses(*body.clone(), false)
+            .into_iter()
+            .map(|b| Quantified {
+                quantifier: syntax::Quantifier::Forall,
+                body: Box::new(b),
+                binders: binders.clone(),
+            })
+            .collect(),
+        _ => body_to_clauses(t.clone(), false),
+    };
+}
+
 impl Cnf {
+    #[allow(dead_code)]
     pub fn new(t: Term) -> Self {
         let t = if let Some(body) = get_always(&t) {
             UnaryOp(Always, Box::new(body))
@@ -87,6 +196,8 @@ impl Cnf {
 mod tests {
     use crate::fly::parser::term;
     use crate::fly::syntax::{NOp, Term};
+    use crate::term::cnf::{body_to_clauses, term_to_cnf_clauses};
+    use std::collections::HashSet;
 
     use super::{cnf, Cnf};
 
@@ -118,5 +229,37 @@ mod tests {
         let t = term("p | q");
         let cnf = Cnf::new(t.clone());
         assert_eq!(cnf.0, Term::NAryOp(NOp::And, vec![t]));
+    }
+
+    #[test]
+    fn test_cnf_eq() {
+        let t = term("p = q");
+        let cnf = Cnf::new(t);
+        assert_eq!(cnf.0, Term::NAryOp(NOp::And, vec![term("p = q")]));
+    }
+
+    #[test]
+    fn test_body_to_clauses() {
+        let t = term("(a | (b & c)) | (e & (f = g))");
+        let terms: HashSet<_> = body_to_clauses(t, false).into_iter().collect();
+        let expected: HashSet<_> = vec![
+            term("a | b | e"),
+            term("a | c | e"),
+            term("a | b | (f = g)"),
+            term("a | c | (f = g)"),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(terms, expected);
+    }
+
+    #[test]
+    fn test_term_to_clauses() {
+        let t = term("forall a:t, b:t. (a & b)");
+        let terms: HashSet<_> = term_to_cnf_clauses(&t).into_iter().collect();
+        let expected: HashSet<_> = vec![term("forall a:t, b:t. a"), term("forall a:t, b:t. b")]
+            .into_iter()
+            .collect();
+        assert_eq!(terms, expected);
     }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -7,6 +7,7 @@ mod cnf;
 mod fo;
 mod prime;
 pub mod subst;
-pub use cnf::Cnf;
+pub use cnf::{term_to_cnf_clauses, Cnf};
 pub use fo::FirstOrder;
+pub use prime::clear_next;
 pub use prime::Next;

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -21,7 +21,7 @@ use serde_derive::Deserialize;
 use temporal_verifier::solver::solver_path;
 use walkdir::WalkDir;
 
-const SOLVERS_TO_TEST: [&str; 1] = ["z3"];
+const SOLVERS_TO_TEST: [&str; 3] = ["z3", "cvc4", "cvc5"];
 
 lazy_static! {
     static ref SOLVER_VERSION_VARS: HashMap<String, String> = {

--- a/tests/test_examples.rs
+++ b/tests/test_examples.rs
@@ -21,7 +21,7 @@ use serde_derive::Deserialize;
 use temporal_verifier::solver::solver_path;
 use walkdir::WalkDir;
 
-const SOLVERS_TO_TEST: [&str; 3] = ["z3", "cvc4", "cvc5"];
+const SOLVERS_TO_TEST: [&str; 1] = ["z3"];
 
 lazy_static! {
     static ref SOLVER_VERSION_VARS: HashMap<String, String> = {


### PR DESCRIPTION
Added an initial UPDR implementation based on the one in mypyvy. Created as a project in the course "Automatic verification of systems" taught by Prof. Sharon Shoham Buchbinder. 

The implementation itself takes 11.31 secs to run on `lockserver.fly` as opposed to the 5.47 secs it takes mypyvy to run updr on `lockserv.pyv`. Sadly, when attempting more complex problems, such as `consensus.fly` , we get a timeout. This implementation will require some more work until it can be merged IMO.

The PR also contains some helper functions that the mypyvy implentation used and were added to flyvy:
 - Conversion to CNF.
 - Splitting a CNF term into clauses.
 - Negation that pushes the `-` inward in a term.
 - Removal of `prime` from a term.

If any of these functions feel useful enough, I can open a separate PR for them.