### PR TITLE
Improve query determinism

### DIFF
--- a/src/fly/syntax.rs
+++ b/src/fly/syntax.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use serde::Serialize;
 
 /// Unary operators
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum UOp {
     /// Boolean negation
     Not,
@@ -27,7 +27,7 @@ pub enum UOp {
 
 /// Binary operators
 #[allow(missing_docs)]
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum BinOp {
     Equals,
     NotEquals,
@@ -41,7 +41,7 @@ pub enum BinOp {
 
 /// N-ary logical operators
 #[allow(missing_docs)]
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum NOp {
     And,
     Or,
@@ -49,14 +49,14 @@ pub enum NOp {
 
 /// A kind of quantifier (forall or exists)
 #[allow(missing_docs)]
-#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum Quantifier {
     Forall,
     Exists,
 }
 
 /// A binder for a quantifier
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub struct Binder {
     /// Bound name
     pub name: String,
@@ -68,7 +68,7 @@ pub struct Binder {
 /// being a sequence of values of some sort (often bool for example) under a
 /// given signature and an infinite sequence of states (consisting of values for
 /// all the functions in the signature at each point in time).
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub enum Term {
     /// A constant true or false
     Literal(bool),
@@ -230,7 +230,7 @@ impl Term {
 /// A Sort represents a collection of values, which can be the built-in boolean
 /// sort or a named sort (coming from a Signature).
 #[allow(missing_docs)]
-#[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, PartialOrd, Ord)]
 pub enum Sort {
     Bool,
     Id(String),

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -283,6 +283,7 @@ impl FOModule {
                     return TransCexResult::Cancelled;
                 }
                 let resp = solver.check_sat(assumptions).expect("error in solver");
+                solver.save_tee();
                 if cancelled() {
                     return TransCexResult::Cancelled;
                 }
@@ -371,6 +372,7 @@ impl FOModule {
             solver.assert(&Term::negate(t.clone()));
 
             let resp = solver.check_sat(HashMap::new()).expect("error in solver");
+            solver.save_tee();
             match resp {
                 SatResp::Sat => {
                     let mut states = solver
@@ -421,7 +423,7 @@ impl FOModule {
                 }
 
                 let resp = solver.check_sat(HashMap::new()).expect("error in solver");
-
+                solver.save_tee();
                 match resp {
                     SatResp::Sat => {
                         let mut states = solver.get_model();
@@ -527,6 +529,7 @@ impl FOModule {
             }
 
             let resp = solver.check_sat(indicators).expect("error in solver");
+            solver.save_tee();
             match resp {
                 SatResp::Sat => {
                     let states = solver.get_minimal_model().expect("error in solver");
@@ -556,6 +559,7 @@ impl FOModule {
         solver.assert(&Term::negate(t.clone()));
 
         let resp = solver.check_sat(HashMap::new()).expect("error in solver");
+        solver.save_tee();
         match resp {
             SatResp::Sat => {
                 let states = solver.get_minimal_model().expect("error in solver");

--- a/src/inference/basics.rs
+++ b/src/inference/basics.rs
@@ -411,7 +411,7 @@ impl FOModule {
 
         let mut unblocked_trans: HashSet<usize> = HashSet::from_iter(0..disj_trans.len());
         while !unblocked_trans.is_empty() && samples.len() < width {
-            for i in unblocked_trans.iter().copied().collect_vec() {
+            for i in unblocked_trans.iter().copied().sorted().collect_vec() {
                 if samples.len() >= width {
                     break;
                 }

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -239,6 +239,7 @@ impl Updr {
         }
     }
 
+    #[allow(clippy::let_and_return)]
     fn get_predecessor(
         &mut self,
         term_or_model: &TermOrModel,

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 use im::{hashset, HashSet};
+use itertools::Itertools;
 use std::sync::Arc;
 
 use crate::fly::syntax::Term::{NAryOp, Quantified, UnaryOp};
@@ -188,7 +189,7 @@ impl Updr {
         };
         // println!("CORE");
         let mut terms: Vec<Term> = vec![];
-        for key in core.keys() {
+        for key in core.keys().sorted() {
             // println!("{}", key);
             if let UnaryOp(UOp::Next, t) = key.clone() {
                 terms.push(*t);
@@ -288,7 +289,7 @@ impl Updr {
                                 .collect();
 
                             println!("\nunsat core:");
-                            for (term, b) in out {
+                            for (term, b) in out.iter().sorted() {
                                 if *b {
                                     println!("{}", term);
                                 }

--- a/src/inference/updr.rs
+++ b/src/inference/updr.rs
@@ -249,73 +249,73 @@ impl Updr {
         let prev_frame = &self.frames[frame_index];
         let out = module.get_pred(&self.solver_conf, &prev_frame.terms, term_or_model);
 
-        if let TermOrModel::Model(model) = term_or_model {
-            if let CexOrCore::Core(out) = &out {
-                // run MARCO on cores without affecting UPDR
-                if let Term::Quantified {
-                    quantifier,
-                    binders,
-                    body,
-                } = &model.to_diagram()
-                {
-                    if *quantifier == Quantifier::Exists {
-                        if let Term::NAryOp(NOp::And, conj) = &**body {
-                            let func = |array: &[bool]| {
-                                assert!(array.len() == conj.len());
-                                // only enable terms in conj that match array
-                                let chosen: Vec<Term> = (0..conj.len())
-                                    .filter(|i| array[*i])
-                                    .map(|i| conj[i].clone())
-                                    .collect();
-                                let term = Term::Quantified {
-                                    quantifier: Quantifier::Exists,
-                                    binders: binders.clone(),
-                                    body: Box::new(Term::NAryOp(NOp::And, chosen)),
-                                };
-                                let term = TermOrModel::Term(term);
-                                let out =
-                                    module.get_pred(&self.solver_conf, &prev_frame.terms, &term);
-                                matches!(out, CexOrCore::Core(_))
-                            };
+        // if let TermOrModel::Model(model) = term_or_model {
+        //     if let CexOrCore::Core(out) = &out {
+        //         // run MARCO on cores without affecting UPDR
+        //         if let Term::Quantified {
+        //             quantifier,
+        //             binders,
+        //             body,
+        //         } = &model.to_diagram()
+        //         {
+        //             if *quantifier == Quantifier::Exists {
+        //                 if let Term::NAryOp(NOp::And, conj) = &**body {
+        //                     let func = |array: &[bool]| {
+        //                         assert!(array.len() == conj.len());
+        //                         // only enable terms in conj that match array
+        //                         let chosen: Vec<Term> = (0..conj.len())
+        //                             .filter(|i| array[*i])
+        //                             .map(|i| conj[i].clone())
+        //                             .collect();
+        //                         let term = Term::Quantified {
+        //                             quantifier: Quantifier::Exists,
+        //                             binders: binders.clone(),
+        //                             body: Box::new(Term::NAryOp(NOp::And, chosen)),
+        //                         };
+        //                         let term = TermOrModel::Term(term);
+        //                         let out =
+        //                             module.get_pred(&self.solver_conf, &prev_frame.terms, &term);
+        //                         matches!(out, CexOrCore::Core(_))
+        //                     };
 
-                            use crate::inference::marco::*;
-                            // we use !func because func is monotone in the wrong direction
-                            let results: Vec<_> = marco(|array| !func(array), conj.len())
-                                // therefore we also want MUS instead of MSS
-                                .filter_map(|mss_or_mus| match mss_or_mus {
-                                    MssOrMus::Mus(array) => Some(array),
-                                    MssOrMus::Mss(_) => None,
-                                })
-                                .collect();
+        //                     use crate::inference::marco::*;
+        //                     // we use !func because func is monotone in the wrong direction
+        //                     let results: Vec<_> = marco(|array| !func(array), conj.len())
+        //                         // therefore we also want MUS instead of MSS
+        //                         .filter_map(|mss_or_mus| match mss_or_mus {
+        //                             MssOrMus::Mus(array) => Some(array),
+        //                             MssOrMus::Mss(_) => None,
+        //                         })
+        //                         .collect();
 
-                            println!("\nunsat core:");
-                            for (term, b) in out.iter().sorted() {
-                                if *b {
-                                    println!("{}", term);
-                                }
-                            }
+        //                     println!("\nunsat core:");
+        //                     for (term, b) in out.iter().sorted() {
+        //                         if *b {
+        //                             println!("{}", term);
+        //                         }
+        //                     }
 
-                            println!("\nMARCO: {} cores", results.len());
-                            for (i, array) in results.iter().enumerate() {
-                                println!("core {}:", i);
-                                for (i, b) in array.iter().enumerate() {
-                                    if *b {
-                                        println!("{}", conj[i]);
-                                    }
-                                }
-                            }
-                            println!("\n");
-                        } else {
-                            panic!("MARCO: bad diagram");
-                        }
-                    } else {
-                        panic!("MARCO: bad diagram");
-                    }
-                } else {
-                    panic!("MARCO: bad diagram");
-                }
-            }
-        }
+        //                     println!("\nMARCO: {} cores", results.len());
+        //                     for (i, array) in results.iter().enumerate() {
+        //                         println!("core {}:", i);
+        //                         for (i, b) in array.iter().enumerate() {
+        //                             if *b {
+        //                                 println!("{}", conj[i]);
+        //                             }
+        //                         }
+        //                     }
+        //                     println!("\n");
+        //                 } else {
+        //                     panic!("MARCO: bad diagram");
+        //                 }
+        //             } else {
+        //                 panic!("MARCO: bad diagram");
+        //             }
+        //         } else {
+        //             panic!("MARCO: bad diagram");
+        //         }
+        //     }
+        // }
 
         // return the actual UPDR output
         out

--- a/src/smtlib/sexp.rs
+++ b/src/smtlib/sexp.rs
@@ -12,7 +12,7 @@ use peg::str::LineCol;
 use serde::Serialize;
 
 #[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, PartialOrd, Ord)]
 pub enum Atom {
     I(usize),
     S(String),
@@ -31,7 +31,7 @@ impl Atom {
 
 /// An s-expression which also tracks comments.
 #[allow(missing_docs)]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, PartialOrd, Ord)]
 pub enum Sexp {
     Atom(Atom),
     Comment(String),

--- a/src/solver/imp.rs
+++ b/src/solver/imp.rs
@@ -190,6 +190,7 @@ impl<B: Backend> Solver<B> {
         let start = timing::start();
         let r = if assumptions.is_empty() {
             let sat = self.proc.check_sat()?;
+            self.comment_with(|| format!("check sat result: {:?}", sat));
             Ok(sat)
         } else {
             self.last_assumptions = Some(assumptions.clone());
@@ -204,6 +205,7 @@ impl<B: Backend> Solver<B> {
                 })
                 .collect::<Vec<_>>();
             let sat = self.proc.check_sat_assuming(&assumptions)?;
+            self.comment_with(|| format!("check sat result: {:?}", sat));
             Ok(sat)
         };
         timing::elapsed(

--- a/src/solver/imp.rs
+++ b/src/solver/imp.rs
@@ -7,6 +7,8 @@ use std::{
     time::Instant,
 };
 
+use itertools::Itertools;
+
 use crate::{
     fly::{
         semantics::{Interpretation, Model, Universe},
@@ -203,6 +205,7 @@ impl<B: Backend> Solver<B> {
                         sexp::negated_term(&ind)
                     }
                 })
+                .sorted()
                 .collect::<Vec<_>>();
             let sat = self.proc.check_sat_assuming(&assumptions)?;
             self.comment_with(|| format!("check sat result: {:?}", sat));
@@ -374,6 +377,7 @@ impl<B: Backend> Solver<B> {
             .unwrap_or(HashMap::new())
             .into_iter()
             .map(|(ind, val)| if val { ind } else { Term::negate(ind) })
+            .sorted()
             .collect::<Vec<_>>();
         let max_card = self.get_min_max_card(&mut indicators);
         // Minimize each sort in turn, greedily in the order of the signature.

--- a/tests/test_query_determinism.rs
+++ b/tests/test_query_determinism.rs
@@ -1,0 +1,41 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+use std::process::Command;
+
+fn temporal_verifier() -> Command {
+    let mut cmd = Command::new("./target/debug/temporal-verifier");
+    cmd.arg("--color=never");
+    cmd
+}
+
+#[test]
+fn updr_determinism() {
+    let mut expected_output: Option<String> = None;
+    let NUM_ITERS = 2; // ideally this would be higher, but it's too slow at ~6 seconds per iteration
+    for i in 0..NUM_ITERS {
+        println!("updr determinism iteration {}", i);
+        let out = temporal_verifier()
+            .arg("updr-verify")
+            .arg("examples/lockserver.fly")
+            .arg("--solver-seed=1")
+            .output()
+            .expect("could not run temporal-verifier");
+
+        assert!(out.status.success(), "temporal-verifier should succeed");
+
+        let stdout = String::from_utf8(out.stdout).expect("non-utf8 output");
+        let stderr = String::from_utf8(out.stderr).expect("non-utf8 output");
+
+        let combined_stdout_stderr = format!("{stdout}\n======== STDERR: ===========\n{stderr}");
+
+        match expected_output {
+            Some(ref expected) => {
+                assert_eq!(expected, &combined_stdout_stderr);
+            }
+            None => {
+                expected_output = Some(combined_stdout_stderr);
+            }
+        }
+    }
+}

--- a/tests/test_query_determinism.rs
+++ b/tests/test_query_determinism.rs
@@ -12,8 +12,8 @@ fn temporal_verifier() -> Command {
 #[test]
 fn updr_determinism() {
     let mut expected_output: Option<String> = None;
-    let NUM_ITERS = 2; // ideally this would be higher, but it's too slow at ~6 seconds per iteration
-    for i in 0..NUM_ITERS {
+    let num_iters = 2; // ideally this would be higher, but it's too slow at ~6 seconds per iteration
+    for i in 0..num_iters {
         println!("updr determinism iteration {}", i);
         let out = temporal_verifier()
             .arg("updr-verify")


### PR DESCRIPTION
As preparation for benchmarking flyvy, we will want results to be reproducible, which means that all sources of randomness need to be controlled. 

As a first cut, this PR makes executions of UPDR (more?) deterministic by fixing several issues related to hash table iteration order. 

My workflow was:

```
cargo build
for i in {1..10}; do 
  rm -rf .flyvy-log
  echo $i
  ./target/debug/temporal-verifier updr-verify examples/lockserver.fly --solver-seed 1 --smt > log-$i.txt 2>&1
  mv .flyvy-log/lockserver/ log-$i-smt-logs
done
```

which runs UPDR ten times with the same random seed and collects stdout/stderr logs as well as all smt2 "tee" logs for each run.

Then I diffed the stdout/stderr logs with

```
for i in {2..10}; do diff -uw log-1.txt log-$i.txt; done
```

and confirmed that there were no differences.

When there were differences, I used the smt2 "tee" logs to find the first query file name that differed (I added code to `save_tee` to print the query file names as they were saved, in order, so that I could grep for them easily in the log -- I did not push this code). I then diffed the first two differing queries to understand what was causing the divergence. In all cases I found, this boiled down to iterating over a hash table. (We may want to consider a policy of not iterating over hash tables, because these bugs may be difficult to keep out of the codebase otherwise.)

Along the way, I made a small improvement to the smt2 "tee" logs, so that they now include the answer from check-sat as a comment.

Can anyone think of a good way to make this into an integration test? Is there a way to run the tool over and over from inside a rust test? I'm not sure if we just call `updr` as a function that we will actually observe a different hash iteration order (I didn't try it).

Also, we should consider running similar investigations for all other subcommands.