### PR TITLE
Improvements to qAlpha algorithm

### DIFF
--- a/examples/lockserver.fly
+++ b/examples/lockserver.fly
@@ -3,8 +3,8 @@
 
 # Lock server example, translated from mypyvy
 # TEST --all-solvers -- verify
-# TEST --name infer-z3 -- infer qalpha --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3
-# TEST --name infer-cvc5 -- infer qalpha --solver cvc5 --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3
+# TEST --name infer-z3 -- infer qalpha --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
+# TEST --name infer-cvc5 -- infer qalpha --solver cvc5 --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
 
 sort node
 

--- a/examples/lockserver.fly
+++ b/examples/lockserver.fly
@@ -3,8 +3,8 @@
 
 # Lock server example, translated from mypyvy
 # TEST --all-solvers -- verify
-# TEST --name infer-z3 -- infer qalpha --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
-# TEST --name infer-cvc5 -- infer qalpha --solver cvc5 --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
+# TEST --name infer-z3 -- infer --no-print-invariant qalpha --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
+# TEST --name infer-cvc5 -- infer --no-print-invariant qalpha --solver cvc5 --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
 
 sort node
 

--- a/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
+++ b/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test_examples.rs
-description: "--name=infer-cvc5.2 -- infer qalpha --solver cvc5 --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 examples/lockserver.fly"
+description: "--name=infer-cvc5.2 -- infer qalpha --solver cvc5 --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
 proof {
@@ -21,7 +21,6 @@ Fixpoint SAFE!
 Fixpoint size = 12
 Fixpoint runtime = ###s
 Covers 9 / 9 of handwritten invariant.
-0 out of 12 lemmas are trivial.
 
 ======== STDERR: ===========
 

--- a/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
+++ b/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
@@ -1,25 +1,10 @@
 ---
 source: tests/test_examples.rs
-description: "--name=infer-cvc5.2 -- infer qalpha --solver cvc5 --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
+description: "--name=infer-cvc5.2 -- infer --no-print-invariant qalpha --solver cvc5 --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
-proof {
-  invariant forall node_1:node. !grant_msg(node_1) | !server_holds_lock
-  invariant forall node_1:node, node_2:node. node_1 = node_2 | !grant_msg(node_2) | !grant_msg(node_1)
-  invariant forall node_1:node, node_2:node. !holds_lock(node_1) | !grant_msg(node_2)
-  invariant forall node_1:node, node_2:node. node_1 = node_2 | !holds_lock(node_2) | !holds_lock(node_1)
-  invariant forall node_1:node. !holds_lock(node_1) | !server_holds_lock
-  invariant forall node_1:node. !holds_lock(node_1) | !grant_msg(node_1)
-  invariant forall node_1:node. !unlock_msg(node_1) | !server_holds_lock
-  invariant forall node_1:node, node_2:node. node_1 = node_2 | !unlock_msg(node_2) | !unlock_msg(node_1)
-  invariant forall node_1:node, node_2:node. !holds_lock(node_2) | !unlock_msg(node_1)
-  invariant forall node_1:node. !unlock_msg(node_1) | !grant_msg(node_1)
-  invariant forall node_1:node, node_2:node. !unlock_msg(node_1) | !grant_msg(node_2)
-  invariant forall node_1:node. !holds_lock(node_1) | !unlock_msg(node_1)
-}
 Fixpoint SAFE!
 Fixpoint size = 12
-Fixpoint runtime = ###s
 Covers 9 / 9 of handwritten invariant.
 
 ======== STDERR: ===========

--- a/examples/snapshots/lockserver.fly.infer-z3.1.snap
+++ b/examples/snapshots/lockserver.fly.infer-z3.1.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/test_examples.rs
-description: "--name=infer-z3.1 -- infer qalpha --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 examples/lockserver.fly"
+description: "--name=infer-z3.1 -- infer qalpha --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
 proof {
@@ -21,7 +21,6 @@ Fixpoint SAFE!
 Fixpoint size = 12
 Fixpoint runtime = ###s
 Covers 9 / 9 of handwritten invariant.
-0 out of 12 lemmas are trivial.
 
 ======== STDERR: ===========
 

--- a/examples/snapshots/lockserver.fly.infer-z3.1.snap
+++ b/examples/snapshots/lockserver.fly.infer-z3.1.snap
@@ -1,25 +1,10 @@
 ---
 source: tests/test_examples.rs
-description: "--name=infer-z3.1 -- infer qalpha --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
+description: "--name=infer-z3.1 -- infer --no-print-invariant qalpha --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
-proof {
-  invariant forall node_1:node. !grant_msg(node_1) | !server_holds_lock
-  invariant forall node_1:node, node_2:node. node_1 = node_2 | !grant_msg(node_2) | !grant_msg(node_1)
-  invariant forall node_1:node, node_2:node. !holds_lock(node_1) | !grant_msg(node_2)
-  invariant forall node_1:node, node_2:node. node_1 = node_2 | !holds_lock(node_2) | !holds_lock(node_1)
-  invariant forall node_1:node. !holds_lock(node_1) | !server_holds_lock
-  invariant forall node_1:node. !holds_lock(node_1) | !grant_msg(node_1)
-  invariant forall node_1:node. !unlock_msg(node_1) | !server_holds_lock
-  invariant forall node_1:node, node_2:node. node_1 = node_2 | !unlock_msg(node_2) | !unlock_msg(node_1)
-  invariant forall node_1:node, node_2:node. !holds_lock(node_2) | !unlock_msg(node_1)
-  invariant forall node_1:node. !unlock_msg(node_1) | !grant_msg(node_1)
-  invariant forall node_1:node, node_2:node. !unlock_msg(node_1) | !grant_msg(node_2)
-  invariant forall node_1:node. !holds_lock(node_1) | !unlock_msg(node_1)
-}
 Fixpoint SAFE!
 Fixpoint size = 12
-Fixpoint runtime = ###s
 Covers 9 / 9 of handwritten invariant.
 
 ======== STDERR: ===========

--- a/src/command.rs
+++ b/src/command.rs
@@ -153,6 +153,10 @@ struct InferenceConfigArgs {
     gradual_smt: bool,
 
     #[arg(long)]
+    /// Perform SMT queries gradually and minimally
+    minimal_smt: bool,
+
+    #[arg(long)]
     /// Advance the prestate frontier gradually
     gradual_advance: bool,
 
@@ -194,7 +198,8 @@ impl InferenceConfigArgs {
             nesting: self.nesting,
             include_eq: !self.no_include_eq,
             disj: self.disj,
-            gradual_smt: self.gradual_smt,
+            gradual_smt: self.gradual_smt || self.minimal_smt,
+            minimal_smt: self.minimal_smt,
             gradual_advance: self.gradual_advance,
             indiv: self.indiv,
             extend_width: self.extend_width,

--- a/src/command.rs
+++ b/src/command.rs
@@ -237,6 +237,10 @@ struct InferArgs {
     /// Print timing statistics
     time: bool,
 
+    #[arg(long)]
+    /// Don't print the found invariant (for testing)
+    no_print_invariant: bool,
+
     #[command(subcommand)]
     infer_cmd: InferCommand,
 }
@@ -469,7 +473,7 @@ impl App {
                         >(infer_cfg, &conf, &m),
                     }
                 } else {
-                    match infer_cfg.qf_body {
+                    let fixpoint = match infer_cfg.qf_body {
                         QfBody::CNF => fixpoint_single::<
                             subsume::Cnf<atoms::Literal>,
                             lemma::LemmaCnf,
@@ -485,6 +489,11 @@ impl App {
                             lemma::LemmaPDnfNaive,
                             Vec<Vec<atoms::Literal>>,
                         >(infer_cfg, &conf, &m),
+                    };
+                    if args.no_print_invariant {
+                        fixpoint.test_report();
+                    } else {
+                        fixpoint.report();
                     }
                 }
                 if args.time {

--- a/src/command.rs
+++ b/src/command.rs
@@ -149,8 +149,12 @@ struct InferenceConfigArgs {
     disj: bool,
 
     #[arg(long)]
-    /// Perform SAT queries gradually
-    gradual: bool,
+    /// Perform SMT queries gradually
+    gradual_smt: bool,
+
+    #[arg(long)]
+    /// Advance the prestate frontier gradually
+    gradual_advance: bool,
 
     #[arg(long)]
     /// Try to find individually inductive lemmas
@@ -190,7 +194,8 @@ impl InferenceConfigArgs {
             nesting: self.nesting,
             include_eq: !self.no_include_eq,
             disj: self.disj,
-            gradual: self.gradual,
+            gradual_smt: self.gradual_smt,
+            gradual_advance: self.gradual_advance,
             indiv: self.indiv,
             extend_width: self.extend_width,
             extend_depth: self.extend_depth,

--- a/src/inference/atoms.rs
+++ b/src/inference/atoms.rs
@@ -150,4 +150,20 @@ impl RestrictedAtoms {
             None
         }
     }
+
+    pub fn containing_vars(
+        &self,
+        mut literals: Vec<Literal>,
+        vars: &HashSet<String>,
+    ) -> Vec<Literal> {
+        literals.retain(|(i, _)| !self.atoms.to_term[*i].ids().is_disjoint(vars));
+        literals
+    }
+
+    pub fn atoms_containing_vars(&self, vars: &HashSet<String>) -> usize {
+        self.allowed
+            .iter()
+            .filter(|i| !self.atoms.to_term[**i].ids().is_disjoint(vars))
+            .count()
+    }
 }

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -172,7 +172,10 @@ impl FOModule {
                 let resp = solver.check_sat(assumptions).expect("error in solver");
                 match resp {
                     SatResp::Sat => {
-                        let mut states = solver.get_minimal_model().into_iter();
+                        let mut states = solver
+                            .get_minimal_model()
+                            .expect("solver error while minimizing")
+                            .into_iter();
                         let pre = states.next().unwrap();
                         let post = states.next().unwrap();
                         assert_eq!(states.next(), None);
@@ -242,7 +245,9 @@ impl FOModule {
             let resp = solver.check_sat(HashMap::new()).expect("error in solver");
             match resp {
                 SatResp::Sat => {
-                    let mut states = solver.get_minimal_model();
+                    let mut states = solver
+                        .get_minimal_model()
+                        .expect("solver error while minimizing");
                     assert_eq!(states.len(), 1);
 
                     if let Some(i) = (0..hyp.len())

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -19,6 +19,104 @@ use crate::{
 };
 
 use rayon::prelude::*;
+pub enum TransCexResult {
+    CTI(Model, Model),
+    UnsatCore(HashSet<usize>),
+    Cancelled,
+    Unknown,
+}
+
+/// Manages a subset of constraints, based on the counter-models they do not satisfy.
+struct Core<'a> {
+    formulas: &'a [Term],
+    participants: HashSet<usize>,
+    counter_models: Vec<Model>,
+    to_participants: HashMap<usize, HashSet<usize>>,
+    to_counter_models: HashMap<usize, HashSet<usize>>,
+    minimal: bool,
+}
+
+impl<'a> Core<'a> {
+    fn new(terms: &'a [Term], initial: HashSet<usize>, minimal: bool) -> Self {
+        Core {
+            formulas: terms,
+            participants: initial,
+            counter_models: vec![],
+            to_participants: HashMap::new(),
+            to_counter_models: HashMap::new(),
+            minimal,
+        }
+    }
+
+    fn add_counter_model(&mut self, counter_model: Model) -> bool {
+        // We assume that the new counter-model satisfies all previous formulas.
+        for &p_idx in &self.participants {
+            assert_eq!(counter_model.eval(&self.formulas[p_idx]), 1);
+        }
+
+        let new_participant = (0..self.formulas.len()).find(|i| {
+            !self.participants.contains(i) && counter_model.eval(&self.formulas[*i]) == 0
+        });
+
+        match new_participant {
+            Some(p_idx) => {
+                let model_idx = self.counter_models.len();
+                self.participants.insert(p_idx);
+                self.to_participants.insert(model_idx, HashSet::new());
+                let mut counter_models: HashSet<usize> = (0..self.counter_models.len())
+                    .filter(|i| self.counter_models[*i].eval(&self.formulas[p_idx]) == 0)
+                    .collect();
+                counter_models.insert(model_idx);
+                self.counter_models.push(counter_model);
+                for m_idx in &counter_models {
+                    self.to_participants.get_mut(m_idx).unwrap().insert(p_idx);
+                }
+                self.to_counter_models.insert(p_idx, counter_models);
+
+                if self.minimal {
+                    while self.reduce() {}
+
+                    assert!(self.participants.iter().all(|p_idx| {
+                        self.to_counter_models[p_idx]
+                            .iter()
+                            .any(|m_idx| self.to_participants[m_idx] == HashSet::from([*p_idx]))
+                    }));
+                }
+
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn reduce(&mut self) -> bool {
+        if let Some(p_idx) = self
+            .participants
+            .iter()
+            .copied()
+            .sorted()
+            .rev()
+            .find(|p_idx| {
+                self.to_counter_models[p_idx]
+                    .iter()
+                    .all(|m_idx| self.to_participants[m_idx].len() > 1)
+            })
+        {
+            assert!(self.participants.remove(&p_idx));
+            for m_idx in self.to_counter_models.remove(&p_idx).unwrap() {
+                assert!(self.to_participants.get_mut(&m_idx).unwrap().remove(&p_idx));
+            }
+
+            true
+        } else {
+            false
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.participants.len()
+    }
+}
 
 /// A first-order module is represented using first-order formulas,
 /// namely single-vocabulary axioms, initial assertions and safety assertions,
@@ -32,16 +130,11 @@ pub struct FOModule {
     pub safeties: Vec<Term>,
     disj: bool,
     gradual: bool,
-}
-
-pub enum TransCexResult {
-    CTI(Model, Model),
-    UnsatCore(HashSet<usize>),
-    Cancelled,
+    minimal: bool,
 }
 
 impl FOModule {
-    pub fn new(m: &Module, disj: bool, gradual: bool) -> Self {
+    pub fn new(m: &Module, disj: bool, gradual: bool, minimal: bool) -> Self {
         let mut fo = FOModule {
             signature: m.signature.clone(),
             axioms: vec![],
@@ -50,6 +143,7 @@ impl FOModule {
             safeties: vec![],
             disj,
             gradual,
+            minimal,
         };
 
         for statement in &m.statements {
@@ -112,25 +206,26 @@ impl FOModule {
             None => false,
             Some(lock) => *lock.read().unwrap(),
         };
-        let mut participants: Vec<usize> = if self.gradual {
-            vec![]
+
+        let mut core: Core = if self.gradual {
+            Core::new(hyp, HashSet::new(), self.minimal)
         } else {
-            (0..hyp.len()).collect()
+            Core::new(hyp, (0..hyp.len()).collect(), self.minimal)
         };
 
-        loop {
-            let mut core: HashSet<usize> = HashSet::new();
-            let mut new_participants: HashSet<usize> = HashSet::new();
-            for trans in self.disj_trans() {
-                if cancelled() {
-                    return TransCexResult::Cancelled;
-                }
+        let transitions = self.disj_trans();
+        let mut check_transition: Vec<bool> = vec![true; transitions.len()];
+        let mut unsat_cores: Vec<HashSet<usize>> = vec![HashSet::new(); transitions.len()];
+        let mut unknown = false;
 
+        while let Some(t_idx) = (0..transitions.len()).find(|i| check_transition[*i]) {
+            check_transition[t_idx] = false;
+            'inner: loop {
                 let mut solver = conf.solver(&self.signature, 2);
                 let mut assumptions = HashMap::new();
 
                 let mut prestate = vec![];
-                for &i in &participants {
+                for &i in &core.participants {
                     let ind = solver.get_indicator(i.to_string().as_str());
                     assumptions.insert(ind.clone(), true);
                     prestate.push(Term::BinOp(
@@ -144,15 +239,17 @@ impl FOModule {
                     let init = Term::and(self.inits.iter().cloned());
                     solver.assert(&Term::or([init, Term::and(prestate)]));
                 } else {
-                    solver.assert(&Term::and(prestate));
+                    for p in &prestate {
+                        solver.assert(p)
+                    }
                 }
 
-                for a in self.axioms.iter() {
+                for a in &self.axioms {
                     solver.assert(a);
                     solver.assert(&Next::new(&self.signature).prime(a));
                 }
 
-                for a in trans {
+                for a in &transitions[t_idx] {
                     solver.assert(a);
                 }
 
@@ -169,50 +266,78 @@ impl FOModule {
 
                 solver.assert(&Term::negate(Next::new(&self.signature).prime(t)));
 
+                if cancelled() {
+                    return TransCexResult::Cancelled;
+                }
                 let resp = solver.check_sat(assumptions).expect("error in solver");
+                if cancelled() {
+                    return TransCexResult::Cancelled;
+                }
                 match resp {
-                    SatResp::Sat => {
-                        let mut states = solver
-                            .get_minimal_model()
-                            .expect("solver error while minimizing")
-                            .into_iter();
-                        let pre = states.next().unwrap();
-                        let post = states.next().unwrap();
-                        assert_eq!(states.next(), None);
+                    SatResp::Sat => match solver.get_minimal_model() {
+                        Ok(states_vec) => {
+                            let mut states = states_vec.into_iter();
+                            let pre = states.next().unwrap();
+                            let post = states.next().unwrap();
+                            assert_eq!(states.next(), None);
 
-                        if let Some(i) = (0..hyp.len())
-                            .find(|i| !participants.contains(i) && pre.eval(&hyp[*i]) == 0)
-                        {
-                            new_participants.insert(i);
-                        } else {
-                            log::debug!(
-                                "Found SAT with {} formulas in prestate.",
-                                participants.len()
-                            );
-                            return TransCexResult::CTI(pre, post);
-                        }
-                    }
-                    SatResp::Unsat => {
-                        for ind in solver.get_unsat_core() {
-                            if let Term::Id(s) = ind.0 {
-                                core.insert(s[6..].parse().unwrap());
+                            if !core.add_counter_model(pre.clone()) {
+                                log::debug!("Found SAT with {} formulas in prestate.", core.len());
+                                return TransCexResult::CTI(pre, post);
+                            }
+
+                            for i in 0..transitions.len() {
+                                if i != t_idx
+                                    && !check_transition[i]
+                                    && !unsat_cores[i].is_subset(&core.participants)
+                                {
+                                    check_transition[i] = true;
+                                    unsat_cores[i] = HashSet::new();
+                                }
                             }
                         }
-                        log::debug!(
-                            "Found UNSAT with {} formulas in prestate.",
-                            participants.len()
-                        );
+                        _ => {
+                            unknown = true;
+                            break 'inner;
+                        }
+                    },
+                    SatResp::Unsat => {
+                        assert!(unsat_cores[t_idx].is_empty());
+                        for ind in solver.get_unsat_core() {
+                            if let Term::Id(s) = ind.0 {
+                                unsat_cores[t_idx].insert(s[6..].parse().unwrap());
+                            }
+                        }
+                        break 'inner;
                     }
-                    SatResp::Unknown(reason) => panic!("sat solver returned unknown: {reason}"),
+                    SatResp::Unknown(_) => {
+                        unknown = true;
+                        break 'inner;
+                    }
                 }
             }
-
-            if new_participants.is_empty() {
-                return TransCexResult::UnsatCore(core);
-            } else {
-                participants.extend(new_participants);
-            }
         }
+
+        if unknown {
+            log::debug!("Found unknown.");
+            return TransCexResult::Unknown;
+        }
+
+        let unsat_core = unsat_cores
+            .into_iter()
+            .reduce(|x, y| x.union(&y).cloned().collect())
+            .unwrap();
+
+        log::debug!(
+            "Found UNSAT with {} formulas in prestate.",
+            unsat_core.len()
+        );
+
+        if self.minimal {
+            assert_eq!(unsat_core, core.participants);
+        }
+
+        TransCexResult::UnsatCore(unsat_core)
     }
 
     pub fn trans_safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> Option<Model> {
@@ -226,10 +351,10 @@ impl FOModule {
     }
 
     pub fn implication_cex(&self, conf: &SolverConf, hyp: &[Term], t: &Term) -> Option<Model> {
-        let mut participants: Vec<usize> = if self.gradual {
-            vec![]
+        let mut core: Core = if self.gradual {
+            Core::new(hyp, HashSet::new(), self.minimal)
         } else {
-            (0..hyp.len()).collect()
+            Core::new(hyp, (0..hyp.len()).collect(), self.minimal)
         };
 
         loop {
@@ -237,7 +362,7 @@ impl FOModule {
             for a in &self.axioms {
                 solver.assert(a);
             }
-            for &i in &participants {
+            for &i in &core.participants {
                 solver.assert(&hyp[i])
             }
             solver.assert(&Term::negate(t.clone()));
@@ -250,11 +375,7 @@ impl FOModule {
                         .expect("solver error while minimizing");
                     assert_eq!(states.len(), 1);
 
-                    if let Some(i) = (0..hyp.len())
-                        .find(|i| !participants.contains(i) && states[0].eval(&hyp[*i]) == 0)
-                    {
-                        participants.push(i);
-                    } else {
+                    if !core.add_counter_model(states[0].clone()) {
                         return Some(states.pop().unwrap());
                     }
                 }
@@ -305,10 +426,9 @@ impl FOModule {
 
                         new_sample = states.pop();
                     }
-                    SatResp::Unsat => {
+                    SatResp::Unsat | SatResp::Unknown(_) => {
                         unblocked_trans.remove(&i);
                     }
-                    SatResp::Unknown(reason) => panic!("sat solver returned unknown: {reason}"),
                 }
 
                 solver.pop();
@@ -359,6 +479,7 @@ pub struct InferenceConfig {
 
     pub disj: bool,
     pub gradual_smt: bool,
+    pub minimal_smt: bool,
     pub gradual_advance: bool,
     pub indiv: bool,
 

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -4,7 +4,7 @@
 use itertools::Itertools;
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, RwLock},
+    sync::RwLock,
 };
 
 use crate::{
@@ -106,7 +106,7 @@ impl FOModule {
         t: &Term,
         with_init: bool,
         with_safety: bool,
-        cancel: Option<Arc<RwLock<bool>>>,
+        cancel: Option<&RwLock<bool>>,
     ) -> TransCexResult {
         let cancelled = || match &cancel {
             None => false,
@@ -182,6 +182,10 @@ impl FOModule {
                         {
                             new_participants.insert(i);
                         } else {
+                            log::debug!(
+                                "Found SAT with {} formulas in prestate.",
+                                participants.len()
+                            );
                             return TransCexResult::CTI(pre, post);
                         }
                     }
@@ -191,6 +195,10 @@ impl FOModule {
                                 core.insert(s[6..].parse().unwrap());
                             }
                         }
+                        log::debug!(
+                            "Found UNSAT with {} formulas in prestate.",
+                            participants.len()
+                        );
                     }
                     SatResp::Unknown(reason) => panic!("sat solver returned unknown: {reason}"),
                 }

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -52,15 +52,6 @@ fn invariant_cover(
     (covered, proof.invariants.len())
 }
 
-/// Check how many of the given lemmas are trivial, i.e. valid given the axioms.
-#[allow(dead_code)]
-fn count_trivial(conf: &SolverConf, fo: &FOModule, lemmas: &[Term]) -> usize {
-    lemmas
-        .par_iter()
-        .filter(|t| fo.implication_cex(conf, &[], t).is_none())
-        .count()
-}
-
 pub fn fixpoint_single<O, L, B>(infer_cfg: InferenceConfig, conf: &SolverConf, m: &Module)
 where
     O: OrderSubsumption<Base = B>,
@@ -130,12 +121,10 @@ where
     }
 
     let (covered, size) = invariant_cover(m, conf, &fo, &proof);
-    // let trivial = count_trivial(conf, &fo, &proof);
 
     println!("Fixpoint size = {}", proof.len());
     println!("Fixpoint runtime = {:.2}s", total_time);
     println!("Covers {covered} / {size} of handwritten invariant.");
-    // println!("{trivial} out of {} lemmas are trivial.", proof.len());
 }
 
 pub fn fixpoint_multi<O, L, B>(infer_cfg: InferenceConfig, conf: &SolverConf, m: &Module)
@@ -207,12 +196,10 @@ where
         }
 
         let (covered, size) = invariant_cover(m, conf, &fo, &proof);
-        // let trivial = count_trivial(conf, &fo, &proof);
 
         println!("    Fixpoint size = {}", proof.len());
         println!("    Fixpoint runtime = {:.2}s", total_time);
         println!("    Covers {covered} / {size} of handwritten invariant.");
-        // println!("    {trivial} out of {} lemmas are trivial.", proof.len());
     }
 
     println!();

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -58,7 +58,12 @@ where
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
 {
-    let fo = FOModule::new(m, infer_cfg.disj, infer_cfg.gradual_smt);
+    let fo = FOModule::new(
+        m,
+        infer_cfg.disj,
+        infer_cfg.gradual_smt,
+        infer_cfg.minimal_smt,
+    );
     let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let domains: Vec<Domain<L>> = infer_cfg
@@ -133,7 +138,12 @@ where
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
 {
-    let fo = FOModule::new(m, infer_cfg.disj, infer_cfg.gradual_smt);
+    let fo = FOModule::new(
+        m,
+        infer_cfg.disj,
+        infer_cfg.gradual_smt,
+        infer_cfg.minimal_smt,
+    );
     let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let domains: Vec<Domain<L>> = infer_cfg

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -126,16 +126,16 @@ where
     if fo.trans_safe_cex(conf, &proof).is_none() {
         println!("Fixpoint SAFE!");
     } else {
-        log::info!("Fixpoint UNSAFE!");
+        println!("Fixpoint UNSAFE!");
     }
 
     let (covered, size) = invariant_cover(m, conf, &fo, &proof);
     // let trivial = count_trivial(conf, &fo, &proof);
 
-    log::info!("    Fixpoint size = {}", proof.len());
-    log::info!("    Fixpoint runtime = {:.2}s", total_time);
-    log::info!("    Covers {covered} / {size} of handwritten invariant.");
-    // log::info!("    {trivial} out of {} lemmas are trivial.", proof.len());
+    println!("Fixpoint size = {}", proof.len());
+    println!("Fixpoint runtime = {:.2}s", total_time);
+    println!("Covers {covered} / {size} of handwritten invariant.");
+    // println!("{trivial} out of {} lemmas are trivial.", proof.len());
 }
 
 pub fn fixpoint_multi<O, L, B>(infer_cfg: InferenceConfig, conf: &SolverConf, m: &Module)
@@ -201,18 +201,18 @@ where
         let total_time = start.elapsed().as_secs_f32();
         let proof = fixpoint.to_terms();
         if fo.trans_safe_cex(conf, &proof).is_none() {
-            println!("    Fixpoint SAFE!");
+            println!("({}) Fixpoint SAFE!", i + 1);
         } else {
-            log::info!("({}) Fixpoint UNSAFE!", i + 1);
+            println!("({}) Fixpoint UNSAFE!", i + 1);
         }
 
         let (covered, size) = invariant_cover(m, conf, &fo, &proof);
         // let trivial = count_trivial(conf, &fo, &proof);
 
-        log::info!("    Fixpoint size = {}", proof.len());
-        log::info!("    Fixpoint runtime = {:.2}s", total_time);
-        log::info!("    Covers {covered} / {size} of handwritten invariant.");
-        // log::info!("    {trivial} out of {} lemmas are trivial.", proof.len());
+        println!("    Fixpoint size = {}", proof.len());
+        println!("    Fixpoint runtime = {:.2}s", total_time);
+        println!("    Covers {covered} / {size} of handwritten invariant.");
+        // println!("    {trivial} out of {} lemmas are trivial.", proof.len());
     }
 
     println!();

--- a/src/inference/fixpoint.rs
+++ b/src/inference/fixpoint.rs
@@ -66,9 +66,8 @@ where
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
 {
-    let atoms = Arc::new(Atoms::new(
-        infer_cfg.cfg.atoms(infer_cfg.nesting, infer_cfg.include_eq),
-    ));
+    let fo = FOModule::new(m, infer_cfg.disj, infer_cfg.gradual);
+    let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let domains: Vec<Domain<L>> = infer_cfg
         .cfg
@@ -90,7 +89,6 @@ where
         })
         .collect_vec();
     let infer_cfg = Arc::new(infer_cfg);
-    let fo = FOModule::new(m, infer_cfg.disj, infer_cfg.gradual);
     let extend = match (infer_cfg.extend_width, infer_cfg.extend_depth) {
         (None, None) => None,
         (Some(width), Some(depth)) => Some((width, depth)),
@@ -145,9 +143,8 @@ where
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
 {
-    let atoms = Arc::new(Atoms::new(
-        infer_cfg.cfg.atoms(infer_cfg.nesting, infer_cfg.include_eq),
-    ));
+    let fo = FOModule::new(m, infer_cfg.disj, infer_cfg.gradual);
+    let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let domains: Vec<Domain<L>> = infer_cfg
         .cfg
@@ -165,7 +162,6 @@ where
         .sorted_by_key(|(p, lemma_qf, _)| (p.existentials(), lemma_qf.approx_space_size()))
         .collect_vec();
     let infer_cfg = Arc::new(infer_cfg);
-    let fo = FOModule::new(m, infer_cfg.disj, infer_cfg.gradual);
     let extend = match (infer_cfg.extend_width, infer_cfg.extend_depth) {
         (None, None) => None,
         (Some(width), Some(depth)) => Some((width, depth)),

--- a/src/inference/lemma.rs
+++ b/src/inference/lemma.rs
@@ -929,6 +929,7 @@ where
                             let mut total_unsat_lock = total_unsat.lock().unwrap();
                             *total_unsat_lock += 1;
                         }
+
                         let mut new_cores_vec = new_cores.lock().unwrap();
                         new_cores_vec.push((prefix, body.clone(), hashmap::set_from_std(core)));
                     }
@@ -939,7 +940,7 @@ where
             });
 
         log::info!(
-            "SMT STATS: total_time={:.5}s, until_sat={:.5}s, sat_found={}, unsat_found={}",
+            "    SMT STATS: total_time={:.5}s, until_sat={:.5}s, sat_found={}, unsat_found={}",
             (Instant::now() - start_time).as_secs_f64(),
             (first_sat.into_inner().unwrap().unwrap_or(start_time) - start_time).as_secs_f64(),
             total_sat.into_inner().unwrap(),

--- a/src/inference/lemma.rs
+++ b/src/inference/lemma.rs
@@ -886,7 +886,7 @@ where
                 .enumerate()
                 .flat_map_iter(|(id, state)| {
                     log::debug!("[{}] Extending CTI trace #{id}...", lemmas.len());
-                    let samples = fo.simulate_from(conf, &state, width, depth);
+                    let samples = fo.simulate_from(conf, state, width, depth);
                     log::debug!(
                         "[{}] Found {} simulated samples from CTI #{id}...",
                         lemmas.len(),

--- a/src/inference/lemma.rs
+++ b/src/inference/lemma.rs
@@ -1040,9 +1040,9 @@ where
             for id in &weakened_parents {
                 self.remove_lemma(id)
             }
-            for (prefix, body) in new_lemmas.as_vec() {
+            for (prefix, body) in new_lemmas.as_iter() {
                 if !self.lemmas.subsumes(prefix.as_ref(), body) {
-                    self.lemmas.insert(prefix.clone(), body.clone());
+                    self.lemmas.insert(prefix, body.clone());
                 }
             }
             return advanced;

--- a/src/inference/lemma.rs
+++ b/src/inference/lemma.rs
@@ -30,7 +30,11 @@ use super::hashmap;
 use super::quant::QuantifierPrefix;
 
 fn clauses_cubes_count(atoms: usize, len: usize) -> usize {
-    ((atoms - len + 1)..=atoms).product::<usize>() * 2_usize.pow(len as u32)
+    if len > atoms {
+        0
+    } else {
+        ((atoms - len + 1)..=atoms).product::<usize>() * 2_usize.pow(len as u32)
+    }
 }
 
 #[derive(Clone)]

--- a/src/inference/quant.rs
+++ b/src/inference/quant.rs
@@ -226,10 +226,14 @@ impl QuantifierConfig {
             .collect_vec()
     }
 
-    pub fn is_universal(&self) -> bool {
-        self.quantifiers
-            .iter()
-            .all(|q| q == &Some(Quantifier::Forall))
+    pub fn non_universal_vars(&self) -> HashSet<String> {
+        match (0..self.len()).find(|i| !matches!(self.quantifiers[*i], Some(Quantifier::Forall))) {
+            Some(first_exists) => self.names[first_exists..]
+                .iter()
+                .flat_map(|ns| ns.iter().cloned())
+                .collect(),
+            None => HashSet::default(),
+        }
     }
 }
 
@@ -307,13 +311,18 @@ impl QuantifierPrefix {
         })
     }
 
-    pub fn is_universal(&self) -> bool {
-        (0..self.len())
-            .all(|i| self.names[i].is_empty() || self.quantifiers[i] == Quantifier::Forall)
-    }
-
     pub fn existentials(&self) -> usize {
         count_exists(&self.quantifiers)
+    }
+
+    pub fn non_universal_vars(&self) -> HashSet<String> {
+        match (0..self.len()).find(|i| matches!(self.quantifiers[*i], Quantifier::Exists)) {
+            Some(first_exists) => self.names[first_exists..]
+                .iter()
+                .flat_map(|ns| ns.iter().cloned())
+                .collect(),
+            None => HashSet::default(),
+        }
     }
 }
 

--- a/src/inference/quant.rs
+++ b/src/inference/quant.rs
@@ -157,6 +157,15 @@ impl<Q: Clone> QuantifierSequence<Q> {
             })
             .collect_vec()
     }
+
+    pub fn as_universal(&self) -> QuantifierPrefix {
+        QuantifierPrefix {
+            signature: self.signature.clone(),
+            quantifiers: vec![Quantifier::Forall; self.len()],
+            sorts: self.sorts.clone(),
+            names: self.names.clone(),
+        }
+    }
 }
 
 impl QuantifierConfig {

--- a/src/inference/weaken.rs
+++ b/src/inference/weaken.rs
@@ -69,7 +69,11 @@ pub trait LemmaQf: Clone + Sync + Send {
     fn base_to_term(&self, base: &Self::Base) -> Term;
 
     /// Create a new instance given the following configuration.
-    fn new(cfg: &InferenceConfig, atoms: Arc<RestrictedAtoms>, is_universal: bool) -> Self;
+    fn new(
+        cfg: &InferenceConfig,
+        atoms: Arc<RestrictedAtoms>,
+        non_universal_vars: HashSet<String>,
+    ) -> Self;
 
     /// Return the strongest instances of the associated [`Self::Base`]
     fn strongest(&self) -> Vec<Self::Base>;
@@ -79,7 +83,7 @@ pub trait LemmaQf: Clone + Sync + Send {
     where
         I: Fn(&Self::Base) -> bool;
 
-    fn approx_space_size(&self, atoms: usize) -> usize;
+    fn approx_space_size(&self) -> usize;
 
     fn sub_spaces(&self) -> Vec<Self>;
 
@@ -609,11 +613,11 @@ where
         infer_cfg: &InferenceConfig,
         atoms: Arc<RestrictedAtoms>,
     ) -> Self {
-        let is_universal = config.is_universal();
+        let non_universal_vars = config.non_universal_vars();
 
         Self {
             config,
-            lemma_qf: Arc::new(L::new(infer_cfg, atoms, is_universal)),
+            lemma_qf: Arc::new(L::new(infer_cfg, atoms, non_universal_vars)),
             to_prefixes: HashMap::default(),
             to_bodies: HashMap::default(),
             bodies: O::Map::new(),

--- a/src/inference/weaken.rs
+++ b/src/inference/weaken.rs
@@ -575,6 +575,12 @@ where
         self.as_iter().collect_vec()
     }
 
+    pub fn unsat(&self, model: &Model) -> bool {
+        self.sets
+            .par_iter()
+            .any(|set| !set.unsat(model, &Assignment::new(), 0).is_empty())
+    }
+
     pub fn minimized(&self) -> LemmaSet<O, L, B> {
         let mut lemmas: LemmaSet<O, L, B> =
             LemmaSet::new(self.config.clone(), &self.infer_cfg, self.atoms.clone());

--- a/src/inference/weaken.rs
+++ b/src/inference/weaken.rs
@@ -491,11 +491,8 @@ where
         self.by_id.values().map(|o| o.to_base()).collect_vec()
     }
 
-    pub fn as_vec(&self) -> Vec<(Arc<QuantifierPrefix>, &O)> {
-        self.by_id
-            .values()
-            .map(|body| (self.prefix.clone(), body))
-            .collect_vec()
+    pub fn as_iter(&self) -> impl Iterator<Item = (Arc<QuantifierPrefix>, &O)> {
+        self.by_id.values().map(|body| (self.prefix.clone(), body))
     }
 }
 
@@ -567,12 +564,15 @@ where
         self.sets.iter().map(|set| set.by_id.len()).sum()
     }
 
-    pub fn as_vec(&self) -> Vec<(Arc<QuantifierPrefix>, &O)> {
+    pub fn as_iter(&self) -> impl Iterator<Item = (Arc<QuantifierPrefix>, &O)> {
         self.sets
             .iter()
             .sorted_by_key(|set| set.prefix.existentials())
-            .flat_map(|set| set.as_vec())
-            .collect_vec()
+            .flat_map(|set| set.as_iter())
+    }
+
+    pub fn as_vec(&self) -> Vec<(Arc<QuantifierPrefix>, &O)> {
+        self.as_iter().collect_vec()
     }
 
     pub fn minimized(&self) -> LemmaSet<O, L, B> {

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -8,7 +8,6 @@
 use std::{
     collections::{HashMap, HashSet},
     iter::zip,
-    time::Instant,
 };
 
 use crate::{
@@ -156,7 +155,6 @@ impl Backend for &GenericBackend {
             if indicators.contains(symbol) {
                 continue;
             }
-            let start = Instant::now();
             let ModelSymbol {
                 binders,
                 body,
@@ -218,10 +216,6 @@ impl Backend for &GenericBackend {
             part_interp
                 .interps
                 .insert(symbol.clone(), (interp, ret_sort.clone()));
-            log::debug!(
-                "evaluated {symbol} in {:.1}s",
-                Instant::now().duration_since(start).as_secs_f64()
-            )
         }
 
         let interp = part_interp

--- a/src/solver/backends.rs
+++ b/src/solver/backends.rs
@@ -342,7 +342,9 @@ mod tests {
         assumptions.insert(ind, true);
         let resp = solver.check_sat(assumptions).unwrap();
         assert!(resp == SatResp::Sat);
-        let model = &solver.get_minimal_model()[0];
+        let model = &solver
+            .get_minimal_model()
+            .expect("solver error while minimizing")[0];
         assert_eq!(
             model.eval(&parser::term("p(x)")),
             1,

--- a/src/solver/imp.rs
+++ b/src/solver/imp.rs
@@ -364,7 +364,7 @@ impl<B: Backend> Solver<B> {
     /// step it enforces that all the previous sorts have their minimized
     /// cardinalities. Finally, it returns the model with these cardinality
     /// constraints in place.
-    pub fn get_minimal_model(&mut self) -> Vec<Model> {
+    pub fn get_minimal_model(&mut self) -> Result<Vec<Model>, SolverError> {
         let start = std::time::Instant::now();
         let assumptions = self.last_assumptions.take();
         // initially, assume anything used by the last check_sat call
@@ -381,13 +381,11 @@ impl<B: Backend> Solver<B> {
         {
             let sorts = self.signature.sorts.clone();
             for sort in sorts {
-                // TODO: a solver error should be reported to the caller
-                self.minimize_card(max_card, &mut indicators, &sort)
-                    .expect("solver error while minimizing");
+                self.minimize_card(max_card, &mut indicators, &sort)?;
             }
         }
         let model = self.get_fo_model(TimeType::GetMinimalModel, start);
-        model.into_trace(&self.signature, self.n_states)
+        Ok(model.into_trace(&self.signature, self.n_states))
     }
 
     /// Returns an unsat core as a set of indicator variables (a subset of the

--- a/src/verify/module.rs
+++ b/src/verify/module.rs
@@ -25,7 +25,9 @@ fn verify_term<B: Backend>(solver: &mut Solver<B>, t: Term) -> Result<(), QueryE
     match resp {
         SatResp::Sat { .. } => {
             // TODO: should be configurable whether to minimize or not
-            let states = solver.get_minimal_model();
+            let states = solver
+                .get_minimal_model()
+                .expect("solver error while minimizing");
             // TODO: need a way to report traces rather than just single models
             let s0 = states.into_iter().next().unwrap();
             Err(QueryError::Sat(s0))


### PR DESCRIPTION
Add several improvements and modifications to qAlpha, including:
- Refine invariant language for pDNF, to avoid cubes with literals that only mention variables that appear before the first existential quantifier in the prefix. Such formulas can be equivalently decomposed into formulas that use disjunctive literals instead of the cube, or that use cubes whose literals mention variables from after the first existential quantifier.
- By default, advance the "frontier" frame as much as possible, as opposed to gradually. The gradual option can now be enabled using the flag `--gradual-advance`. (The gradual SMT option, previously `--gradual`, is now `--gradual-smt`.) When using the gradual option, only weaken lemmas which appear in some UNSAT-core, or which have no weakenings.
- Add logging of parallel SMT queries during inference, which show how much time elapsed before the first SAT result was encountered, as well as the total time spent, and the number of SAT and UNSAT results encountered.
- As preprocessing, ignore atoms in the language which are either universally true or universally false.