### PR TITLE
Cancel solver only during `check_sat` and `get_model`

### DIFF
--- a/smtlib/src/conf.rs
+++ b/smtlib/src/conf.rs
@@ -1,0 +1,159 @@
+//! Construct launch and option configurations for Z3 and CVC5.
+
+/// The full invocation of a solver binary.
+#[derive(Debug, Clone)]
+pub struct SolverCmd {
+    /// Binary to launch
+    pub cmd: String,
+    /// Arguments to pass
+    pub args: Vec<String>,
+    /// SMT options to send on startup
+    pub options: Vec<(String, String)>,
+}
+
+impl SolverCmd {
+    fn args<I, S>(&mut self, args: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.args
+            .extend(args.into_iter().map(|s| s.as_ref().to_string()));
+    }
+
+    /// Set an option.
+    pub fn option<S: AsRef<str>>(&mut self, name: &str, val: S) {
+        self.options
+            .push((name.to_string(), val.as_ref().to_string()));
+    }
+
+    /// Build the command line string, for printing purposes.
+    pub fn cmdline(&self) -> String {
+        #[allow(clippy::useless_format)]
+        let args: Vec<_> = self
+            .args
+            .iter()
+            .map(|a| {
+                if a.contains(' ') {
+                    format!("\"{a}\"")
+                } else {
+                    format!("{a}")
+                }
+            })
+            .collect();
+        format!("{} {}", &self.cmd, args.join(" "))
+    }
+}
+
+/// Builder for creating a Z3 [`SolverCmd`].
+#[derive(Debug, Clone)]
+pub struct Z3Conf(SolverCmd);
+
+impl Z3Conf {
+    /// Create a Z3Conf with some default options. Uses `cmd` as the path to Z3.
+    pub fn new(cmd: &str) -> Self {
+        let mut cmd = SolverCmd {
+            cmd: cmd.to_string(),
+            args: vec![],
+            options: vec![],
+        };
+        cmd.args(["-in", "-smt2"]);
+        cmd.option("model.completion", "true");
+        let mut conf = Self(cmd);
+        conf.timeout_ms(Some(30000 * 100));
+        conf
+    }
+
+    /// Enable model compaction
+    pub fn model_compact(&mut self) {
+        self.0.option("model.compact", "true");
+    }
+
+    /// Set the SMT timeout option
+    pub fn timeout_ms(&mut self, ms: Option<usize>) {
+        // this is the default Z3 timeout
+        let ms = ms.unwrap_or(4294967295);
+        self.0.option("timeout", format!("{ms}"));
+    }
+
+    /// Get access to the raw options of the solver.
+    pub fn options(&mut self) -> &mut SolverCmd {
+        &mut self.0
+    }
+
+    /// Get the final command to run the solver.
+    pub fn done(self) -> SolverCmd {
+        self.0
+    }
+}
+
+/// Builder for a CVC4 or CVC5 [`SolverCmd`].
+#[derive(Debug, Clone)]
+pub struct CvcConf {
+    version5: bool,
+    cmd: SolverCmd,
+}
+
+impl CvcConf {
+    fn new_cvc(cmd: &str, version5: bool) -> Self {
+        let mut cmd = SolverCmd {
+            cmd: cmd.to_string(),
+            args: vec![],
+            options: vec![],
+        };
+        // for CVC4, --lang smt2 is needed when using stdin, but when run on a
+        // file with a .smt2 extension it will automatically use the right input
+        // format.
+        cmd.args(vec!["-q", "--lang", "smt2"]);
+        cmd.option("interactive", "false");
+        cmd.option("incremental", "true");
+        cmd.option("seed", "1");
+        Self { version5, cmd }
+    }
+
+    /// Create a new CVC4 builder with some default options.
+    pub fn new_cvc4(cmd: &str) -> Self {
+        Self::new_cvc(cmd, /*version5*/ false)
+    }
+
+    /// Create a new CVC5 builder with some default options.
+    pub fn new_cvc5(cmd: &str) -> Self {
+        Self::new_cvc(cmd, /*version5*/ true)
+    }
+
+    /// Enable finite model finding with mbqi.
+    pub fn finite_models(&mut self) {
+        self.cmd.option("finite-model-find", "true");
+        if self.version5 {
+            self.cmd.option("mbqi", "true");
+            self.cmd.option("fmf-mbqi", "fmc")
+        } else {
+            self.cmd.option("mbqi", "fmc");
+        }
+    }
+
+    /// Enable interleaving enumerative instantiation with other techniques.
+    pub fn interleave_enumerative_instantiation(&mut self) {
+        if self.version5 {
+            self.cmd.option("enum-inst-interleave", "true");
+        } else {
+            self.cmd.option("fs-interleave", "true");
+        }
+    }
+
+    /// Set a per-query time limit. None sets no time limit.
+    pub fn timeout_ms(&mut self, ms: Option<usize>) {
+        let ms = ms.unwrap_or(0);
+        self.cmd.option("tlimit-per", format!("{ms}"));
+    }
+
+    /// Get access to the raw options of the solver.
+    pub fn options(&mut self) -> &mut SolverCmd {
+        &mut self.cmd
+    }
+
+    /// Get the final command to run the solver.
+    pub fn done(self) -> SolverCmd {
+        self.cmd
+    }
+}

