### PR TITLE
Add doc and test for the fact that a quantifier's bindings can be empty

### DIFF
--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -310,6 +310,8 @@ proof {
         term("forall (x : t). x");
         term("forall (x : t),(y:t). x = y");
 
+        term("forall. true"); // empty quantifiers are allowed!
+
         assert_eq!(
             term("forall x:t. x = y & exists z:t. x = z"),
             term("forall x:t. (x = y & exists z:t. x = z)"),

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -97,6 +97,7 @@ pub enum Term {
     #[allow(missing_docs)]
     Quantified {
         quantifier: Quantifier,
+        /// The sequence of bindings bound by this quantifier. Might be empty!
         binders: Vec<Binder>,
         body: Box<Term>,
     },

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -97,7 +97,7 @@ pub enum Term {
     #[allow(missing_docs)]
     Quantified {
         quantifier: Quantifier,
-        /// The sequence of bindings bound by this quantifier. Might be empty!
+        /// The sequence of bindings bound by this quantifier. Might be empty.
         binders: Vec<Binder>,
         body: Box<Term>,
     },


### PR DESCRIPTION
This PR adds a bit of documentation and a test to call out the fact that a `Term::Quantifier`'s list of bindings can be empty.

Not saying I think it *should* work this way, but this is how the code works. The parser supports it, and at least some paths in the code (eg [`semantics::eval_assign`](https://github.com/vmware-research/temporal-verifier/blob/36e811450c1ecc3841ee2cc56f016d16d66cad9b/fly/src/semantics.rs#L271-L275)) handle this case.