### PR TITLE
Remove a verbose debug print

### DIFF
--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -1487,7 +1487,6 @@ mod tests {
 
         let bug = interpret(&target, Some(12), TraceCompression::No, false);
         if let InterpreterResult::Counterexample(trace) = &bug {
-            println!("{:#?}", trace);
             assert_eq!(trace.depth(), 12);
         } else {
             assert!(matches!(bug, InterpreterResult::Counterexample(_)));


### PR DESCRIPTION
This makes it hard to read the CI test output (which also has a lot of other extraneous output, but this is the worst offender).