### PR TITLE
Cancel solver queries (qalpha)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "itertools",
  "log",
  "rayon",
+ "smtlib",
  "solver",
  "thiserror",
  "verify",

--- a/inference/Cargo.toml
+++ b/inference/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 fly = { path = "../fly" }
+smtlib = { path = "../smtlib" }
 solver = { path = "../solver" }
 verify = { path = "../verify" }
 bounded = { path = "../bounded" }

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -297,7 +297,7 @@ impl FOModule {
                             }
                         }
                         Err(SolverError::Killed) => return TransCexResult::Cancelled,
-                        Err(SolverError::Unknown(_)) => (),
+                        Err(SolverError::CouldNotMinimize(_)) => (),
                         Err(e) => panic!("error in solver: {e}"),
                     },
                     Ok(SatResp::Unsat) => {
@@ -319,7 +319,7 @@ impl FOModule {
                         break 'inner;
                     }
                     Err(SolverError::Killed) => return TransCexResult::Cancelled,
-                    Ok(SatResp::Unknown(_)) | Err(SolverError::Unknown(_)) => (),
+                    Ok(SatResp::Unknown(_)) | Err(SolverError::CouldNotMinimize(_)) => (),
                     Err(e) => panic!("error in solver: {e}"),
                 }
                 solver.save_tee();

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -332,10 +332,7 @@ impl FOModule {
             .reduce(|x, y| x.union(&y).cloned().collect())
             .unwrap();
 
-        log::debug!(
-            "Found UNSAT with {} formulas in prestate.",
-            unsat_core.len()
-        );
+        log::debug!("Found UNSAT with {} formulas in prestate.", core.len());
 
         if self.minimal {
             assert_eq!(unsat_core, core.participants);

--- a/inference/src/houdini.rs
+++ b/inference/src/houdini.rs
@@ -74,7 +74,7 @@ impl Houdini {
             match resp {
                 SatResp::Sat => {
                     log::info!("        Got model");
-                    let states = solver.get_model();
+                    let states = solver.get_model().expect("could not get model");
                     assert_eq!(states.len(), 1);
                     // TODO(oded): make 0 and 1 special constants for this use
                     assert_eq!(states[0].eval(&self.init), 1);
@@ -123,7 +123,7 @@ impl Houdini {
                 let resp = solver.check_sat(HashMap::new()).expect("error in solver");
                 if matches!(resp, SatResp::Sat) {
                     log::info!("        Got model");
-                    let states = solver.get_model();
+                    let states = solver.get_model().expect("could not get model");
                     assert_eq!(states.len(), 2);
                     // TODO(oded): make 0 and 1 special constants for their use as Booleans
                     assert_eq!(states[1].eval(q), 0);

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -948,6 +948,7 @@ where
                             let mut cancel_lock = cancel.write().unwrap();
                             *cancel_lock = true;
                         }
+                        fo.kill_all_solvers();
                         {
                             let mut first_sat_lock = first_sat.lock().unwrap();
                             if first_sat_lock.is_none() {
@@ -1308,8 +1309,11 @@ where
                 let term = [prefix.quantify(self.inductive.lemma_qf.base_to_term(&body.to_base()))];
                 match fo.trans_cex(conf, &term, &term[0], false, false, Some(&cancel)) {
                     TransCexResult::CTI(pre, post) => {
-                        let mut lock = cancel.write().unwrap();
-                        *lock = true;
+                        {
+                            let mut lock = cancel.write().unwrap();
+                            *lock = true;
+                        }
+                        fo.kill_all_solvers();
                         return Some((pre, post));
                     }
                     TransCexResult::UnsatCore(_) => {

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -7,7 +7,7 @@ use fly::ouritertools::OurItertools;
 use itertools::Itertools;
 use std::collections::VecDeque;
 use std::fmt::Debug;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use fly::semantics::Model;
@@ -17,7 +17,7 @@ use solver::conf::SolverConf;
 
 use crate::{
     atoms::{Literal, RestrictedAtoms},
-    basics::{FOModule, InferenceConfig, TransCexResult},
+    basics::{FOModule, InferenceConfig, SolverPids, TransCexResult},
     hashmap::{HashMap, HashSet},
     quant::QuantifierPrefix,
     subsume::OrderSubsumption,
@@ -929,7 +929,7 @@ where
             self.lemmas.to_terms_ids().into_iter().unzip();
 
         let new_cores: Mutex<Vec<(Arc<QuantifierPrefix>, O, HashSet<usize>)>> = Mutex::new(vec![]);
-        let cancel = RwLock::new(false);
+        let solver_pids = SolverPids::new();
         let unknown = Mutex::new(false);
         let first_sat = Mutex::new(None);
         let total_sat = Mutex::new(0_usize);
@@ -942,13 +942,9 @@ where
             .filter(|(prefix, body)| !self.blocked.subsumes(prefix, body))
             .find_map_any(|(prefix, body)| {
                 let term = prefix.quantify(self.lemmas.lemma_qf.base_to_term(&body.to_base()));
-                match fo.trans_cex(conf, &pre_terms, &term, false, false, Some(&cancel)) {
+                match fo.trans_cex(conf, &pre_terms, &term, false, false, Some(&solver_pids)) {
                     TransCexResult::CTI(_, model) => {
-                        {
-                            let mut cancel_lock = cancel.write().unwrap();
-                            *cancel_lock = true;
-                        }
-                        fo.kill_all_solvers();
+                        solver_pids.cancel();
                         {
                             let mut first_sat_lock = first_sat.lock().unwrap();
                             if first_sat_lock.is_none() {
@@ -1297,7 +1293,7 @@ where
 
     pub fn trans_cycle(&mut self, fo: &FOModule, conf: &SolverConf) -> bool {
         let new_inductive: Mutex<Vec<_>> = Mutex::new(vec![]);
-        let cancel = RwLock::new(false);
+        let solver_pids = SolverPids::new();
         let unknown = Mutex::new(false);
         log::info!("Getting weakest lemmas...");
         let weakest = self.weaken_set.as_vec();
@@ -1307,13 +1303,9 @@ where
             .filter(|(prefix, body)| !self.inductive.subsumes(prefix, body))
             .find_map_any(|(prefix, body)| {
                 let term = [prefix.quantify(self.inductive.lemma_qf.base_to_term(&body.to_base()))];
-                match fo.trans_cex(conf, &term, &term[0], false, false, Some(&cancel)) {
+                match fo.trans_cex(conf, &term, &term[0], false, false, Some(&solver_pids)) {
                     TransCexResult::CTI(pre, post) => {
-                        {
-                            let mut lock = cancel.write().unwrap();
-                            *lock = true;
-                        }
-                        fo.kill_all_solvers();
+                        solver_pids.cancel();
                         return Some((pre, post));
                     }
                     TransCexResult::UnsatCore(_) => {

--- a/inference/src/lib.rs
+++ b/inference/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::new_without_default)]
 // documentation-related lints (only checked when running rustdoc)
 #![allow(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/smtlib/src/proc.rs
+++ b/smtlib/src/proc.rs
@@ -85,6 +85,9 @@ pub enum SolverError {
     /// I/O went wrong
     #[error("some I/O went wrong: {0}")]
     Io(#[from] io::Error),
+    /// Solver returned `unknown
+    #[error("solver returned unknown:\n{0}")]
+    Unknown(String),
     /// Solver returned an `(error ...)` response
     #[error("solver returned an error:\n{0}")]
     UnexpectedClose(String),

--- a/smtlib/src/proc.rs
+++ b/smtlib/src/proc.rs
@@ -85,9 +85,9 @@ pub enum SolverError {
     /// I/O went wrong
     #[error("some I/O went wrong: {0}")]
     Io(#[from] io::Error),
-    /// Solver returned `unknown
-    #[error("solver returned unknown:\n{0}")]
-    Unknown(String),
+    /// Could not minimize
+    #[error("could not minimize:\n{0}")]
+    CouldNotMinimize(String),
     /// Solver returned an `(error ...)` response
     #[error("solver returned an error:\n{0}")]
     UnexpectedClose(String),

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -300,8 +300,7 @@ impl<B: Backend> Solver<B> {
                     return Ok(new_card + 1);
                 }
                 SatResp::Unknown(msg) => {
-                    // TODO: add a case to SolverError for unknown
-                    return Err(SolverError::UnexpectedClose(msg));
+                    return Err(SolverError::Unknown(msg));
                 }
             }
             prev_ind = Some(ind);

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -221,21 +221,22 @@ impl<B: Backend> Solver<B> {
         r
     }
 
-    fn get_fo_model(&mut self, typ: TimeType, start: Instant) -> FOModel {
-        let model = self.proc.get_model().expect("could not get model");
+    fn get_fo_model(&mut self, typ: TimeType, start: Instant) -> Result<FOModel, SolverError> {
+        let model = self.proc.get_model()?;
         fly::timing::elapsed(typ, start);
-        self.backend
-            .parse(&self.signature, self.n_states, &self.indicators, &model)
+        Ok(self
+            .backend
+            .parse(&self.signature, self.n_states, &self.indicators, &model))
     }
 
     /// After a sat response to check_sat or check_sat_assuming, produce a trace
     /// of models, one per state. Each model interprets all of the symbols in
     /// the signature.
-    pub fn get_model(&mut self) -> Vec<Model> {
+    pub fn get_model(&mut self) -> Result<Vec<Model>, SolverError> {
         self.last_assumptions = None;
         let start = fly::timing::start();
-        let fo_model = self.get_fo_model(TimeType::GetModel, start);
-        fo_model.into_trace(&self.signature, self.n_states)
+        let fo_model = self.get_fo_model(TimeType::GetModel, start)?;
+        Ok(fo_model.into_trace(&self.signature, self.n_states))
     }
 
     /// Construct an assertion that enforces `univ` has max cardinality `card`.
@@ -314,7 +315,11 @@ impl<B: Backend> Solver<B> {
     ///
     /// Returns true on success and adds indicators to `indicators` to enforce
     /// the cardinality `card`.
-    fn is_valid_max_card(&mut self, card: usize, indicators: &mut Vec<Term>) -> bool {
+    fn is_valid_max_card(
+        &mut self,
+        card: usize,
+        indicators: &mut Vec<Term>,
+    ) -> Result<bool, SolverError> {
         let mut new_indicators = vec![];
         let sorts = self.signature.sorts.clone();
         for sort in &sorts {
@@ -326,15 +331,14 @@ impl<B: Backend> Solver<B> {
             .chain(new_indicators.iter())
             .map(sexp::term)
             .collect::<Vec<_>>();
-        let r = self.proc.check_sat_assuming(&assumptions);
+        let r = self.proc.check_sat_assuming(&assumptions)?;
         match r {
-            Ok(SatResp::Sat) => {
+            SatResp::Sat => {
                 indicators.extend(new_indicators);
-                true
+                Ok(true)
             }
-            Ok(SatResp::Unsat) => false,
-            Ok(SatResp::Unknown(msg)) => panic!("could not check card {card}: {msg}"),
-            Err(err) => panic!("error checking card: {err}"),
+            SatResp::Unsat => Ok(false),
+            SatResp::Unknown(msg) => panic!("could not check card {card}: {msg}"),
         }
     }
 
@@ -342,13 +346,13 @@ impl<B: Backend> Solver<B> {
     /// where all universes are at `card` in size.
     ///
     /// Returns the cardinality `card` and adds indicators to enforce this cardinality to `indicators`.
-    fn get_min_max_card(&mut self, indicators: &mut Vec<Term>) -> usize {
+    fn get_min_max_card(&mut self, indicators: &mut Vec<Term>) -> Result<usize, SolverError> {
         if self.signature.sorts.is_empty() {
-            return 0;
+            return Ok(0);
         }
         for card in 1..100 {
-            if self.is_valid_max_card(card, indicators) {
-                return card;
+            if self.is_valid_max_card(card, indicators)? {
+                return Ok(card);
             }
         }
         panic!("max cardinality got too high");
@@ -377,7 +381,7 @@ impl<B: Backend> Solver<B> {
             .map(|(ind, val)| if val { ind } else { Term::negate(ind) })
             .sorted()
             .collect::<Vec<_>>();
-        let max_card = self.get_min_max_card(&mut indicators);
+        let max_card = self.get_min_max_card(&mut indicators)?;
         // Minimize each sort in turn, greedily in the order of the signature.
         //
         // (This does not produce a global optimum but the search process is
@@ -388,7 +392,7 @@ impl<B: Backend> Solver<B> {
                 self.minimize_card(max_card, &mut indicators, &sort)?;
             }
         }
-        let model = self.get_fo_model(TimeType::GetMinimalModel, start);
+        let model = self.get_fo_model(TimeType::GetMinimalModel, start)?;
         Ok(model.into_trace(&self.signature, self.n_states))
     }
 

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -300,7 +300,7 @@ impl<B: Backend> Solver<B> {
                     return Ok(new_card + 1);
                 }
                 SatResp::Unknown(msg) => {
-                    return Err(SolverError::Unknown(msg));
+                    return Err(SolverError::CouldNotMinimize(msg));
                 }
             }
             prev_ind = Some(ind);


### PR DESCRIPTION
This PR employs solver cancellation in the context of `qalpha` in inference, where many solver calls run in parallel, but progress can be made immediately after finding the first SAT result. This requires bubbling up some solver errors and handling them, as well as creating the dedicated struct `SolverPids` which manages the solvers that have been called and allows the caller to cancel them upon request.