### PR TITLE
Make bounded checkers' arguments more uniform

### DIFF
--- a/src/bounded/bdd.rs
+++ b/src/bounded/bdd.rs
@@ -446,7 +446,7 @@ mod tests {
     use crate::fly::sorts::sort_check_and_infer;
 
     #[test]
-    fn checker_basic() -> Result<(), CheckerError> {
+    fn checker_bdd_basic() -> Result<(), CheckerError> {
         let source = "
 mutable x: bool
 
@@ -471,7 +471,7 @@ assert always x
     }
 
     #[test]
-    fn checker_lockserver() -> Result<(), CheckerError> {
+    fn checker_bdd_lockserver() -> Result<(), CheckerError> {
         let source = "
 sort node
 
@@ -538,7 +538,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn checker_lockserver_buggy() -> Result<(), CheckerError> {
+    fn checker_bdd_lockserver_buggy() -> Result<(), CheckerError> {
         let source = "
 sort node
 
@@ -601,6 +601,8 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
 
         let bug = check(&module, &universe, Some(12))?;
         assert_eq!(CheckerAnswer::Counterexample, bug);
+        let bug = check(&module, &universe, None)?;
+        assert_eq!(CheckerAnswer::Counterexample, bug);
 
         let too_short = check(&module, &universe, Some(11))?;
         assert_eq!(CheckerAnswer::Unknown, too_short);
@@ -609,7 +611,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn checker_consensus() -> Result<(), CheckerError> {
+    fn checker_bdd_consensus() -> Result<(), CheckerError> {
         let source = "
 sort node
 sort quorum
@@ -677,7 +679,7 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
     }
 
     #[test]
-    fn checker_immutability() -> Result<(), CheckerError> {
+    fn checker_bdd_immutability() -> Result<(), CheckerError> {
         let source = "
 immutable r: bool
 assume r

--- a/src/bounded/bdd.rs
+++ b/src/bounded/bdd.rs
@@ -3,7 +3,7 @@
 
 //! A bounded model checker for flyvy programs using symbolic evaluation.
 
-use crate::fly::{sorts::*, syntax::*};
+use crate::fly::syntax::*;
 use crate::term::FirstOrder;
 use biodivine_lib_bdd::*;
 use itertools::Itertools;
@@ -145,8 +145,6 @@ pub enum CheckerAnswer {
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum CheckerError {
-    #[error("sort checking error: {0}")]
-    SortError(SortError),
     #[error("sort {0} not found in universe {1:#?}")]
     UnknownSort(String, Universe),
 
@@ -179,12 +177,8 @@ fn cardinality(universe: &Universe, sort: &Sort) -> usize {
 pub fn check(
     module: &mut Module,
     universe: &Universe,
-    depth: usize,
+    depth: Option<usize>,
 ) -> Result<CheckerAnswer, CheckerError> {
-    if let Err((error, _)) = sort_check_and_infer(module) {
-        return Err(CheckerError::SortError(error));
-    }
-
     for sort in &module.signature.sorts {
         if !universe.contains_key(sort) {
             return Err(CheckerError::UnknownSort(sort.clone(), universe.clone()));
@@ -274,7 +268,8 @@ pub fn check(
         context.print_counterexample(valuation, &trace, &tr);
         return Ok(CheckerAnswer::Counterexample);
     }
-    for _ in 0..depth {
+    let mut i = 0;
+    while depth.map(|d| i < d).unwrap_or(true) {
         current = Bdd::binary_op_with_exists(
             &current,
             &tr,
@@ -292,6 +287,8 @@ pub fn check(
             context.print_counterexample(valuation, &trace, &tr);
             return Ok(CheckerAnswer::Counterexample);
         }
+
+        i += 1;
     }
 
     println!("search finished in {:0.1}s", time.elapsed().as_secs_f64());
@@ -460,10 +457,13 @@ assert always x
         let mut module = crate::fly::parse(source).unwrap();
         let universe = HashMap::from([]);
 
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 0)?);
+        assert_eq!(
+            CheckerAnswer::Unknown,
+            check(&mut module, &universe, Some(0))?
+        );
         assert_eq!(
             CheckerAnswer::Counterexample,
-            check(&mut module, &universe, 1)?
+            check(&mut module, &universe, Some(1))?
         );
 
         Ok(())
@@ -530,7 +530,10 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
         let mut module = crate::fly::parse(source).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 10)?);
+        assert_eq!(
+            CheckerAnswer::Unknown,
+            check(&mut module, &universe, Some(10))?
+        );
 
         Ok(())
     }
@@ -596,10 +599,10 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
         let mut module = crate::fly::parse(source).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
-        let bug = check(&mut module, &universe, 12)?;
+        let bug = check(&mut module, &universe, Some(12))?;
         assert_eq!(CheckerAnswer::Counterexample, bug);
 
-        let too_short = check(&mut module, &universe, 11)?;
+        let too_short = check(&mut module, &universe, Some(11))?;
         assert_eq!(CheckerAnswer::Unknown, too_short);
 
         Ok(())
@@ -667,7 +670,10 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
             ("value".to_string(), 1),
         ]);
 
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 0)?);
+        assert_eq!(
+            CheckerAnswer::Unknown,
+            check(&mut module, &universe, Some(0))?
+        );
 
         Ok(())
     }
@@ -681,7 +687,10 @@ assert always r
         ";
         let mut module = crate::fly::parse(source).unwrap();
         let universe = std::collections::HashMap::new();
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 10)?);
+        assert_eq!(
+            CheckerAnswer::Unknown,
+            check(&mut module, &universe, Some(10))?
+        );
         Ok(())
     }
 }

--- a/src/bounded/sat.rs
+++ b/src/bounded/sat.rs
@@ -145,16 +145,13 @@ pub enum CheckerAnswer {
     Unknown,
 }
 
-/// Check a given Module out to some depth
+/// Check a given Module out to some depth.
+/// This function assumes that the module has been typechecked.
 pub fn check(
-    module: &mut Module,
+    module: &Module,
     universe: &Universe,
     depth: usize,
 ) -> Result<CheckerAnswer, CheckerError> {
-    if let Err((error, _)) = sort_check_and_infer(module) {
-        return Err(CheckerError::SortError(error));
-    }
-
     for sort in &module.signature.sorts {
         if !universe.contains_key(sort) {
             return Err(CheckerError::UnknownSort(sort.clone(), universe.clone()));
@@ -577,6 +574,7 @@ fn dimacs(cnf: &Cnf, context: &Context) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fly::sorts::sort_check_and_infer;
 
     #[test]
     fn checker_basic() -> Result<(), CheckerError> {
@@ -591,13 +589,11 @@ assert always x
         ";
 
         let mut module = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
         let universe = HashMap::from([]);
 
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 0)?);
-        assert_eq!(
-            CheckerAnswer::Counterexample,
-            check(&mut module, &universe, 1)?
-        );
+        assert_eq!(CheckerAnswer::Unknown, check(&module, &universe, 0)?);
+        assert_eq!(CheckerAnswer::Counterexample, check(&module, &universe, 1)?);
 
         Ok(())
     }
@@ -661,9 +657,10 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
         ";
 
         let mut module = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 10)?);
+        assert_eq!(CheckerAnswer::Unknown, check(&module, &universe, 10)?);
 
         Ok(())
     }
@@ -727,12 +724,13 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
         ";
 
         let mut module = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
-        let bug = check(&mut module, &universe, 12)?;
+        let bug = check(&module, &universe, 12)?;
         assert_eq!(CheckerAnswer::Counterexample, bug);
 
-        let too_short = check(&mut module, &universe, 11)?;
+        let too_short = check(&module, &universe, 11)?;
         assert_eq!(CheckerAnswer::Unknown, too_short);
 
         Ok(())
@@ -793,13 +791,14 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
         ";
 
         let mut module = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
         let universe = std::collections::HashMap::from([
             ("node".to_string(), 2),
             ("quorum".to_string(), 2),
             ("value".to_string(), 2),
         ]);
 
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 10)?);
+        assert_eq!(CheckerAnswer::Unknown, check(&module, &universe, 10)?);
 
         Ok(())
     }
