### PR TITLE
Checker improvements

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -251,6 +251,7 @@ pub fn check<'a>(
 
 /// The same as `check`, but instead of starting at `init` and going until it gets to `not_safe`,
 /// it starts at `not_safe` and goes backwards until it gets to `init`.
+/// It also returns a negated Bdd if it returns Convergence.
 pub fn check_reversed<'a>(
     module: &'a Module,
     universe: &'a Universe,

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -169,33 +169,33 @@ impl Context<'_> {
 
         // Convert valuations to models
         let valuations: Vec<_> = valuations.into_iter().map(Option::unwrap).collect();
+        let universe = self
+            .signature
+            .sorts
+            .iter()
+            .map(|s| self.universe[s])
+            .collect();
         valuations
             .into_iter()
             .map(|valuation| {
                 Model::new(
                     self.signature,
-                    &self
-                        .signature
-                        .sorts
-                        .iter()
-                        .map(|s| self.universe[s])
-                        .collect(),
+                    &universe,
                     self.signature
                         .relations
                         .iter()
                         .map(|r| {
-                            Interpretation::new(
-                                &r.args
-                                    .iter()
-                                    .map(|s| cardinality(self.universe, s))
-                                    .chain([2])
-                                    .collect(),
-                                |elements| {
-                                    valuation
-                                        .value(self.vars[self.indices[r.name.as_str()][elements].0])
-                                        as usize
-                                },
-                            )
+                            let shape = r
+                                .args
+                                .iter()
+                                .map(|s| cardinality(self.universe, s))
+                                .chain([2])
+                                .collect();
+                            Interpretation::new(&shape, |elements| {
+                                valuation
+                                    .value(self.vars[self.indices[r.name.as_str()][elements].0])
+                                    as usize
+                            })
                         })
                         .collect(),
                 )

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -316,6 +316,7 @@ fn check_internal<'a>(
     let translate = |term| {
         let term = nullary_id_to_app(term, &module.signature.relations);
         let term = fly::term::prime::Next::new(&module.signature).normalize(&term);
+        println!("{}\n", term);
         term_to_bdd(&term, &context, &HashMap::new())
     };
 

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -294,12 +294,12 @@ fn check_internal<'a>(
 
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
-            todo!("non-bool relations")
+            panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions in checker (use Module::inline_defs)")
     }
 
     let d = extract(module).map_err(CheckerError::ExtractionError)?;

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -316,7 +316,6 @@ fn check_internal<'a>(
     let translate = |term| {
         let term = nullary_id_to_app(term, &module.signature.relations);
         let term = fly::term::prime::Next::new(&module.signature).normalize(&term);
-        println!("{}\n", term);
         term_to_bdd(&term, &context, &HashMap::new())
     };
 

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -235,7 +235,7 @@ pub fn check<'a>(
     let mut trace = vec![init.clone()];
 
     let mut current = init;
-    let mut reachable = current.clone();
+    let mut reachable = context.mk_bool(false);
 
     if let Some(valuation) = current.and(&not_safe).sat_witness() {
         context.print_counterexample(&valuation, &trace, &tr);

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -454,6 +454,11 @@ fn term_to_bdd(
 
     let bdd: Bdd = match term {
         Term::Literal(value) => context.mk_bool(*value),
+        Term::Id(id) => match assignments.get(id) {
+            Some(0) => context.mk_bool(false),
+            Some(1) => context.mk_bool(true),
+            _ => return Err(CheckerError::CouldNotTranslateToBdd(term.clone())),
+        },
         Term::App(relation, primes, args) => context.get(
             relation,
             &args.iter().map(element).collect::<Result<Vec<_>, _>>()?,
@@ -508,8 +513,9 @@ fn term_to_bdd(
         }
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
         | Term::UnaryOp(UOp::Next | UOp::Previously, _)
-        | Term::BinOp(BinOp::Until | BinOp::Since, ..)
-        | Term::Id(_) => return Err(CheckerError::CouldNotTranslateToBdd(term.clone())),
+        | Term::BinOp(BinOp::Until | BinOp::Since, ..) => {
+            return Err(CheckerError::CouldNotTranslateToBdd(term.clone()))
+        }
     };
     Ok(bdd)
 }

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -289,7 +289,7 @@ fn check_internal<'a>(
             init,
             Box::new(|current: &mut Bdd, context: &Context| {
                 let primed = context.mutables..context.mutables * 2;
-                for i in primed.clone().into_iter().rev() {
+                for i in primed.clone().rev() {
                     unsafe {
                         current
                             .rename_variable(context.vars[i - context.mutables], context.vars[i]);
@@ -633,6 +633,95 @@ mod tests {
         let universe = std::collections::HashMap::new();
         assert!(matches!(
             check(&module, &universe, None, false)?,
+            CheckerAnswer::Convergence(..),
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_basic_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/tests/examples/basic2.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = HashMap::from([]);
+
+        assert!(matches!(
+            check_reversed(&module, &universe, Some(0), false)?,
+            CheckerAnswer::Unknown,
+        ));
+        assert!(matches!(
+            check_reversed(&module, &universe, Some(1), false)?,
+            CheckerAnswer::Counterexample(_),
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_lockserver_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = HashMap::from([("node".to_string(), 2)]);
+
+        assert!(matches!(
+            check_reversed(&module, &universe, None, false)?,
+            CheckerAnswer::Convergence(..),
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_lockserver_buggy_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = HashMap::from([("node".to_string(), 2)]);
+
+        let bug = check_reversed(&module, &universe, Some(12), false)?;
+        assert!(matches!(bug, CheckerAnswer::Counterexample(_)));
+        let bug = check_reversed(&module, &universe, None, false)?;
+        assert!(matches!(bug, CheckerAnswer::Counterexample(_)));
+
+        let too_short = check_reversed(&module, &universe, Some(11), false)?;
+        assert!(matches!(too_short, CheckerAnswer::Unknown));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_consensus_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/examples/consensus.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = std::collections::HashMap::from([
+            ("node".to_string(), 1),
+            ("quorum".to_string(), 1),
+            ("value".to_string(), 1),
+        ]);
+
+        assert!(matches!(
+            check_reversed(&module, &universe, Some(0), false)?,
+            CheckerAnswer::Unknown,
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_immutability_reversed() -> Result<(), CheckerError> {
+        let source =
+            include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = std::collections::HashMap::new();
+        assert!(matches!(
+            check_reversed(&module, &universe, None, false)?,
             CheckerAnswer::Convergence(..),
         ));
         Ok(())

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -5,8 +5,7 @@
 
 use biodivine_lib_bdd::*;
 use boolean_expression::BooleanExpression;
-use fly::{ouritertools::OurItertools, syntax::*, transitions::*};
-use itertools::Itertools;
+use fly::{ouritertools::OurItertools, semantics::*, syntax::*, transitions::*};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -82,13 +81,13 @@ impl Context<'_> {
         self.bdds.mk_var(self.vars[i])
     }
 
-    fn print_counterexample(
+    fn convert_counterexample(
         &self,
         valuation: &BddValuation,
         trace: &[Bdd],
         tr: &Bdd,
         reversed: bool,
-    ) {
+    ) -> Vec<Model> {
         let mut valuations: Vec<Option<BddValuation>> = Vec::with_capacity(trace.len());
         valuations.resize(trace.len(), None);
 
@@ -168,21 +167,40 @@ impl Context<'_> {
             valuations[i] = Some(bdd.sat_witness().unwrap());
         }
 
-        println!("found counterexample!");
-        for (i, valuation) in valuations.iter().enumerate() {
-            println!("state {}:", i);
-            let valuation = valuation.clone().unwrap();
-            for relation in self.indices.keys().sorted() {
-                print!("{}: {{", relation);
-                for (elements, (i, _mutable)) in self.indices[relation].iter().sorted() {
-                    if valuation.value(self.vars[*i]) {
-                        print!("{:?}, ", elements);
-                    }
-                }
-                println!("}}");
-            }
-            println!();
-        }
+        // Convert valuations to models
+        let valuations: Vec<_> = valuations.into_iter().map(Option::unwrap).collect();
+        valuations
+            .into_iter()
+            .map(|valuation| {
+                Model::new(
+                    self.signature,
+                    &self
+                        .signature
+                        .sorts
+                        .iter()
+                        .map(|s| self.universe[s])
+                        .collect(),
+                    self.signature
+                        .relations
+                        .iter()
+                        .map(|r| {
+                            Interpretation::new(
+                                &r.args
+                                    .iter()
+                                    .map(|s| cardinality(self.universe, s))
+                                    .chain([2])
+                                    .collect(),
+                                |elements| {
+                                    valuation
+                                        .value(self.vars[self.indices[r.name.as_str()][elements].0])
+                                        as usize
+                                },
+                            )
+                        })
+                        .collect(),
+                )
+            })
+            .collect()
     }
 
     fn mk_bool(&self, value: bool) -> Bdd {
@@ -206,7 +224,7 @@ impl Context<'_> {
 /// The result of a successful run of the bounded model checker
 pub enum CheckerAnswer<'a> {
     /// The checker found a counterexample
-    Counterexample(BddValuation),
+    Counterexample(Vec<Model>),
     /// The checker did not find a counterexample
     Unknown,
     /// The checker found that the set of states stopped changing
@@ -371,8 +389,8 @@ fn check_internal<'a>(
 
     // Do the search
     if let Some(valuation) = current.and(&not_safe).sat_witness() {
-        context.print_counterexample(&valuation, &trace, &tr, reversed);
-        return Ok(CheckerAnswer::Counterexample(valuation));
+        let models = context.convert_counterexample(&valuation, &trace, &tr, reversed);
+        return Ok(CheckerAnswer::Counterexample(models));
     }
     let mut i = 0;
     while depth.map(|d| i < d).unwrap_or(true) {
@@ -391,8 +409,8 @@ fn check_internal<'a>(
 
         trace.push(current.clone());
         if let Some(valuation) = current.and(&not_safe).sat_witness() {
-            context.print_counterexample(&valuation, &trace, &tr, reversed);
-            return Ok(CheckerAnswer::Counterexample(valuation));
+            let models = context.convert_counterexample(&valuation, &trace, &tr, reversed);
+            return Ok(CheckerAnswer::Counterexample(models));
         }
 
         i += 1;

--- a/bounded/src/sat.rs
+++ b/bounded/src/sat.rs
@@ -329,6 +329,11 @@ fn term_to_ast(
     let ast: Ast = match term {
         Term::Literal(true) => Ast::And(vec![]),
         Term::Literal(false) => Ast::Or(vec![]),
+        Term::Id(id) => match assignments.get(id) {
+            Some(0) => Ast::Or(vec![]),
+            Some(1) => Ast::And(vec![]),
+            _ => return Err(CheckerError::CouldNotTranslateToAst(term.clone())),
+        },
         Term::App(relation, primes, args) => Ast::Var(
             relation.to_string(),
             args.iter().map(element).collect::<Result<Vec<_>, _>>()?,
@@ -387,8 +392,9 @@ fn term_to_ast(
         }
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
         | Term::UnaryOp(UOp::Next | UOp::Previously, _)
-        | Term::BinOp(BinOp::Until | BinOp::Since, ..)
-        | Term::Id(_) => return Err(CheckerError::CouldNotTranslateToAst(term.clone())),
+        | Term::BinOp(BinOp::Until | BinOp::Since, ..) => {
+            return Err(CheckerError::CouldNotTranslateToAst(term.clone()))
+        }
     };
     Ok(ast)
 }

--- a/bounded/src/sat.rs
+++ b/bounded/src/sat.rs
@@ -168,12 +168,12 @@ pub fn check(
 
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
-            todo!("non-bool relations")
+            panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions in checker (use Module::inline_defs)")
     }
 
     let d = extract(module).map_err(CheckerError::ExtractionError)?;

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -1061,6 +1061,11 @@ fn term_to_ast(
     let ast: Ast = match term {
         Term::Literal(true) => Ast::And(btreeset![]),
         Term::Literal(false) => Ast::Or(btreeset![]),
+        Term::Id(id) => match assignments.get(id) {
+            Some(0) => Ast::Or(btreeset![]),
+            Some(1) => Ast::And(btreeset![]),
+            _ => return Err(TranslationError::CouldNotTranslateToAst(term.clone())),
+        },
         Term::App(name, 0, args) => {
             let args = args.iter().map(element).collect::<Result<Vec<_>, _>>()?;
             Ast::Includes(name.clone(), Elements::new(args))
@@ -1120,7 +1125,6 @@ fn term_to_ast(
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
         | Term::UnaryOp(UOp::Next | UOp::Previously, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..)
-        | Term::Id(_)
         | Term::App(..) => return Err(TranslationError::CouldNotTranslateToAst(term.clone())),
     };
     Ok(ast)

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -568,7 +568,7 @@ fn translate<'a>(
 ) -> Result<(BoundedProgram, Indices<'a>), TranslationError> {
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
-            todo!("non-bool relations")
+            panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
@@ -584,7 +584,7 @@ fn translate<'a>(
     }
 
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions in checker (use Module::inline_defs)")
     }
 
     let d = extract(module).map_err(TranslationError::ExtractionError)?;

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -5,8 +5,7 @@
 //! into a `BoundedProgram`, then use `interpret` to evaluate it.
 
 use bitvec::prelude::*;
-use fly::{ouritertools::OurItertools, sorts::*, syntax::*, transitions::*};
-use itertools::Itertools;
+use fly::{ouritertools::OurItertools, semantics::*, sorts::*, syntax::*, transitions::*};
 use std::collections::{BTreeSet, VecDeque};
 use thiserror::Error;
 
@@ -14,9 +13,11 @@ use thiserror::Error;
 #[derive(Debug, PartialEq)]
 pub enum CheckerAnswer {
     /// The checker found a counterexample
-    Counterexample,
+    Counterexample(Vec<Model>),
     /// The checker did not find a counterexample
     Unknown,
+    /// The checker found that the set of states stopped changing
+    Convergence,
 }
 
 /// Combined entry point to both translate and search the module.
@@ -26,63 +27,80 @@ pub fn check(
     depth: Option<usize>,
     compress_traces: TraceCompression,
     print_timing: bool,
-) -> Option<CheckerAnswer> {
-    match translate(module, universe) {
-        Err(e) => {
-            eprintln!("{}", e);
-            None
-        }
-        Ok(program) => match interpret(&program, depth, compress_traces, print_timing) {
-            InterpreterResult::Unknown => {
-                println!("no counterexample found");
-                Some(CheckerAnswer::Unknown)
-            }
-            InterpreterResult::Counterexample(trace) => {
-                println!("found counterexample!");
-                let indices = Indices::new(&module.signature, universe);
-                match compress_traces {
-                    TraceCompression::Yes => {
-                        let (state, depth) = match trace {
-                            Trace::Trace(..) => unreachable!(),
-                            Trace::CompressedTrace(state, depth) => (state, depth),
-                        };
-                        println!("final state (depth {}):", depth);
-                        for r in &module.signature.relations {
-                            let relation = &r.name;
-                            print!("{}: {{", relation);
-                            for ((r, elements), i) in indices.0.iter().sorted() {
-                                if r == relation && state.0[*i] {
-                                    print!("{:?}, ", elements);
-                                }
-                            }
-                            println!("}}");
-                        }
-                        println!();
-                    }
-                    TraceCompression::No => {
-                        let states = match trace {
-                            Trace::Trace(states) => states,
-                            Trace::CompressedTrace(..) => unreachable!(),
-                        };
-                        for (i, state) in states.iter().enumerate() {
-                            println!("state {}:", i);
-                            for r in &module.signature.relations {
-                                let relation = &r.name;
-                                print!("{}: {{", relation);
-                                for ((r, elements), i) in indices.0.iter().sorted() {
-                                    if r == relation && state.0[*i] {
-                                        print!("{:?}, ", elements);
-                                    }
-                                }
-                                println!("}}");
-                            }
-                            println!();
-                        }
-                    }
+) -> Result<CheckerAnswer, TranslationError> {
+    let (program, indices) = translate(module, universe)?;
+    match interpret(&program, depth, compress_traces, print_timing) {
+        InterpreterResult::Unknown => Ok(CheckerAnswer::Unknown),
+        InterpreterResult::Convergence => Ok(CheckerAnswer::Convergence),
+        InterpreterResult::Counterexample(trace) => {
+            let u = module.signature.sorts.iter().map(|s| universe[s]).collect();
+            let models = match compress_traces {
+                TraceCompression::Yes => {
+                    let (state, depth) = match trace {
+                        Trace::Trace(..) => unreachable!(),
+                        Trace::CompressedTrace(state, depth) => (state, depth),
+                    };
+                    println!("counterexample is at depth {}, not 0", depth);
+                    vec![Model::new(
+                        &module.signature,
+                        &u,
+                        module
+                            .signature
+                            .relations
+                            .iter()
+                            .map(|r| {
+                                let shape = r
+                                    .args
+                                    .iter()
+                                    .map(|s| cardinality(universe, s))
+                                    .chain([2])
+                                    .collect();
+                                Interpretation::new(&shape, |elements| {
+                                    state.0[indices
+                                        [&(r.name.as_str(), Elements::new(elements.to_vec()))]]
+                                        as usize
+                                })
+                            })
+                            .collect(),
+                    )]
                 }
-                Some(CheckerAnswer::Counterexample)
-            }
-        },
+                TraceCompression::No => {
+                    let states = match trace {
+                        Trace::Trace(states) => states,
+                        Trace::CompressedTrace(..) => unreachable!(),
+                    };
+                    states
+                        .into_iter()
+                        .map(|state| {
+                            Model::new(
+                                &module.signature,
+                                &u,
+                                module
+                                    .signature
+                                    .relations
+                                    .iter()
+                                    .map(|r| {
+                                        let shape = r
+                                            .args
+                                            .iter()
+                                            .map(|s| cardinality(universe, s))
+                                            .chain([2])
+                                            .collect();
+                                        Interpretation::new(&shape, |elements| {
+                                            state.0[indices[&(
+                                                r.name.as_str(),
+                                                Elements::new(elements.to_vec()),
+                                            )]] as usize
+                                        })
+                                    })
+                                    .collect(),
+                            )
+                        })
+                        .collect()
+                }
+            };
+            Ok(CheckerAnswer::Counterexample(models))
+        }
     }
 }
 
@@ -187,6 +205,7 @@ impl PartialEq for BoundedState {
 }
 
 /// A map from (relation name, Elements) pairs to their index in the [BoundedState] bit vector.
+#[derive(Debug, PartialEq)]
 struct Indices<'a>(HashMap<(&'a str, Elements), usize>);
 
 impl Indices<'_> {
@@ -433,6 +452,8 @@ pub enum InterpreterResult {
     Counterexample(Trace),
     /// The checker could not find any counterexamples
     Unknown,
+    /// The checker found that the set of states stopped changing
+    Convergence,
 }
 
 /// Explore reachable states of a BoundedProgram up to (and including) the given max_depth using
@@ -442,8 +463,7 @@ pub enum InterpreterResult {
 /// so if max_depth is Some(3), it means there will be 3 transitions (so 4 states).
 /// If max_depth is None, it means "no upper bound". The program will run until its
 /// state space is exhausted or the process is killed.
-#[allow(dead_code)]
-pub fn interpret(
+fn interpret(
     program: &BoundedProgram,
     max_depth: Option<usize>,
     compress_traces: TraceCompression,
@@ -523,7 +543,11 @@ pub fn interpret(
         }
     }
 
-    InterpreterResult::Unknown
+    if max_depth.map(|md| current_depth < md).unwrap_or(true) {
+        InterpreterResult::Convergence
+    } else {
+        InterpreterResult::Unknown
+    }
 }
 
 #[allow(missing_docs)]
@@ -562,10 +586,10 @@ type UniverseBounds = std::collections::HashMap<String, usize>;
 /// Universe should contain the sizes of all the sorts in module.signature.sorts.
 /// The module is assumed to have already been typechecked.
 /// The translator ignores proof blocks.
-pub fn translate(
-    module: &Module,
+fn translate<'a>(
+    module: &'a Module,
     universe: &UniverseBounds,
-) -> Result<BoundedProgram, TranslationError> {
+) -> Result<(BoundedProgram, Indices<'a>), TranslationError> {
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
             todo!("non-bool relations")
@@ -771,7 +795,7 @@ pub fn translate(
         }
     }
 
-    Ok(BoundedProgram { inits, trs, safes })
+    Ok((BoundedProgram { inits, trs, safes }, indices))
 }
 
 fn nullary_id_to_app(term: Term, relations: &[RelationDecl]) -> Term {
@@ -1464,7 +1488,7 @@ mod tests {
             ],
         };
 
-        let target = translate(&m, &universe)?;
+        let (target, _) = translate(&m, &universe)?;
         assert_eq!(target.inits, expected.inits);
         assert_eq!(target.safes, expected.safes);
         assert_eq!(
@@ -1473,7 +1497,7 @@ mod tests {
         );
 
         let output = interpret(&target, None, TraceCompression::No, false);
-        assert_eq!(output, InterpreterResult::Unknown);
+        assert_eq!(output, InterpreterResult::Convergence);
 
         Ok(())
     }
@@ -1485,7 +1509,7 @@ mod tests {
         let mut m = fly::parser::parse(source).unwrap();
         sort_check_and_infer(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
-        let target = translate(&m, &universe)?;
+        let (target, _) = translate(&m, &universe)?;
 
         let bug = interpret(&target, Some(12), TraceCompression::No, false);
         if let InterpreterResult::Counterexample(trace) = &bug {
@@ -1511,7 +1535,7 @@ mod tests {
             ("quorum".to_string(), 2),
             ("value".to_string(), 2),
         ]);
-        let target = translate(&m, &universe)?;
+        let (target, _) = translate(&m, &universe)?;
         let output = interpret(&target, Some(10), TraceCompression::No, false);
         assert_eq!(output, InterpreterResult::Unknown);
 
@@ -1526,7 +1550,7 @@ mod tests {
         sort_check_and_infer(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
         assert_eq!(
-            Some(CheckerAnswer::Unknown),
+            Ok(CheckerAnswer::Convergence),
             check(&module, &universe, Some(10), true.into(), false)
         );
     }

--- a/bounded/src/smt.rs
+++ b/bounded/src/smt.rs
@@ -40,16 +40,14 @@ pub fn check(
         todo!("definitions are not supported yet");
     }
 
-    let DestructuredModule {
-        inits,
-        transitions,
-        axioms,
-        proofs,
-    } = extract(module).map_err(CheckerError::ExtractionError)?;
-
-    let inits: Vec<_> = inits.into_iter().chain(axioms.clone()).collect();
-    let transitions: Vec<_> = transitions.into_iter().chain(axioms).collect();
-    let safeties: Vec<_> = proofs.into_iter().map(|proof| proof.safety.x).collect();
+    let d = extract(module).map_err(CheckerError::ExtractionError)?;
+    let inits = d.inits.iter().chain(&d.axioms).cloned();
+    let transitions = d
+        .transitions
+        .iter()
+        .chain(d.mutable_axioms(&module.signature.relations))
+        .cloned();
+    let safeties = d.proofs.iter().map(|proof| proof.safety.x.clone());
 
     let next = Next::new(&module.signature);
 

--- a/bounded/src/smt.rs
+++ b/bounded/src/smt.rs
@@ -83,13 +83,6 @@ pub fn check(
         println!("search finished in {:0.1}s", search.elapsed().as_secs_f64());
     }
 
-    if let CheckerAnswer::Counterexample(ref models) = answer {
-        for (i, model) in models.iter().enumerate() {
-            println!("state {}:", i);
-            println!("{}", model.fmt());
-        }
-    }
-
     Ok(answer)
 }
 

--- a/fly/src/lib.rs
+++ b/fly/src/lib.rs
@@ -17,6 +17,7 @@ pub mod defs;
 pub mod ouritertools;
 pub mod parser;
 pub mod printer;
+pub mod rets;
 pub mod semantics;
 pub mod sorts;
 pub mod syntax;

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -143,6 +143,19 @@ fn fix_term(term: &mut Term, changed: &[RelationDecl], to_quantify: &mut Vec<ToB
     };
 
     match term {
+        Term::Id(r) => {
+            if let Some(c) = changed.iter().find(|c| r == &c.name) {
+                let name = new_id();
+                to_quantify.push(ToBeQuantified {
+                    name: name.clone(),
+                    sort: c.sort.clone(),
+                    r: r.to_string(),
+                    p: 0,
+                    xs: vec![],
+                });
+                *term = Term::Id(name);
+            }
+        }
         Term::App(r, p, xs) => {
             xs.iter_mut()
                 .for_each(|x| fix_term(x, changed, to_quantify));
@@ -188,7 +201,7 @@ fn fix_term(term: &mut Term, changed: &[RelationDecl], to_quantify: &mut Vec<ToB
             fix_term(body, changed, to_quantify);
             quantify(body, to_quantify);
         }
-        Term::Literal(_) | Term::Id(_) => {}
+        Term::Literal(_) => {}
     }
 }
 

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -4,7 +4,6 @@
 //! Utility to convert all non-boolean-returning relations in a Module to boolean-returning ones.
 
 use crate::syntax::*;
-use crate::term::prime::Next;
 
 impl Module {
     /// Converts all non-boolean-returning relations to boolean-returning ones
@@ -84,10 +83,7 @@ impl Module {
 
         let mut to_quantify = vec![];
         let mut name = 0;
-        let mut go = |term: &mut Term| {
-            *term = Next::new(&self.signature).normalize(term);
-            fix_term(term, &changed, &mut to_quantify, &mut name);
-        };
+        let mut go = |term: &mut Term| fix_term(term, &changed, &mut to_quantify, &mut name);
         for statement in &mut self.statements {
             match statement {
                 ThmStmt::Assume(term) => go(term),

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -3,23 +3,12 @@
 
 //! Utility to convert all non-boolean-returning relations in a Module to boolean-returning ones.
 
-use crate::semantics::Model;
 use crate::syntax::*;
 
 impl Module {
     /// Converts all non-boolean-returning relations to boolean-returning ones
     /// by adding an extra argument and axioms.
-    /// Returns a closure that can take a Model in the new Module and back-convert it to
-    /// a Model in the old Module.
-    pub fn convert_non_bool_relations(&mut self) -> Box<dyn Fn(&Model) -> Model> {
-        let old_relations: Vec<RelationDecl> = self
-            .signature
-            .relations
-            .iter()
-            .filter(|r| r.sort != Sort::Bool)
-            .cloned()
-            .collect();
-
+    pub fn convert_non_bool_relations(&mut self) {
         let mut axioms = vec![];
         for relation in &mut self.signature.relations {
             if relation.sort != Sort::Bool {
@@ -78,13 +67,7 @@ impl Module {
             }
         }
         self.statements.splice(0..0, axioms);
-
-        Box::new(move |model| back_convert_model(model, old_relations.clone()))
     }
-}
-
-fn back_convert_model(_model: &Model, _old_changed_relations: Vec<RelationDecl>) -> Model {
-    todo!()
 }
 
 #[cfg(test)]
@@ -92,7 +75,7 @@ mod tests {
     use crate::parser::parse;
 
     #[test]
-    fn non_bool_relations_conversion() {
+    fn non_bool_relations_module_conversion() {
         let source1 = "
 sort s
 mutable f(sort, bool): sort
@@ -107,7 +90,7 @@ assume always forall __0:sort, __1: bool. forall __2:sort, __3:sort.
         ";
 
         let mut module1 = parse(source1).unwrap();
-        let _back_convert_model = module1.convert_non_bool_relations();
+        module1.convert_non_bool_relations();
 
         let module2 = parse(source2).unwrap();
 

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -171,10 +171,7 @@ fn fix_term(term: &mut Term, changed: &[RelationDecl], to_quantify: &mut Vec<ToB
                 *term = Term::Id(name);
             }
         }
-        Term::UnaryOp(
-            UOp::Prime | UOp::Always | UOp::Eventually | UOp::Next | UOp::Previously,
-            a,
-        ) => {
+        Term::UnaryOp(UOp::Always | UOp::Eventually, a) => {
             fix_term(a, changed, to_quantify);
             quantify(a, to_quantify);
         }
@@ -215,7 +212,7 @@ mod tests {
 sort s
 mutable f(sort, bool): sort
 
-assume always forall s:sort. f(s, true) = s
+assume always forall s:sort. (f(s, true))' = s
         ";
         let source2 = "
 sort s
@@ -225,7 +222,7 @@ assume always forall __0:sort, __1: bool. exists __2:sort. f(__0, __1, __2)
 assume always forall __0:sort, __1: bool. forall __2:sort, __3:sort.
     (f(__0, __1, __2) & f(__0, __1, __3)) -> (__2 = __3)
 
-assume always forall s:sort. exists ___1:sort. f(s, true, ___1) & ___1 = s
+assume always forall s:sort. exists ___1:sort. f(s, true, ___1) & ___1' = s
         ";
 
         let mut module1 = parse(source1).unwrap();

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -32,34 +32,40 @@ impl Module {
                 *all_args_new_alt.last_mut().unwrap() =
                     Term::Id(binders.last().unwrap().name.clone());
 
+                let at_least_one = Term::exists(
+                    [binders[relation.args.len()].clone()],
+                    Term::App(relation.name.clone(), 0, all_args_new.clone()),
+                );
+                let at_most_one = Term::forall(
+                    new_arg_twice.iter().cloned(),
+                    Term::implies(
+                        Term::and([
+                            Term::App(relation.name.clone(), 0, all_args_new),
+                            Term::App(relation.name.clone(), 0, all_args_new_alt),
+                        ]),
+                        Term::equals(
+                            Term::Id(new_arg_twice[0].name.clone()),
+                            Term::Id(new_arg_twice[1].name.clone()),
+                        ),
+                    ),
+                );
+
+                let at_least_one = match relation.args.len() {
+                    0 => at_least_one,
+                    _ => Term::forall(other_args.iter().cloned(), at_least_one),
+                };
+                let at_most_one = match relation.args.len() {
+                    0 => at_most_one,
+                    _ => Term::forall(other_args.iter().cloned(), at_most_one),
+                };
+
                 axioms.push(ThmStmt::Assume(Term::UnaryOp(
                     UOp::Always,
-                    Box::new(Term::forall(
-                        other_args.iter().cloned(),
-                        Term::exists(
-                            [binders[relation.args.len()].clone()],
-                            Term::App(relation.name.clone(), 0, all_args_new.clone()),
-                        ),
-                    )),
+                    Box::new(at_least_one),
                 )));
                 axioms.push(ThmStmt::Assume(Term::UnaryOp(
                     UOp::Always,
-                    Box::new(Term::forall(
-                        other_args.iter().cloned(),
-                        Term::forall(
-                            new_arg_twice.iter().cloned(),
-                            Term::implies(
-                                Term::and([
-                                    Term::App(relation.name.clone(), 0, all_args_new),
-                                    Term::App(relation.name.clone(), 0, all_args_new_alt),
-                                ]),
-                                Term::equals(
-                                    Term::Id(new_arg_twice[0].name.clone()),
-                                    Term::Id(new_arg_twice[1].name.clone()),
-                                ),
-                            ),
-                        ),
-                    )),
+                    Box::new(at_most_one),
                 )));
 
                 relation.args.push(relation.sort.clone());

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -122,7 +122,7 @@ fn fix_term(
         if !to_quantify.is_empty() {
             let mut binders = vec![];
             let mut clauses = vec![term.clone()];
-            for mut tbq in to_quantify.drain(..) {
+            for mut tbq in to_quantify.drain(..).rev() {
                 tbq.xs.push(Term::Id(tbq.name.clone()));
                 binders.insert(
                     0,

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -1,0 +1,116 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+//! Utility to convert all non-boolean-returning relations in a Module to boolean-returning ones.
+
+use crate::semantics::Model;
+use crate::syntax::*;
+
+impl Module {
+    /// Converts all non-boolean-returning relations to boolean-returning ones
+    /// by adding an extra argument and axioms.
+    /// Returns a closure that can take a Model in the new Module and back-convert it to
+    /// a Model in the old Module.
+    pub fn convert_non_bool_relations(&mut self) -> Box<dyn Fn(&Model) -> Model> {
+        let old_relations: Vec<RelationDecl> = self
+            .signature
+            .relations
+            .iter()
+            .filter(|r| r.sort != Sort::Bool)
+            .cloned()
+            .collect();
+
+        let mut axioms = vec![];
+        for relation in &mut self.signature.relations {
+            if relation.sort != Sort::Bool {
+                let binders: Vec<Binder> = relation
+                    .args
+                    .iter()
+                    .chain([&relation.sort, &relation.sort])
+                    .enumerate()
+                    .map(|(i, sort)| Binder {
+                        sort: sort.clone(),
+                        name: format!("__{}", i),
+                    })
+                    .collect();
+                let other_args = &binders[0..relation.args.len()];
+                let new_arg_twice = &binders[relation.args.len()..];
+                let all_args_new: Vec<_> = binders[0..=relation.args.len()]
+                    .iter()
+                    .map(|b| Term::Id(b.name.clone()))
+                    .collect();
+                let mut all_args_new_alt = all_args_new.clone();
+                *all_args_new_alt.last_mut().unwrap() =
+                    Term::Id(binders.last().unwrap().name.clone());
+
+                axioms.push(ThmStmt::Assume(Term::UnaryOp(
+                    UOp::Always,
+                    Box::new(Term::forall(
+                        other_args.iter().cloned(),
+                        Term::exists(
+                            [binders[relation.args.len()].clone()],
+                            Term::App(relation.name.clone(), 0, all_args_new.clone()),
+                        ),
+                    )),
+                )));
+                axioms.push(ThmStmt::Assume(Term::UnaryOp(
+                    UOp::Always,
+                    Box::new(Term::forall(
+                        other_args.iter().cloned(),
+                        Term::forall(
+                            new_arg_twice.iter().cloned(),
+                            Term::implies(
+                                Term::and([
+                                    Term::App(relation.name.clone(), 0, all_args_new),
+                                    Term::App(relation.name.clone(), 0, all_args_new_alt),
+                                ]),
+                                Term::equals(
+                                    Term::Id(new_arg_twice[0].name.clone()),
+                                    Term::Id(new_arg_twice[1].name.clone()),
+                                ),
+                            ),
+                        ),
+                    )),
+                )));
+
+                relation.args.push(relation.sort.clone());
+                relation.sort = Sort::Bool;
+            }
+        }
+        self.statements.splice(0..0, axioms);
+
+        Box::new(move |model| back_convert_model(model, old_relations.clone()))
+    }
+}
+
+fn back_convert_model(_model: &Model, _old_changed_relations: Vec<RelationDecl>) -> Model {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::parse;
+
+    #[test]
+    fn non_bool_relations_conversion() {
+        let source1 = "
+sort s
+mutable f(sort, bool): sort
+        ";
+        let source2 = "
+sort s
+mutable f(sort, bool, sort): bool
+
+assume always forall __0:sort, __1: bool. exists __2:sort. f(__0, __1, __2)
+assume always forall __0:sort, __1: bool. forall __2:sort, __3:sort.
+    (f(__0, __1, __2) & f(__0, __1, __3)) -> (__2 = __3)
+        ";
+
+        let mut module1 = parse(source1).unwrap();
+        let _back_convert_model = module1.convert_non_bool_relations();
+
+        let module2 = parse(source2).unwrap();
+
+        assert_eq!(module1, module2);
+    }
+}

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -222,6 +222,21 @@ pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Optio
     Ok(())
 }
 
+/// Simple entry point to get the sort of a term. Does not infer any sorts.
+/// This can fail if not enough information is given, e.g. `Term::Id("x")`.
+pub fn sort_of_term(term: &Term, sorts: &HashSet<String>) -> Option<Sort> {
+    let mut context = Context {
+        sorts,
+        names: im::HashMap::new(),
+        vars: &mut UnificationTable::new(),
+    };
+
+    match context.sort_of_term(&mut term.clone()) {
+        Ok(AbstractSort::Known(sort)) => Some(sort),
+        _ => None,
+    }
+}
+
 /// Return whether every quantified variable in every term in the given fly
 /// module has a (non-empty) sort annotation.
 pub fn module_has_all_sort_annotations(module: &Module) -> bool {

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -222,21 +222,6 @@ pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Optio
     Ok(())
 }
 
-/// Simple entry point to get the sort of a term. Does not infer any sorts.
-/// This can fail if not enough information is given, e.g. `Term::Id("x")`.
-pub fn sort_of_term(term: &Term, sorts: &HashSet<String>) -> Option<Sort> {
-    let mut context = Context {
-        sorts,
-        names: im::HashMap::new(),
-        vars: &mut UnificationTable::new(),
-    };
-
-    match context.sort_of_term(&mut term.clone()) {
-        Ok(AbstractSort::Known(sort)) => Some(sort),
-        _ => None,
-    }
-}
-
 /// Return whether every quantified variable in every term in the given fly
 /// module has a (non-empty) sort annotation.
 pub fn module_has_all_sort_annotations(module: &Module) -> bool {

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -140,7 +140,7 @@ impl Term {
         } else if ts.len() == 1 {
             return ts.pop().unwrap();
         }
-        Self::NAryOp(NOp::And, ts)
+        Self::NAryOp(NOp::And, ts).flatten_nary()
     }
 
     /// Smart constructor equivalent to the Or of an iterator of terms
@@ -155,7 +155,7 @@ impl Term {
         } else if ts.len() == 1 {
             return ts.pop().unwrap();
         }
-        Self::NAryOp(NOp::Or, ts)
+        Self::NAryOp(NOp::Or, ts).flatten_nary()
     }
 
     /// Convenience function to create `lhs ==> rhs`

--- a/fly/src/transitions.rs
+++ b/fly/src/transitions.rs
@@ -155,18 +155,26 @@ pub fn extract(module: &Module) -> Result<DestructuredModule, ExtractionError> {
         }
     }
 
-    // optimization: axioms that only mention immutable relations can be treated as inits
-    let (mut immutable_axioms, axioms) = axioms
-        .into_iter()
-        .partition(|term| contains_only_immutables(term, &module.signature.relations));
-    inits.append(&mut immutable_axioms);
-
     Ok(DestructuredModule {
         inits,
         transitions,
         axioms,
         proofs,
     })
+}
+
+impl DestructuredModule {
+    /// Returns only the axioms that mention at least one mutable relation
+    // optimization: axioms that only mention immutable relations can be treated as inits
+    // by the bounded model checkers
+    pub fn mutable_axioms<'a>(
+        &'a self,
+        relations: &'a [RelationDecl],
+    ) -> impl Iterator<Item = &Term> + 'a {
+        self.axioms
+            .iter()
+            .filter(|term| !contains_only_immutables(term, relations))
+    }
 }
 
 fn contains_only_immutables(term: &Term, relations: &[RelationDecl]) -> bool {

--- a/temporal-verifier/examples/snapshots/consensus.fly.snap
+++ b/temporal-verifier/examples/snapshots/consensus.fly.snap
@@ -13,8 +13,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      member(@node_0,@quorum_0) = true
      vote_request_msg(@node_0,@node_0) = false
+     voted(@node_0) = false
+     vote_msg(@node_0,@node_0) = false
+     votes(@node_0,@node_0) = false
+     leader(@node_0) = false
+     decided(@node_0,@value_0) = false
+     
+     state 1:
+     member(@node_0,@quorum_0) = true
+     vote_request_msg(@node_0,@node_0) = true
      voted(@node_0) = false
      vote_msg(@node_0,@node_0) = false
      votes(@node_0,@node_0) = false
@@ -28,8 +38,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      member(@node_0,@quorum_0) = true
      vote_request_msg(@node_0,@node_0) = false
+     voted(@node_0) = false
+     vote_msg(@node_0,@node_0) = false
+     votes(@node_0,@node_0) = false
+     leader(@node_0) = false
+     decided(@node_0,@value_0) = false
+     
+     state 1:
+     member(@node_0,@quorum_0) = true
+     vote_request_msg(@node_0,@node_0) = true
      voted(@node_0) = false
      vote_msg(@node_0,@node_0) = false
      votes(@node_0,@node_0) = false

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -570,13 +570,34 @@ impl App {
                 compress_traces,
             } => {
                 let univ = bounded.get_universe(&m.signature);
-                bounded::set::check(
+                match bounded::set::check(
                     &m,
                     &univ,
                     bounded.depth,
                     compress_traces.into(),
                     bounded.print_timing.unwrap_or(true),
-                );
+                ) {
+                    Ok(bounded::set::CheckerAnswer::Counterexample(models)) => {
+                        println!("found counterexample:");
+                        for (i, model) in models.iter().enumerate() {
+                            println!("state {}:", i);
+                            println!("{}", model.fmt());
+                        }
+                    }
+                    Ok(bounded::set::CheckerAnswer::Unknown) => {
+                        println!(
+                            "answer: safe up to {} for given sort bounds",
+                            bounded
+                                .depth
+                                .map(|d| format!("depth {}", d))
+                                .unwrap_or("any depth".to_string())
+                        );
+                    }
+                    Ok(bounded::set::CheckerAnswer::Convergence) => {
+                        println!("answer: safe forever with given sort bounds")
+                    }
+                    Err(error) => eprintln!("{}", error),
+                }
             }
             Command::SatCheck(bounded) => {
                 let depth = match bounded.depth {

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -607,7 +607,13 @@ impl App {
                     bounded.depth,
                     bounded.print_timing.unwrap_or(true),
                 ) {
-                    Ok(bounded::bdd::CheckerAnswer::Counterexample(..)) => {}
+                    Ok(bounded::bdd::CheckerAnswer::Counterexample(models)) => {
+                        println!("found counterexample:");
+                        for (i, model) in models.iter().enumerate() {
+                            println!("\nstate {}:\n", i);
+                            println!("{}", model.fmt());
+                        }
+                    }
                     Ok(bounded::bdd::CheckerAnswer::Unknown) => {
                         println!(
                             "answer: safe up to {} for given sort bounds",

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -588,7 +588,13 @@ impl App {
                 };
                 let univ = bounded.get_universe(&m.signature);
                 match bounded::sat::check(&m, &univ, depth, bounded.print_timing.unwrap_or(true)) {
-                    Ok(bounded::sat::CheckerAnswer::Counterexample) => {}
+                    Ok(bounded::sat::CheckerAnswer::Counterexample(models)) => {
+                        println!("found counterexample:");
+                        for (i, model) in models.iter().enumerate() {
+                            println!("state {}:", i);
+                            println!("{}", model.fmt());
+                        }
+                    }
                     Ok(bounded::sat::CheckerAnswer::Unknown) => {
                         println!("answer: safe up to depth {} for given sort bounds", depth)
                     }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -569,6 +569,8 @@ impl App {
                 bounded,
                 compress_traces,
             } => {
+                m.inline_defs();
+                m.convert_non_bool_relations();
                 let univ = bounded.get_universe(&m.signature);
                 match bounded::set::check(
                     &m,
@@ -600,6 +602,8 @@ impl App {
                 }
             }
             Command::SatCheck(bounded) => {
+                m.inline_defs();
+                m.convert_non_bool_relations();
                 let depth = match bounded.depth {
                     Some(depth) => depth,
                     None => {
@@ -623,6 +627,8 @@ impl App {
                 }
             }
             Command::BddCheck { bounded, reversed } => {
+                m.inline_defs();
+                m.convert_non_bool_relations();
                 let univ = bounded.get_universe(&m.signature);
                 let check = match reversed {
                     false => bounded::bdd::check,

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -610,7 +610,7 @@ impl App {
                     Ok(bounded::bdd::CheckerAnswer::Counterexample(models)) => {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
-                            println!("\nstate {}:\n", i);
+                            println!("state {}:", i);
                             println!("{}", model.fmt());
                         }
                     }
@@ -643,7 +643,13 @@ impl App {
                     depth,
                     bounded.print_timing.unwrap_or(true),
                 ) {
-                    Ok(bounded::smt::CheckerAnswer::Counterexample(_)) => {}
+                    Ok(bounded::smt::CheckerAnswer::Counterexample(models)) => {
+                        println!("found counterexample:");
+                        for (i, model) in models.iter().enumerate() {
+                            println!("state {}:", i);
+                            println!("{}", model.fmt());
+                        }
+                    }
                     Ok(bounded::smt::CheckerAnswer::Unknown) => {
                         println!("answer: safe up to depth {} for given sort bounds", depth)
                     }

--- a/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@thread_0) = false
      q = false
      t0 = @thread_0

--- a/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@thread_0) = false
      q = false
      t0 = @thread_0

--- a/temporal-verifier/tests/examples/snapshots/fail/basic.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/basic.fly.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@thread_0) = false
      q = false
      t0 = @thread_0

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = false
      lock_msg(@node_1) = true
      grant_msg(@node_0) = false
@@ -22,6 +23,17 @@ error: invariant is not inductive
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = true
+     grant_msg(@node_0) = false
+     grant_msg(@node_1) = false
+     unlock_msg(@node_0) = true
+     unlock_msg(@node_1) = true
+     holds_lock(@node_0) = true
+     holds_lock(@node_1) = true
+     server_holds_lock = true
 
 error: invariant is not inductive
    ┌─ tests/examples/fail/lockserver_bug.fly:26:5
@@ -30,10 +42,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = false
      unlock_msg(@node_0) = true
      holds_lock(@node_0) = true
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = true
+     server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = false
      lock_msg(@node_1) = false
      grant_msg(@node_0) = true
@@ -22,6 +23,17 @@ error: invariant is not inductive
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = false
+     grant_msg(@node_0) = true
+     grant_msg(@node_1) = false
+     unlock_msg(@node_0) = true
+     unlock_msg(@node_1) = true
+     holds_lock(@node_0) = true
+     holds_lock(@node_1) = true
+     server_holds_lock = true
 
 error: invariant is not inductive
    ┌─ tests/examples/fail/lockserver_bug.fly:26:5
@@ -30,10 +42,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = true
      unlock_msg(@node_0) = true
      holds_lock(@node_0) = true
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = true
+     server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
@@ -14,23 +14,23 @@ error: invariant is not inductive
    │
    = counter example:
      state 0:
-     lock_msg(@node_0) = true
-     lock_msg(@node_1) = true
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = false
      grant_msg(@node_0) = true
      grant_msg(@node_1) = true
-     unlock_msg(@node_0) = true
-     unlock_msg(@node_1) = true
+     unlock_msg(@node_0) = false
+     unlock_msg(@node_1) = false
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
      
      state 1:
-     lock_msg(@node_0) = true
-     lock_msg(@node_1) = true
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = false
      grant_msg(@node_0) = true
      grant_msg(@node_1) = false
-     unlock_msg(@node_0) = true
-     unlock_msg(@node_1) = true
+     unlock_msg(@node_0) = false
+     unlock_msg(@node_1) = false
      holds_lock(@node_0) = true
      holds_lock(@node_1) = true
      server_holds_lock = true
@@ -45,15 +45,15 @@ error: invariant is not inductive
      state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = true
-     unlock_msg(@node_0) = false
-     holds_lock(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = false
      server_holds_lock = true
      
      state 1:
      lock_msg(@node_0) = false
      grant_msg(@node_0) = true
-     unlock_msg(@node_0) = false
-     holds_lock(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = false
      server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
@@ -13,6 +13,7 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      lock_msg(@node_1) = true
      grant_msg(@node_0) = true
@@ -22,6 +23,17 @@ error: invariant is not inductive
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = true
+     lock_msg(@node_1) = true
+     grant_msg(@node_0) = true
+     grant_msg(@node_1) = false
+     unlock_msg(@node_0) = true
+     unlock_msg(@node_1) = true
+     holds_lock(@node_0) = true
+     holds_lock(@node_1) = true
+     server_holds_lock = true
 
 error: invariant is not inductive
    ┌─ tests/examples/fail/lockserver_bug.fly:26:5
@@ -30,10 +42,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = true
      unlock_msg(@node_0) = false
      holds_lock(@node_0) = true
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = false
+     holds_lock(@node_0) = true
+     server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true

--- a/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true

--- a/temporal-verifier/tests/examples/snapshots/fail/relations.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/relations.fly.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc4.snap
@@ -13,7 +13,12 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
+     q = true
+     
+     state 1:
+     p = true
      q = true
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc5.snap
@@ -13,7 +13,12 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
+     q = true
+     
+     state 1:
+     p = true
      q = true
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.z3.snap
@@ -13,7 +13,12 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
+     q = true
+     
+     state 1:
+     p = true
      q = true
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = true
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = true
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = true
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc4.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
+     z = false
+     
+     state 1:
+     x = true
+     y = false
      z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc5.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
+     z = false
+     
+     state 1:
+     x = true
+     y = false
      z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.z3.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
+     z = false
+     
+     state 1:
+     x = true
+     y = false
      z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc4.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
      z = true
+     
+     state 1:
+     x = true
+     y = true
+     z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc5.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
      z = true
+     
+     state 1:
+     x = true
+     y = true
+     z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.z3.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
      z = true
+     
+     state 1:
+     x = true
+     y = true
+     z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/sorts/sort_inference_but_still_wrong.fly.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/sorts/sort_inference_but_still_wrong.fly.snap
@@ -13,5 +13,6 @@ error: init does not imply invariant
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = counter example:
+    state 0:
 
 

--- a/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.1.snap
+++ b/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.1.snap
@@ -5,153 +5,321 @@ expression: combined_stdout_stderr
 ---
 starting translation...
 starting search...
-found counterexample!
+found counterexample:
 state 0:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {}
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 1:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 2:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 3:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 4:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 5:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 6:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {[], }
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 7:
-grant_msg: {[1], }
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {}
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = true
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 8:
-grant_msg: {}
-holds_lock: {[1], }
-lock_msg: {[0], }
-server_holds_lock: {}
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 9:
-grant_msg: {}
-holds_lock: {[1], }
-lock_msg: {[0], }
-server_holds_lock: {}
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 10:
-grant_msg: {}
-holds_lock: {[1], }
-lock_msg: {[0], [1], }
-server_holds_lock: {}
-unlock_msg: {}
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 11:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {}
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 12:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], [2], }
-server_holds_lock: {}
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 13:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], [2], }
-server_holds_lock: {[], }
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 14:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], [2], }
-server_holds_lock: {[], }
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 15:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], [2], }
-server_holds_lock: {[], }
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 16:
-grant_msg: {[2], }
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {}
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = true
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 17:
-grant_msg: {[2], }
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {[], }
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = true
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 18:
-grant_msg: {}
-holds_lock: {[2], }
-lock_msg: {[0], [1], }
-server_holds_lock: {[], }
-unlock_msg: {[1], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = true
+server_holds_lock = true
 
 state 19:
-grant_msg: {[0], }
-holds_lock: {[2], }
-lock_msg: {[1], }
-server_holds_lock: {}
-unlock_msg: {[1], }
+lock_msg(@node_0) = false
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = true
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = true
+server_holds_lock = false
 
 state 20:
-grant_msg: {}
-holds_lock: {[0], [2], }
-lock_msg: {[1], }
-server_holds_lock: {}
-unlock_msg: {[1], }
+lock_msg(@node_0) = false
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = true
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = true
+holds_lock(@node_1) = false
+holds_lock(@node_2) = true
+server_holds_lock = false
 
 
 ======== STDERR: ===========

--- a/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.2.snap
+++ b/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.2.snap
@@ -16,97 +16,201 @@ considering new depth: 9. queue length is 92. seen 251 unique states.
 considering new depth: 10. queue length is 110. seen 362 unique states.
 considering new depth: 11. queue length is 125. seen 488 unique states.
 considering new depth: 12. queue length is 200. seen 689 unique states.
-found counterexample!
+found counterexample:
 state 0:
-lock_msg: {}
-grant_msg: {}
-unlock_msg: {}
-holds_lock: {}
-server_holds_lock: {[], }
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 1:
-lock_msg: {[0], }
-grant_msg: {}
-unlock_msg: {}
-holds_lock: {}
-server_holds_lock: {[], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 2:
-lock_msg: {[0], [1], }
-grant_msg: {}
-unlock_msg: {}
-holds_lock: {}
-server_holds_lock: {[], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 3:
-lock_msg: {[0], [1], [2], }
-grant_msg: {}
-unlock_msg: {}
-holds_lock: {}
-server_holds_lock: {[], }
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 4:
-lock_msg: {[1], [2], }
-grant_msg: {[0], }
-unlock_msg: {}
-holds_lock: {}
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = true
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 5:
-lock_msg: {[1], [2], }
-grant_msg: {}
-unlock_msg: {}
-holds_lock: {[0], }
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = true
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 6:
-lock_msg: {[1], [2], }
-grant_msg: {}
-unlock_msg: {[0], }
-holds_lock: {}
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 7:
-lock_msg: {[1], [2], }
-grant_msg: {}
-unlock_msg: {[0], }
-holds_lock: {}
-server_holds_lock: {[], }
+lock_msg(@node_0) = false
+lock_msg(@node_1) = true
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 8:
-lock_msg: {[2], }
-grant_msg: {[1], }
-unlock_msg: {[0], }
-holds_lock: {}
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = true
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 9:
-lock_msg: {[2], }
-grant_msg: {[1], }
-unlock_msg: {[0], }
-holds_lock: {}
-server_holds_lock: {[], }
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = true
+grant_msg(@node_0) = false
+grant_msg(@node_1) = true
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
 
 state 10:
-lock_msg: {}
-grant_msg: {[1], [2], }
-unlock_msg: {[0], }
-holds_lock: {}
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = true
+grant_msg(@node_2) = true
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 11:
-lock_msg: {}
-grant_msg: {[2], }
-unlock_msg: {[0], }
-holds_lock: {[1], }
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = true
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 state 12:
-lock_msg: {}
-grant_msg: {}
-unlock_msg: {[0], }
-holds_lock: {[1], [2], }
-server_holds_lock: {}
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = true
+server_holds_lock = false
 
 
 ======== STDERR: ===========

--- a/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.snap
+++ b/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.snap
@@ -5,97 +5,227 @@ expression: combined_stdout_stderr
 ---
 starting translation...
 starting search...
-found counterexample!
+found counterexample:
+
 state 0:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {}
-server_holds_lock: {[], }
-unlock_msg: {}
+
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
+
 
 state 1:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {}
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
+
 
 state 2:
-grant_msg: {[0], }
-holds_lock: {}
-lock_msg: {}
-server_holds_lock: {}
-unlock_msg: {}
+
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = true
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 3:
-grant_msg: {[0], }
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {}
-unlock_msg: {}
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = true
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 4:
-grant_msg: {[0], }
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {}
-unlock_msg: {}
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = true
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 5:
-grant_msg: {}
-holds_lock: {[0], }
-lock_msg: {[0], [1], }
-server_holds_lock: {}
-unlock_msg: {}
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = false
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = true
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 6:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {}
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 7:
-grant_msg: {}
-holds_lock: {}
-lock_msg: {[0], [1], }
-server_holds_lock: {[], }
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = true
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
+
 
 state 8:
-grant_msg: {[1], }
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {}
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = true
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 9:
-grant_msg: {[1], }
-holds_lock: {}
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = true
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = false
+holds_lock(@node_2) = false
+server_holds_lock = true
+
 
 state 10:
-grant_msg: {}
-holds_lock: {[1], }
-lock_msg: {[0], }
-server_holds_lock: {[], }
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = true
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = true
+
 
 state 11:
-grant_msg: {[0], }
-holds_lock: {[1], }
-lock_msg: {}
-server_holds_lock: {}
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = true
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = false
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = false
+
 
 state 12:
-grant_msg: {}
-holds_lock: {[0], [1], }
-lock_msg: {}
-server_holds_lock: {}
-unlock_msg: {[0], }
+
+lock_msg(@node_0) = false
+lock_msg(@node_1) = false
+lock_msg(@node_2) = false
+grant_msg(@node_0) = false
+grant_msg(@node_1) = false
+grant_msg(@node_2) = false
+unlock_msg(@node_0) = true
+unlock_msg(@node_1) = false
+unlock_msg(@node_2) = false
+holds_lock(@node_0) = true
+holds_lock(@node_1) = true
+holds_lock(@node_2) = false
+server_holds_lock = false
 
 
 ======== STDERR: ===========

--- a/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.snap
+++ b/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.snap
@@ -6,9 +6,7 @@ expression: combined_stdout_stderr
 starting translation...
 starting search...
 found counterexample:
-
 state 0:
-
 lock_msg(@node_0) = false
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -22,10 +20,8 @@ holds_lock(@node_0) = false
 holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = true
-
 
 state 1:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -40,9 +36,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = true
 
-
 state 2:
-
 lock_msg(@node_0) = false
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -57,9 +51,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = false
 
-
 state 3:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -74,9 +66,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = false
 
-
 state 4:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = true
 lock_msg(@node_2) = false
@@ -91,9 +81,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = false
 
-
 state 5:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = true
 lock_msg(@node_2) = false
@@ -108,9 +96,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = false
 
-
 state 6:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = true
 lock_msg(@node_2) = false
@@ -124,10 +110,8 @@ holds_lock(@node_0) = false
 holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = false
-
 
 state 7:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = true
 lock_msg(@node_2) = false
@@ -142,9 +126,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = true
 
-
 state 8:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -159,9 +141,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = false
 
-
 state 9:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -176,9 +156,7 @@ holds_lock(@node_1) = false
 holds_lock(@node_2) = false
 server_holds_lock = true
 
-
 state 10:
-
 lock_msg(@node_0) = true
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -193,9 +171,7 @@ holds_lock(@node_1) = true
 holds_lock(@node_2) = false
 server_holds_lock = true
 
-
 state 11:
-
 lock_msg(@node_0) = false
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false
@@ -210,9 +186,7 @@ holds_lock(@node_1) = true
 holds_lock(@node_2) = false
 server_holds_lock = false
 
-
 state 12:
-
 lock_msg(@node_0) = false
 lock_msg(@node_1) = false
 lock_msg(@node_2) = false

--- a/verify/src/error.rs
+++ b/verify/src/error.rs
@@ -54,8 +54,9 @@ impl AssertionFailure {
             .with_labels(vec![Label::primary(file_id, self.loc.start..self.loc.end)])
             .with_notes(vec![match &self.error {
                 QueryError::Sat(models) => {
-                    let mut message = "counter example:\n".to_string();
-                    for model in models {
+                    let mut message = "counter example:".to_string();
+                    for (i, model) in models.iter().enumerate() {
+                        message.push_str(&format!("\nstate {}:\n", i));
                         message.push_str(&model.fmt());
                     }
                     message

--- a/verify/src/error.rs
+++ b/verify/src/error.rs
@@ -25,7 +25,7 @@ pub enum FailureType {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum QueryError {
     /// The solver returned Sat
-    Sat(Model),
+    Sat(Vec<Model>),
     /// The solver returned Unknown
     Unknown(String),
 }
@@ -53,7 +53,13 @@ impl AssertionFailure {
             .with_message(msg)
             .with_labels(vec![Label::primary(file_id, self.loc.start..self.loc.end)])
             .with_notes(vec![match &self.error {
-                QueryError::Sat(model) => format!("counter example:\n{}", model.fmt()),
+                QueryError::Sat(models) => {
+                    let mut message = "counter example:\n".to_string();
+                    for model in models {
+                        message.push_str(&model.fmt());
+                    }
+                    message
+                }
                 QueryError::Unknown(err) => format!("smt solver returned unknown: {err}"),
             }])
     }

--- a/verify/src/module.rs
+++ b/verify/src/module.rs
@@ -25,9 +25,7 @@ fn verify_term<B: Backend>(solver: &mut Solver<B>, t: Term) -> Result<(), QueryE
             let states = solver
                 .get_minimal_model()
                 .expect("solver error while minimizing");
-            // TODO: need a way to report traces rather than just single models
-            let s0 = states.into_iter().next().unwrap();
-            Err(QueryError::Sat(s0))
+            Err(QueryError::Sat(states))
         }
         SatResp::Unsat => Ok(()),
         SatResp::Unknown(m) => Err(QueryError::Unknown(m)),

--- a/verify/src/snapshots/verify__module__tests__verify_failing2.snap
+++ b/verify/src/snapshots/verify__module__tests__verify_failing2.snap
@@ -9,38 +9,38 @@ fails:
     reason: InitInv
     error:
       Sat:
-        signature:
-          sorts:
-            - thread
-          relations:
-            - mutable: false
-              name: p
-              args:
-                - Id: thread
-              sort: Bool
-            - mutable: false
-              name: q
-              args: []
-              sort: Bool
-            - mutable: false
-              name: t0
-              args: []
-              sort:
-                Id: thread
-        universe:
-          - 1
-        interp:
-          - shape:
-              - 1
-              - 2
-            data:
-              - 0
-          - shape:
-              - 2
-            data:
-              - 0
-          - shape:
-              - 1
-            data:
-              - 0
+        - signature:
+            sorts:
+              - thread
+            relations:
+              - mutable: false
+                name: p
+                args:
+                  - Id: thread
+                sort: Bool
+              - mutable: false
+                name: q
+                args: []
+                sort: Bool
+              - mutable: false
+                name: t0
+                args: []
+                sort:
+                  Id: thread
+          universe:
+            - 1
+          interp:
+            - shape:
+                - 1
+                - 2
+              data:
+                - 0
+            - shape:
+                - 2
+              data:
+                - 0
+            - shape:
+                - 1
+              data:
+                - 0
 

--- a/verify/src/snapshots/verify__module__tests__verify_safety1_fail.snap
+++ b/verify/src/snapshots/verify__module__tests__verify_safety1_fail.snap
@@ -9,25 +9,46 @@ fails:
     reason: NotInductive
     error:
       Sat:
-        signature:
-          sorts: []
-          relations:
-            - mutable: true
-              name: p
-              args: []
-              sort: Bool
-            - mutable: true
-              name: q
-              args: []
-              sort: Bool
-        universe: []
-        interp:
-          - shape:
-              - 2
-            data:
-              - 0
-          - shape:
-              - 2
-            data:
-              - 1
+        - signature:
+            sorts: []
+            relations:
+              - mutable: true
+                name: p
+                args: []
+                sort: Bool
+              - mutable: true
+                name: q
+                args: []
+                sort: Bool
+          universe: []
+          interp:
+            - shape:
+                - 2
+              data:
+                - 0
+            - shape:
+                - 2
+              data:
+                - 1
+        - signature:
+            sorts: []
+            relations:
+              - mutable: true
+                name: p
+                args: []
+                sort: Bool
+              - mutable: true
+                name: q
+                args: []
+                sort: Bool
+          universe: []
+          interp:
+            - shape:
+                - 2
+              data:
+                - 1
+            - shape:
+                - 2
+              data:
+                - 1
 


### PR DESCRIPTION
This PR makes a number of small improvements, mostly to the bounded model checkers.
- The BDD checker can now be run backwards, starting with the unsafe states and taking reverse steps to try and reach an initial state.
- All checkers can now translate boolean bound variables that aren't inside an App, which was previously an oversight.
- A new file to do a source-to-source translation to eliminate non-boolean-returning relations was added. This file probably needs more tests, as well as a better name (right now it's in `rets.rs` to align with `defs.rs`). This function should also return a closure that can back-translate `Model`s from the new `Module` into the original.
- The code paths that call the checkers have been updated to inline definitions and to eliminate non-bool-returning relations. The `todo`s inside the checkers were changed to `panic`s to match.
- The transition system extraction was improved by treating axioms that only mention immutable relations as initial conditions. This is an optimization for the bounded model checkers, since they only have to consider the init formula once as opposed to the transition relation.
- SMT queries that fail now return all states in time, instead of only keeping the first one for no reason. (Well, no reason in the current code, anyway.) This greatly improves debugging UX, because the user can look at what's changed between the two states. This is the change responsible for most of (all?) the `.snap` diffs.