--- a/smtlib/src/conf.rs
+++ b/smtlib/src/conf.rs
@@ -1,3 +1,6 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 //! Construct launch and option configurations for Z3 and CVC5.
 
 /// The full invocation of a solver binary.

--- a/smtlib/src/lib.rs
+++ b/smtlib/src/lib.rs
@@ -18,6 +18,8 @@
 #![allow(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+pub mod conf;
 pub mod path;
 pub mod proc;
 pub mod sexp;
+mod tee;

--- a/smtlib/src/tee.rs
+++ b/smtlib/src/tee.rs
@@ -1,3 +1,6 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
 //! Record SMT output and save to a file for debugging purposes.
 
 use std::{

--- a/smtlib/src/tee.rs
+++ b/smtlib/src/tee.rs
@@ -1,0 +1,71 @@
+//! Record SMT output and save to a file for debugging purposes.
+
+use std::{
+    collections::hash_map::DefaultHasher,
+    fs::OpenOptions,
+    hash::{Hash, Hasher},
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use crate::sexp::Sexp;
+
+/// Track and save SMT sent to solver so far.
+#[derive(Debug)]
+pub struct Tee {
+    dir: PathBuf,
+    contents: Vec<Sexp>,
+}
+
+fn calculate_hash<T: Hash>(v: T) -> String {
+    let mut hash_state = DefaultHasher::new();
+    v.hash(&mut hash_state);
+    let h = hash_state.finish();
+    return format!("{:016x}", h)[..8].to_string();
+}
+
+impl Tee {
+    /// Create a new empty `Tee`.
+    pub fn new<P: AsRef<Path>>(dir: P) -> Self {
+        Self {
+            dir: dir.as_ref().to_path_buf(),
+            contents: vec![],
+        }
+    }
+
+    /// Append a raw s-expression sent to solver.
+    pub fn append(&mut self, s: Sexp) {
+        self.contents.push(s)
+    }
+
+    /// Save the SMT2 input currently sent to the solver to a file based on
+    /// content hash. Returns the saved file name.
+    pub fn save(&self) -> io::Result<PathBuf> {
+        let contents = self
+            .contents
+            .iter()
+            .map(|s| {
+                if let Sexp::Comment(c) = s {
+                    #[allow(clippy::comparison_to_empty)]
+                    if c == "" {
+                        return "".to_string();
+                    }
+                    return format!(";; {c}");
+                }
+                // TODO: this should be pretty-printed
+                s.to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let hash = calculate_hash(&contents);
+        let fname = PathBuf::from(format!("query-{hash}.smt2"));
+        let dest = self.dir.join(&fname);
+        let mut f = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(dest)?;
+        write!(&mut f, "{contents}")?;
+        Ok(fname)
+    }
+}

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -15,7 +15,7 @@ use fly::{
     syntax::{Signature, Sort},
 };
 use smtlib::{
-    proc::{CvcConf, SolverCmd, Z3Conf},
+    conf::{CvcConf, SolverCmd, Z3Conf},
     sexp::{self, Atom},
 };
 

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -222,10 +222,7 @@ impl<B: Backend> Solver<B> {
     }
 
     fn get_fo_model(&mut self, typ: TimeType, start: Instant) -> FOModel {
-        let model = self
-            .proc
-            .send_with_reply(&app("get-model", []))
-            .expect("could not get model");
+        let model = self.proc.get_model().expect("could not get model");
         fly::timing::elapsed(typ, start);
         self.backend
             .parse(&self.signature, self.n_states, &self.indicators, &model)

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -18,7 +18,8 @@ use fly::{
     syntax::{Binder, Signature, Sort, Term},
 };
 use smtlib::{
-    proc::{SatResp, SmtPid, SmtProc, SolverCmd, SolverError},
+    conf::SolverCmd,
+    proc::{SatResp, SmtPid, SmtProc, SolverError},
     sexp::{app, atom_i, atom_s, sexp_l, Atom, Sexp},
 };
 


### PR DESCRIPTION
The flow is now that cancelling a solver kills it with a signal if it's in the middle of a check-sat or get-model, and otherwise simply set a flag `Status::Stopping`. If the solver is stopping, then on any subsequent call the solver will be killed. Calls that don't return anything like `assert` and `push` will silently succeed in this case. Eventually a `check_sat` or `get_model` will be called, and it will immediately return `Err(SolverError::Killed)`, and this will be processed as usual by code that deals with cancellation (if the caller knows the solver is never cancelled they can treat this, they can panic on any error to correctly handle I/O errors, which can still happen at any time).

The result is that all the commands that set up the solver should never fail (and we can panic if they do), only `check_sat` and `get_model`. It does mean we no longer handle killing the solver externally with a signal gracefully - cancellation must go through the API to work.