### PR TITLE
Disable macOS runs in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
           - nightly
         os:
           - ubuntu-latest
-          - macos-latest
+          # disabled since we aren't typically making OS-specific changes
+          # - macos-latest
       fail-fast: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I think this is kind of a waste of resources since only `download-solvers.sh` does anything macOS specific. We can revisit this if that changes.