### PR TITLE
Multi cartesian product fix

### DIFF
--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -147,6 +147,7 @@ impl std::fmt::Debug for Elements {
         write!(f, "]")
     }
 }
+#[allow(unused_macros)]
 macro_rules! element {
     ($($v:expr),* $(,)?) => {{
         Elements::new(vec![$($v,)*])

--- a/fly/src/lib.rs
+++ b/fly/src/lib.rs
@@ -14,6 +14,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod defs;
+pub mod ouritertools;
 pub mod parser;
 pub mod printer;
 pub mod semantics;

--- a/fly/src/ouritertools.rs
+++ b/fly/src/ouritertools.rs
@@ -1,0 +1,107 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+//! Utility methods on iterators
+
+use itertools::{Itertools, MultiProduct};
+
+enum MultiProductFixedState<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    EmptySource { done: bool },
+    UnderlyingIter(MultiProduct<I>),
+}
+
+/// A wrapper around [itertools::structs::MultiProduct] for handling the product of an empty sequence
+pub struct MultiProductFixed<I>(MultiProductFixedState<I>)
+where
+    I: Iterator + Clone,
+    I::Item: Clone;
+
+impl<I> Iterator for MultiProductFixed<I>
+where
+    I: Iterator + Clone,
+    I::Item: Clone,
+{
+    type Item = Vec<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.0 {
+            MultiProductFixedState::EmptySource { done } => {
+                if *done {
+                    None
+                } else {
+                    *done = true;
+                    Some(vec![])
+                }
+            }
+            MultiProductFixedState::UnderlyingIter(iter) => iter.next(),
+        }
+    }
+}
+
+/// Utility methods for extending the iterator API
+pub trait OurItertools: Iterator {
+    /// Like [itertools::Itertools::multi_cartesian_product], but handles empty self correctly
+    fn multi_cartesian_product_fixed(
+        self,
+    ) -> MultiProductFixed<<Self::Item as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        Self::Item: IntoIterator,
+        <Self::Item as IntoIterator>::IntoIter: Clone,
+        <Self::Item as IntoIterator>::Item: Clone,
+    {
+        let mut p = self.peekable();
+        if p.peek().is_none() {
+            MultiProductFixed(MultiProductFixedState::EmptySource { done: false })
+        } else {
+            MultiProductFixed(MultiProductFixedState::UnderlyingIter(
+                p.multi_cartesian_product(),
+            ))
+        }
+    }
+}
+
+impl<T: ?Sized> OurItertools for T where T: Iterator {}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::empty;
+
+    use super::OurItertools;
+    use itertools::Itertools;
+
+    #[test]
+    // from the itertools documentation
+    fn test_multi_cartesian_product_fixed_doctest() {
+        let mut multi_prod = (0..3)
+            .map(|i| (i * 2)..(i * 2 + 2))
+            .multi_cartesian_product_fixed();
+        assert_eq!(multi_prod.next(), Some(vec![0, 2, 4]));
+        assert_eq!(multi_prod.next(), Some(vec![0, 2, 5]));
+        assert_eq!(multi_prod.next(), Some(vec![0, 3, 4]));
+        assert_eq!(multi_prod.next(), Some(vec![0, 3, 5]));
+        assert_eq!(multi_prod.next(), Some(vec![1, 2, 4]));
+        assert_eq!(multi_prod.next(), Some(vec![1, 2, 5]));
+        assert_eq!(multi_prod.next(), Some(vec![1, 3, 4]));
+        assert_eq!(multi_prod.next(), Some(vec![1, 3, 5]));
+        assert_eq!(multi_prod.next(), None);
+    }
+
+    #[test]
+    fn test_multi_cartesian_product_empty() {
+        let mut i = empty::<Vec<usize>>().multi_cartesian_product();
+        // This demonstrates the bug in itertools. The correct answer is actually Some([]) followed by None.
+        assert_eq!(i.next(), None);
+    }
+
+    #[test]
+    fn test_multi_cartesian_product_fixed_empty() {
+        let mut i = empty::<Vec<usize>>().multi_cartesian_product_fixed();
+        assert_eq!(i.next(), Some(vec![]));
+        assert_eq!(i.next(), None);
+    }
+}

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -8,6 +8,8 @@ use std::fmt;
 
 use serde::Serialize;
 