@@ -812,8 +811,9 @@ assume r
 assert always r
         ";
         let mut module = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
-        assert_eq!(CheckerAnswer::Unknown, check(&mut module, &universe, 10)?);
+        assert_eq!(CheckerAnswer::Unknown, check(&module, &universe, 10)?);
         Ok(())
     }
 }

--- a/src/bounded/sat.rs
+++ b/src/bounded/sat.rs
@@ -577,7 +577,7 @@ mod tests {
     use crate::fly::sorts::sort_check_and_infer;
 
     #[test]
-    fn checker_basic() -> Result<(), CheckerError> {
+    fn checker_sat_basic() -> Result<(), CheckerError> {
         let source = "
 mutable x: bool
 
@@ -599,7 +599,7 @@ assert always x
     }
 
     #[test]
-    fn checker_lockserver() -> Result<(), CheckerError> {
+    fn checker_sat_lockserver() -> Result<(), CheckerError> {
         let source = "
 sort node
 
@@ -666,7 +666,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn checker_lockserver_buggy() -> Result<(), CheckerError> {
+    fn checker_sat_lockserver_buggy() -> Result<(), CheckerError> {
         let source = "
 sort node
 
@@ -737,7 +737,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn checker_consensus() -> Result<(), CheckerError> {
+    fn checker_sat_consensus() -> Result<(), CheckerError> {
         let source = "
 sort node
 sort quorum
@@ -804,7 +804,7 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
     }
 
     #[test]
-    fn checker_immutability() -> Result<(), CheckerError> {
+    fn checker_sat_immutability() -> Result<(), CheckerError> {
         let source = "
 immutable r: bool
 assume r

--- a/src/bounded/set.rs
+++ b/src/bounded/set.rs
@@ -1268,7 +1268,7 @@ mod tests {
     }
 
     #[test]
-    fn checker_basic() {
+    fn checker_set_basic() {
         let program = BoundedProgram {
             inits: vec![state([0])],
             trs: vec![
@@ -1295,7 +1295,7 @@ mod tests {
     }
 
     #[test]
-    fn checker_cycle() {
+    fn checker_set_cycle() {
         let program = BoundedProgram {
             inits: vec![state([1, 0, 0, 0])],
             trs: vec![
@@ -1390,7 +1390,7 @@ mod tests {
     }
 
     #[test]
-    fn checker_translate_lockserver() -> Result<(), TranslationError> {
+    fn checker_set_translate_lockserver() -> Result<(), TranslationError> {
         let source = "
 sort node
 
@@ -1568,7 +1568,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn checker_translate_lockserver_buggy() -> Result<(), TranslationError> {
+    fn checker_set_translate_lockserver_buggy() -> Result<(), TranslationError> {
         // A buggy version of lockserv. See "here is the bug" below.
         let source = "
 sort node
@@ -1659,7 +1659,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn checker_translate_consensus() -> Result<(), TranslationError> {
+    fn checker_set_translate_consensus() -> Result<(), TranslationError> {
         let source = "
 sort node
 sort quorum
@@ -1727,7 +1727,7 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
     }
 
     #[test]
-    fn checker_immutability() {
+    fn checker_set_immutability() {
         let source = "
 immutable r: bool
 assume r

--- a/src/bounded/set.rs
+++ b/src/bounded/set.rs
@@ -22,7 +22,7 @@ pub enum CheckerAnswer {
 
 /// Combined entry point to both translate and search the module.
 pub fn check(
-    module: &mut Module,
+    module: &Module,
     universe: &UniverseBounds,
     depth: Option<usize>,
     compress_traces: TraceCompression,
@@ -566,21 +566,15 @@ type UniverseBounds = std::collections::HashMap<String, usize>;
 
 /// Translate a flyvy module into a BoundedProgram, given the bounds on the sort sizes.
 /// Universe should contain the sizes of all the sorts in module.signature.sorts.
-/// The module is mutable for sort inference, but the caller should not rely on
-/// this being the only change that translation makes to the module.
-#[allow(dead_code)]
+/// The module is assumed to have already been typechecked.
 pub fn translate(
-    module: &mut Module,
+    module: &Module,
     universe: &UniverseBounds,
 ) -> Result<BoundedProgram, TranslationError> {
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
             todo!("non-bool relations")
         }
-    }
-
-    if let Err((e, _)) = sort_check_and_infer(module) {
-        return Err(TranslationError::SortError(e));
     }
 
     let indices = Indices::new(&module.signature, universe);
@@ -1274,7 +1268,7 @@ mod tests {
     }
 
     #[test]
-    fn interpreter_basic() {
+    fn checker_basic() {
         let program = BoundedProgram {
             inits: vec![state([0])],
             trs: vec![
@@ -1301,7 +1295,7 @@ mod tests {
     }
 
     #[test]
-    fn interpreter_cycle() {
+    fn checker_cycle() {
         let program = BoundedProgram {
             inits: vec![state([1, 0, 0, 0])],
             trs: vec![
@@ -1396,7 +1390,7 @@ mod tests {
     }
 
     #[test]
-    fn interpreter_translate_lockserver() -> Result<(), TranslationError> {
+    fn checker_translate_lockserver() -> Result<(), TranslationError> {
         let source = "
 sort node
 
@@ -1454,6 +1448,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
         ";
 
         let mut m = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
         let indices = Indices::new(&m.signature, &universe);
 
@@ -1558,7 +1553,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
             ],
         };
 
-        let target = translate(&mut m, &universe)?;
+        let target = translate(&m, &universe)?;
         assert_eq!(target.inits, expected.inits);
         assert_eq!(target.safes, expected.safes);
         assert_eq!(
@@ -1573,7 +1568,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn interpreter_translate_lockserver_buggy() -> Result<(), TranslationError> {
+    fn checker_translate_lockserver_buggy() -> Result<(), TranslationError> {
         // A buggy version of lockserv. See "here is the bug" below.
         let source = "
 sort node
@@ -1645,8 +1640,9 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
         // The test below asserts that interpret finds the bug at depth 12 but not at depth 11.
 
         let mut m = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
-        let target = translate(&mut m, &universe)?;
+        let target = translate(&m, &universe)?;
 
         let bug = interpret(&target, Some(12), TraceCompression::No);
         if let InterpreterResult::Counterexample(trace) = &bug {
@@ -1663,7 +1659,7 @@ assert always (forall N1:node, N2:node. holds_lock(N1) & holds_lock(N2) -> N1 = 
     }
 
     #[test]
-    fn interpreter_translate_consensus() -> Result<(), TranslationError> {
+    fn checker_translate_consensus() -> Result<(), TranslationError> {
         let source = "
 sort node
 sort quorum
@@ -1717,12 +1713,13 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
         ";
 
         let mut m = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut m).unwrap();
         let universe = std::collections::HashMap::from([
             ("node".to_string(), 2),
             ("quorum".to_string(), 2),
             ("value".to_string(), 2),
         ]);
-        let target = translate(&mut m, &universe)?;
+        let target = translate(&m, &universe)?;
         let output = interpret(&target, Some(10), TraceCompression::No);
         assert_eq!(output, InterpreterResult::Unknown);
 
@@ -1730,17 +1727,18 @@ assert always (forall N1:node, V1:value, N2:node, V2:value. decided(N1, V1) & de
     }
 
     #[test]
-    fn interpreter_immutability() {
+    fn checker_immutability() {
         let source = "
 immutable r: bool
 assume r
 assert always r
         ";
         let mut module = crate::fly::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
         assert_eq!(
             Some(CheckerAnswer::Unknown),
-            check(&mut module, &universe, Some(10), true.into())
+            check(&module, &universe, Some(10), true.into())
         );
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -582,7 +582,7 @@ impl App {
                 compress_traces,
             } => {
                 let univ = bounded.get_universe(&m.signature);
-                crate::bounded::set::check(&mut m, &univ, bounded.depth, compress_traces.into());
+                crate::bounded::set::check(&m, &univ, bounded.depth, compress_traces.into());
             }
             Command::SatCheck(bounded) => {
                 let depth = match bounded.depth {
@@ -593,7 +593,7 @@ impl App {
                     }
                 };
                 let univ = bounded.get_universe(&m.signature);
-                match crate::bounded::sat::check(&mut m, &univ, depth) {
+                match crate::bounded::sat::check(&m, &univ, depth) {
                     Ok(crate::bounded::sat::CheckerAnswer::Counterexample) => {}
                     Ok(crate::bounded::sat::CheckerAnswer::Unknown) => {
                         println!("answer: safe up to depth {} for given sort bounds", depth)
@@ -603,7 +603,7 @@ impl App {
             }
             Command::BddCheck(bounded) => {
                 let univ = bounded.get_universe(&m.signature);
-                match crate::bounded::bdd::check(&mut m, &univ, bounded.depth) {
+                match crate::bounded::bdd::check(&m, &univ, bounded.depth) {
                     Ok(crate::bounded::bdd::CheckerAnswer::Counterexample) => {}
                     Ok(crate::bounded::bdd::CheckerAnswer::Unknown) => {
                         println!(


### PR DESCRIPTION
- Support unbounded depth in the BDD checker
- Report that unbounded depth is *not* supported in the SAT checker
- Clean up code in command.rs for collecting bounds on universe sizes