### PR TITLE
Save content-hashed smt2 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 /pegviz.html
 *.smt2
+/.flyvy-log
 /solvers/
 # coverage report
 lcov.info

--- a/src/solver/imp.rs
+++ b/src/solver/imp.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
     time::Instant,
 };
 
@@ -96,6 +96,11 @@ impl<B: Backend> Solver<B> {
     /// Return a handle to cancel the solver
     pub fn pid(&self) -> SmtPid {
         self.proc.pid()
+    }
+
+    /// Save the solver state so far to a tee file.
+    pub fn save_tee(&self) -> Option<PathBuf> {
+        self.proc.save_tee()
     }
 
     /// Emit encoding of signature, using `n_states` to determine how many times

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -9,6 +9,6 @@ mod models;
 mod path;
 mod sexp;
 pub use imp::{Backend, FOModel, Solver};
-pub use path::solver_path;
+pub use path::{log_dir, solver_path};
 mod conf;
 pub use conf::SolverConf;

--- a/src/solver/path.rs
+++ b/src/solver/path.rs
@@ -1,7 +1,15 @@
 // Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-use std::{env, path::Path};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+#[allow(non_snake_case)]
+fn REPO_ROOT_PATH() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
 
 /// Get the right invocation of the solver with binary name bin.
 ///
@@ -19,10 +27,17 @@ pub fn solver_path(bin: &str) -> String {
     } else {
         bin.to_owned()
     };
-    let src_dir = env!("CARGO_MANIFEST_DIR");
-    let src_bin_path = Path::new(src_dir).join("solvers").join(&bin);
+    let src_bin_path = REPO_ROOT_PATH().join("solvers").join(&bin);
     if src_bin_path.exists() {
         return src_bin_path.to_string_lossy().into();
     }
     bin
+}
+
+/// Get the log directory for a flyvy file
+pub fn log_dir(fly_path: &Path) -> PathBuf {
+    let log_base = REPO_ROOT_PATH().join(".flyvy-log");
+    let Some(fname) = fly_path.file_name()
+    else { return log_base; };
+    log_base.join(Path::new(fname).with_extension(""))
 }

--- a/src/verify/module.rs
+++ b/src/verify/module.rs
@@ -42,8 +42,7 @@ fn verify_firstorder(
     assumes: &[&Term],
     assert: &Term,
 ) -> Result<(), QueryError> {
-    let mut solver =
-        Solver::new(sig, n, &conf.backend, conf.tee.as_deref()).expect("could not start solver");
+    let mut solver = conf.solver(sig, n);
     for assume in assumes {
         solver.assert(assume);
     }
@@ -62,6 +61,7 @@ pub fn verify_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
             solver.comment_with(|| format!("init implies: {}", printer::term(&assert.inv.x)));
             // TODO: break this down per invariant, as with consecutions()
             let res = verify_term(&mut solver, assert.initiation().0);
+            solver.save_tee();
             if let Err(cex) = res {
                 failures.push(AssertionFailure {
                     loc: pf.assert.span,
@@ -79,6 +79,7 @@ pub fn verify_module(conf: &SolverConf, m: &Module) -> Result<(), SolveError> {
                     let mut solver = conf.solver(&m.signature, 2);
                     solver.comment_with(|| format!("inductive: {}", printer::term(&assert.inv.x)));
                     let res = verify_term(&mut solver, t.0);
+                    solver.save_tee();
                     if let Err(cex) = res {
                         Some(AssertionFailure {
                             loc: span,


### PR DESCRIPTION
Each solver run now gets a separate output file. These are gathered up and emitted to .flyvy-log/{fly file basename}/query-{content hash}.smt2.

Saving smt2 is now only done on demand, with a new save_tee() method on the solver. The policy implemented here is that any unknown response is automatically saved and printed to stderr, and verify_module (the main call in the verify subcommand) logs all of its queries.