+use crate::ouritertools::OurItertools;
+
 /// Unary operators
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum UOp {
@@ -376,7 +378,7 @@ impl Signature {
 
                 for new_ind in (0..rel_decl.args.len())
                     .map(|_| [false, true])
-                    .multi_cartesian_product()
+                    .multi_cartesian_product_fixed()
                 {
                     // Only generate terms where at least one argument is a newly generated term,
                     // to make sure each term is generated exactly once.
@@ -397,7 +399,7 @@ impl Signature {
                         for args in arg_terms
                             .iter()
                             .map(|&t| t.iter())
-                            .multi_cartesian_product()
+                            .multi_cartesian_product_fixed()
                         {
                             let term_vec = args.iter().map(|&x| x.clone()).collect();
                             new_new_terms[sort_idx(&rel_decl.sort)].push(Term::App(

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -9,11 +9,11 @@ use std::{
 };
 
 use crate::quant::QuantifierConfig;
-use fly::semantics::Model;
 use fly::syntax::BinOp;
 use fly::syntax::Term::*;
 use fly::syntax::*;
 use fly::term::{fo::FirstOrder, prime::clear_next, prime::Next};
+use fly::{ouritertools::OurItertools, semantics::Model};
 use solver::conf::SolverConf;
 use solver::SatResp;
 
@@ -191,7 +191,7 @@ impl FOModule {
                     Term::NAryOp(NOp::Or, args) => args.iter().collect_vec(),
                     _ => vec![t],
                 })
-                .multi_cartesian_product()
+                .multi_cartesian_product_fixed()
                 .collect_vec()
         } else {
             vec![self.transitions.iter().collect_vec()]

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -3,6 +3,7 @@
 
 //! Implement simple components, lemma domains and data structures for use in inference.
 
+use fly::ouritertools::OurItertools;
 use itertools::Itertools;
 use std::collections::VecDeque;
 use std::fmt::Debug;
@@ -156,7 +157,7 @@ impl LemmaQf for LemmaCnf {
         // Return all combinations of weakened clauses.
         weakened_clauses
             .into_iter()
-            .multi_cartesian_product()
+            .multi_cartesian_product_fixed()
             .filter(|b| !ignore(b))
             .collect_vec()
     }

--- a/inference/src/quant.rs
+++ b/inference/src/quant.rs
@@ -4,6 +4,7 @@
 //! Manage quantifiers used in inference.
 
 use crate::hashmap::HashSet;
+use fly::ouritertools::OurItertools;
 use itertools::Itertools;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -149,7 +150,7 @@ impl<Q: Clone> QuantifierSequence<Q> {
         vars.iter()
             .enumerate()
             .map(|(i, vs)| vs.iter().permutations(only_vars[i].len()))
-            .multi_cartesian_product()
+            .multi_cartesian_product_fixed()
             .map(|perm| {
                 only_vars
                     .iter()
@@ -218,7 +219,7 @@ impl QuantifierConfig {
                         }
                         Some(q) => vec![*q],
                     })
-                    .multi_cartesian_product()
+                    .multi_cartesian_product_fixed()
                     .filter(|qs| {
                         let e = count_exists(qs);
                         e >= min_existentials && e <= max_existentials

--- a/inference/src/weaken.rs
+++ b/inference/src/weaken.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use crate::hashmap::{HashMap, HashSet};
 
+use fly::ouritertools::OurItertools;
 use itertools::FoldWhile::{Continue, Done};
 use itertools::Itertools;
 
@@ -37,7 +38,7 @@ fn extend_assignment(
 
     vars.iter()
         .map(|_| 0..elem_count)
-        .multi_cartesian_product()
+        .multi_cartesian_product_fixed()
         .map(|asgn| {
             let mut new_assignment = assignment.clone();
             for i in 0..vars.len() {

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -116,7 +116,7 @@ end_group
 
 start_group "project-specific lints"
 if grep -wr --include '*.rs' --exclude ouritertools.rs multi_cartesian_product; then
-  error "found some occurrences of multi_cartesian_product"
+  error "found some occurrences of multi_cartesian_product; use multi_cartesian_product_fixed to handle empty iterators correctly"
   exit 1
 fi
 end_group

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -115,7 +115,7 @@ fi
 end_group
 
 start_group "project-specific lints"
-if grep -wr --include '*.rs' --exclude '*/src/ouritertools.rs' multi_cartesian_product; then
+if grep -wr --include '*.rs' --exclude ouritertools.rs multi_cartesian_product; then
   error "found some occurrences of multi_cartesian_product"
   exit 1
 fi

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -113,3 +113,10 @@ else
   cargo doc --quiet --document-private-items --no-deps
 fi
 end_group
+
+start_group "project-specific lints"
+if grep -wr --include '*.rs' --exclude './target/*' --exclude './.git/*' --exclude ./fly/src/ouritertools.rs multi_cartesian_product; then
+  error "found some occurrences of multi_cartesian_product"
+  exit 1
+fi
+end_group

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -115,7 +115,7 @@ fi
 end_group
 
 start_group "project-specific lints"
-if grep -wr --include '*.rs' --exclude './target/*' --exclude './.git/*' --exclude ./fly/src/ouritertools.rs multi_cartesian_product; then
+if grep -wr --include '*.rs' --exclude '*/src/ouritertools.rs' multi_cartesian_product; then
   error "found some occurrences of multi_cartesian_product"
   exit 1
 fi


### PR DESCRIPTION
This PR implements a corrected wrapper around `itertools::multi_cartesian_product`.

I added a CI lint that forbids the string `multi_cartesian_product` (as a standalone word, not a substring, as decided by `grep -w`) from the code base. Use the wrapper `multi_cartesian_product_fixed` instead.

I ported all existing call sites to use the fixed version. I considered each call site manually and convinced myself that either the iterator was never empty or that the old code did not correctly handle that case already. I also removed some obvious workarounds that handled the empty iterator case separately to avoid the bug.

Fixes #73 