### PR TITLE
Ignore updr-determinism test and run ignored tests in CI

### DIFF
--- a/bounded/src/smt.rs
+++ b/bounded/src/smt.rs
@@ -137,7 +137,7 @@ mod tests {
         Ok(())
     }
 
-    #[ignore] // too slow
+    #[ignore]
     #[test]
     fn checker_smt_lockserver_buggy() -> Result<(), CheckerError> {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");

--- a/temporal-verifier/tests/test_query_determinism.rs
+++ b/temporal-verifier/tests/test_query_determinism.rs
@@ -9,6 +9,7 @@ fn temporal_verifier() -> Command {
     cmd
 }
 
+#[ignore]
 #[test]
 fn updr_determinism() {
     let mut expected_output: Option<String> = None;

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -72,7 +72,8 @@ end_group
 
 start_group "cargo test"
 if [ "$ci" = true ]; then
-  cargo test --all-targets --verbose -- --nocapture --include-ignored
+  cargo test --lib --bins --tests --examples --verbose -- --nocapture --include-ignored
+  cargo test --benches --verbose -- --nocapture
 else
   cargo test --all-targets --quiet
 fi

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -75,7 +75,8 @@ if [ "$ci" = true ]; then
   cargo test --lib --bins --tests --examples --verbose -- --nocapture --include-ignored
   cargo test --benches --verbose -- --nocapture
 else
-  cargo test --all-targets --quiet
+  cargo test --lib --bins --tests --examples --quiet -- --include-ignored
+  cargo test --benches --quiet
 fi
 end_group
 

--- a/tools/ci-check.sh
+++ b/tools/ci-check.sh
@@ -72,7 +72,7 @@ end_group
 
 start_group "cargo test"
 if [ "$ci" = true ]; then
-  cargo test --all-targets --verbose -- --nocapture
+  cargo test --all-targets --verbose -- --nocapture --include-ignored
 else
   cargo test --all-targets --quiet
 fi


### PR DESCRIPTION
I think that we should save the really slow tests that are touched infrequently for CI. I believe that the best way to do this is the `#[ignore]` attribute, since we can use the `--include-ignored` flag to run them in CI.