### PR TITLE
Fix bdd convergence check by tracking reachable states

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -266,6 +266,8 @@ pub fn check(
     let mut trace = vec![init.clone()];
 
     let mut current = init;
+    let mut reachable = current.clone();
+
     if let Some(valuation) = current.and(&not_safe).sat_witness() {
         context.print_counterexample(valuation, &trace, &tr);
         return Ok(CheckerAnswer::Counterexample);
@@ -284,12 +286,16 @@ pub fn check(
             }
         }
 
+        let new_reachable = reachable.or(&current);
+
         if print_timing {
             println!("depth {} in {:0.1}s", i + 1, time.elapsed().as_secs_f64());
         }
 
-        if &current == trace.last().unwrap() {
+        if reachable == new_reachable {
             return Ok(CheckerAnswer::Convergence);
+        } else {
+            reachable = new_reachable;
         }
 
         trace.push(current.clone());


### PR DESCRIPTION
Previously, the convergence check was "sound but not complete", because it relied on the presence of loops in the transition system. This is fixed by keeping track of all reachable states that we've ever seen, instead of just comparing the frontiers.