### PR TITLE
Fix a stray clippy warning

### DIFF
--- a/temporal-verifier/tests/test_examples.rs
+++ b/temporal-verifier/tests/test_examples.rs
@@ -198,9 +198,7 @@ fn get_file_tests(path: &Path) -> Vec<Test> {
                         panic!("{err}");
                     }
                 };
-                let args = ["TEST".to_string()]
-                    .into_iter()
-                    .chain(split_line.into_iter());
+                let args = ["TEST".to_string()].into_iter().chain(split_line);
                 Test {
                     path: path.to_path_buf(),
                     cfg: TestCfg::try_parse_from(args).unwrap_or_else(|err| {


### PR DESCRIPTION
I don't really understand why this doesn't show up in CI, but VS Code reliably reports it (with the rust-analyzer check command set to `clippy`).