### PR TITLE
Benchmark compile times and move qalpha generic instantiation into inference crate

### DIFF
--- a/inference/src/updr.rs
+++ b/inference/src/updr.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: BSD-2-Clause
 
-//! Implementation of UPDR. See https://www.tau.ac.il/~sharonshoham/papers/jacm17.pdf.
+//! Implementation of UPDR. See <https://www.tau.ac.il/~sharonshoham/papers/jacm17.pdf>.
 
 use im::{hashset, HashSet};
 use itertools::Itertools;

--- a/tools/compile-times.sh
+++ b/tools/compile-times.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Copyright 2022-2023 VMware, Inc.
+# SPDX-License-Identifier: BSD-2-Clause
+
+## This script measures the time it takes to build temporal-verifier under various configurations.
+##
+## Run it from the root of the repository, like this:
+##
+##     ./tools/compile-times.sh
+##
+## You can also pass additional filenames on the command line to benchmark the scenario "how long
+## does it take to rebuild after changing this file", as in:
+##
+##     ./tools/compile-times.sh fly/src/syntax.rs inference/src/basics.rs
+
+
+set -e
+
+function cargo_under_config() {
+  CONFIG="$1"
+  /usr/bin/time -p cargo build $CONFIG 2>&1 | tail -n 3 | head -n 1 | sed 's/^real /    /'
+}
+
+function build_after_touching() {
+  CONFIG="$1"
+  shift
+  FILE="$1"
+  shift
+
+  echo "  building after touching $FILE:"
+  touch "$FILE"
+  cargo_under_config "$CONFIG"
+}
+
+function build_under_config() {
+  CONFIG="$1"
+  shift
+  echo building with config "'$CONFIG'"
+
+  echo -n '  cleaning...'
+  cargo clean >/dev/null 2>&1
+  echo ' clean.'
+
+  echo '  building from scrach:'
+  cargo_under_config "$CONFIG"
+
+  echo '  building after touching all .rs files:'
+  find . -iname '*.rs' -not -path './target/*' -exec touch {} \+
+  cargo_under_config "$CONFIG"
+
+
+  build_after_touching "$CONFIG" temporal-verifier/src/command.rs
+
+  # loop over remaining arguments, if any
+  until [ -z "$1" ]
+  do
+    FILE="$1"
+    shift
+
+    build_after_touching "$CONFIG" "$FILE"
+  done
+}
+
+build_under_config "" "$@"
+build_under_config "--release" "$@"


### PR DESCRIPTION
This PR adds a script `./tools/compile-times.sh` to help with benchmarking and
understanding compile times for building this project. The script measures the
following scenarios (under both debug and release configurations):
- build everything from scratch including dependencies
- rebuild after touching every `.rs` file in this repo
- rebuild after touching just the `command.rs` file
- for any additional filenames passed on the command line, rebuild after touching just that file

This PR also moves some particularly nasty generics instantiation into the `inference` crate. (I also fixed an unrelated doc warning.)

Here are the results (times are wall clock from my macbook)

- Pre PR #94 
  - Debug
    - From scratch including deps: 20s
    - Touching all .rs files: ~3s
    - Touching command.rs: ~3s
    - Touching bounded/set.rs: ~3s
  - Release
    - From scratch including deps: 37s
    - Touching all .rs files: 17s
    - Touching command.rs: 17s
    - Touching bounded/set.rs: 17s
- After PR #94 but before this PR
  - Debug
    - From scratch including deps: 18s
    - Touching all .rs files: ~3s
    - Touching command.rs: ~2s
    - Touching bounded/set.rs: ~3s
  - Release
    - From scratch including deps: 35s
    - Touching all .rs files: 16s
    - Touching command.rs: 10s
    - Touching bounded/set.rs: 12s
- Tip of this PR (after moving generics instantiation into inference crate)
  - Debug
    - From scratch including deps: 18s
    - Touching all .rs files: ~3s
    - Touching command.rs: ~2s
    - Touching bounded/set.rs: ~2s
  - Release
    - From scratch including deps: 35s
    - Touching all .rs files: 15s
    - Touching command.rs: 3s
    - Touching bounded/set.rs: ~3.5s


The takeaway is that PR #94 improved release mode incremental builds by about
30% when not touching the inference crate, but moving that one generic
instantiation into the inference crate improves the same metric by a factor of
5.

I think this also points to some future opportunities to further split the
inference crate to improve the situation further when working inside that crate
(which will be common).

Full logs:
- [pre-pr-94.log](https://github.com/vmware-research/temporal-verifier/files/12008986/pre-pr-94.log)
- [pre-this-pr.log](https://github.com/vmware-research/temporal-verifier/files/12008987/pre-moving-instantiation.log)
- [after-this-pr.log](https://github.com/vmware-research/temporal-verifier/files/12008988/head.log)


