### PR TITLE
Verify return all states

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -235,7 +235,7 @@ pub fn check<'a>(
     let mut trace = vec![init.clone()];
 
     let mut current = init;
-    let mut reachable = current.clone();
+    let mut reachable = context.mk_bool(false);
 
     if let Some(valuation) = current.and(&not_safe).sat_witness() {
         context.print_counterexample(&valuation, &trace, &tr);

--- a/temporal-verifier/examples/snapshots/consensus.fly.snap
+++ b/temporal-verifier/examples/snapshots/consensus.fly.snap
@@ -13,8 +13,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      member(@node_0,@quorum_0) = true
      vote_request_msg(@node_0,@node_0) = false
+     voted(@node_0) = false
+     vote_msg(@node_0,@node_0) = false
+     votes(@node_0,@node_0) = false
+     leader(@node_0) = false
+     decided(@node_0,@value_0) = false
+     
+     state 1:
+     member(@node_0,@quorum_0) = true
+     vote_request_msg(@node_0,@node_0) = true
      voted(@node_0) = false
      vote_msg(@node_0,@node_0) = false
      votes(@node_0,@node_0) = false
@@ -28,8 +38,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      member(@node_0,@quorum_0) = true
      vote_request_msg(@node_0,@node_0) = false
+     voted(@node_0) = false
+     vote_msg(@node_0,@node_0) = false
+     votes(@node_0,@node_0) = false
+     leader(@node_0) = false
+     decided(@node_0,@value_0) = false
+     
+     state 1:
+     member(@node_0,@quorum_0) = true
+     vote_request_msg(@node_0,@node_0) = true
      voted(@node_0) = false
      vote_msg(@node_0,@node_0) = false
      votes(@node_0,@node_0) = false

--- a/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@thread_0) = false
      q = false
      t0 = @thread_0

--- a/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/basic.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@thread_0) = false
      q = false
      t0 = @thread_0

--- a/temporal-verifier/tests/examples/snapshots/fail/basic.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/basic.fly.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@thread_0) = false
      q = false
      t0 = @thread_0

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = false
      lock_msg(@node_1) = true
      grant_msg(@node_0) = false
@@ -22,6 +23,17 @@ error: invariant is not inductive
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = true
+     grant_msg(@node_0) = false
+     grant_msg(@node_1) = false
+     unlock_msg(@node_0) = true
+     unlock_msg(@node_1) = true
+     holds_lock(@node_0) = true
+     holds_lock(@node_1) = true
+     server_holds_lock = true
 
 error: invariant is not inductive
    ┌─ tests/examples/fail/lockserver_bug.fly:26:5
@@ -30,10 +42,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = false
      unlock_msg(@node_0) = true
      holds_lock(@node_0) = true
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = true
+     server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = false
      lock_msg(@node_1) = false
      grant_msg(@node_0) = true
@@ -22,6 +23,17 @@ error: invariant is not inductive
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = false
+     grant_msg(@node_0) = true
+     grant_msg(@node_1) = false
+     unlock_msg(@node_0) = true
+     unlock_msg(@node_1) = true
+     holds_lock(@node_0) = true
+     holds_lock(@node_1) = true
+     server_holds_lock = true
 
 error: invariant is not inductive
    ┌─ tests/examples/fail/lockserver_bug.fly:26:5
@@ -30,10 +42,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = true
      unlock_msg(@node_0) = true
      holds_lock(@node_0) = true
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = true
+     server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
@@ -13,6 +13,7 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      lock_msg(@node_1) = true
      grant_msg(@node_0) = true
@@ -22,6 +23,17 @@ error: invariant is not inductive
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = true
+     lock_msg(@node_1) = true
+     grant_msg(@node_0) = true
+     grant_msg(@node_1) = false
+     unlock_msg(@node_0) = true
+     unlock_msg(@node_1) = true
+     holds_lock(@node_0) = true
+     holds_lock(@node_1) = true
+     server_holds_lock = true
 
 error: invariant is not inductive
    ┌─ tests/examples/fail/lockserver_bug.fly:26:5
@@ -30,10 +42,18 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = true
      unlock_msg(@node_0) = false
      holds_lock(@node_0) = true
      server_holds_lock = true
+     
+     state 1:
+     lock_msg(@node_0) = false
+     grant_msg(@node_0) = true
+     unlock_msg(@node_0) = false
+     holds_lock(@node_0) = true
+     server_holds_lock = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true

--- a/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/relations.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true

--- a/temporal-verifier/tests/examples/snapshots/fail/relations.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/relations.fly.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p(@A_0) = false
      p(@A_1) = true
      q(@A_0,@A_0) = true

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc4.snap
@@ -13,7 +13,12 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
+     q = true
+     
+     state 1:
+     p = true
      q = true
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.cvc5.snap
@@ -13,7 +13,12 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
+     q = true
+     
+     state 1:
+     p = true
      q = true
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_ind.fly.z3.snap
@@ -13,7 +13,12 @@ error: invariant is not inductive
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
+     q = true
+     
+     state 1:
+     p = true
      q = true
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = true
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = true
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_init.fly.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = true
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc4.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.cvc5.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety1_proof_invariants.fly.1.z3.snap
@@ -13,6 +13,7 @@ error: init does not imply invariant
    │ ^^^^^^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      p = false
      q = false
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc4.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
+     z = false
+     
+     state 1:
+     x = true
+     y = false
      z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.cvc5.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
+     z = false
+     
+     state 1:
+     x = true
+     y = false
      z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety2_missing_inv.fly.z3.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
+     z = false
+     
+     state 1:
+     x = true
+     y = false
      z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc4.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc4.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
      z = true
+     
+     state 1:
+     x = true
+     y = true
+     z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc5.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.cvc5.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
      z = true
+     
+     state 1:
+     x = true
+     y = true
+     z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/safety3_extra_inv.fly.1.z3.snap
@@ -13,8 +13,14 @@ error: invariant is not inductive
    │     ^^^^^^^^^^^
    │
    = counter example:
+     state 0:
      x = true
      y = true
      z = true
+     
+     state 1:
+     x = true
+     y = true
+     z = false
 
 

--- a/temporal-verifier/tests/examples/snapshots/fail/sorts/sort_inference_but_still_wrong.fly.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/sorts/sort_inference_but_still_wrong.fly.snap
@@ -13,5 +13,6 @@ error: init does not imply invariant
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = counter example:
+    state 0:
 
 

--- a/verify/src/error.rs
+++ b/verify/src/error.rs
@@ -54,8 +54,9 @@ impl AssertionFailure {
             .with_labels(vec![Label::primary(file_id, self.loc.start..self.loc.end)])
             .with_notes(vec![match &self.error {
                 QueryError::Sat(models) => {
-                    let mut message = "counter example:\n".to_string();
-                    for model in models {
+                    let mut message = "counter example:".to_string();
+                    for (i, model) in models.iter().enumerate() {
+                        message.push_str(&format!("\nstate {}:\n", i));
                         message.push_str(&model.fmt());
                     }
                     message

--- a/verify/src/error.rs
+++ b/verify/src/error.rs
@@ -25,7 +25,7 @@ pub enum FailureType {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum QueryError {
     /// The solver returned Sat
-    Sat(Model),
+    Sat(Vec<Model>),
     /// The solver returned Unknown
     Unknown(String),
 }
@@ -53,7 +53,13 @@ impl AssertionFailure {
             .with_message(msg)
             .with_labels(vec![Label::primary(file_id, self.loc.start..self.loc.end)])
             .with_notes(vec![match &self.error {
-                QueryError::Sat(model) => format!("counter example:\n{}", model.fmt()),
+                QueryError::Sat(models) => {
+                    let mut message = "counter example:\n".to_string();
+                    for model in models {
+                        message.push_str(&model.fmt());
+                    }
+                    message
+                }
                 QueryError::Unknown(err) => format!("smt solver returned unknown: {err}"),
             }])
     }

--- a/verify/src/module.rs
+++ b/verify/src/module.rs
@@ -25,9 +25,7 @@ fn verify_term<B: Backend>(solver: &mut Solver<B>, t: Term) -> Result<(), QueryE
             let states = solver
                 .get_minimal_model()
                 .expect("solver error while minimizing");
-            // TODO: need a way to report traces rather than just single models
-            let s0 = states.into_iter().next().unwrap();
-            Err(QueryError::Sat(s0))
+            Err(QueryError::Sat(states))
         }
         SatResp::Unsat => Ok(()),
         SatResp::Unknown(m) => Err(QueryError::Unknown(m)),

--- a/verify/src/snapshots/verify__module__tests__verify_failing2.snap
+++ b/verify/src/snapshots/verify__module__tests__verify_failing2.snap
@@ -9,38 +9,38 @@ fails:
     reason: InitInv
     error:
       Sat:
-        signature:
-          sorts:
-            - thread
-          relations:
-            - mutable: false
-              name: p
-              args:
-                - Id: thread
-              sort: Bool
-            - mutable: false
-              name: q
-              args: []
-              sort: Bool
-            - mutable: false
-              name: t0
-              args: []
-              sort:
-                Id: thread
-        universe:
-          - 1
-        interp:
-          - shape:
-              - 1
-              - 2
-            data:
-              - 0
-          - shape:
-              - 2
-            data:
-              - 0
-          - shape:
-              - 1
-            data:
-              - 0
+        - signature:
+            sorts:
+              - thread
+            relations:
+              - mutable: false
+                name: p
+                args:
+                  - Id: thread
+                sort: Bool
+              - mutable: false
+                name: q
+                args: []
+                sort: Bool
+              - mutable: false
+                name: t0
+                args: []
+                sort:
+                  Id: thread
+          universe:
+            - 1
+          interp:
+            - shape:
+                - 1
+                - 2
+              data:
+                - 0
+            - shape:
+                - 2
+              data:
+                - 0
+            - shape:
+                - 1
+              data:
+                - 0
 

--- a/verify/src/snapshots/verify__module__tests__verify_safety1_fail.snap
+++ b/verify/src/snapshots/verify__module__tests__verify_safety1_fail.snap
@@ -9,25 +9,46 @@ fails:
     reason: NotInductive
     error:
       Sat:
-        signature:
-          sorts: []
-          relations:
-            - mutable: true
-              name: p
-              args: []
-              sort: Bool
-            - mutable: true
-              name: q
-              args: []
-              sort: Bool
-        universe: []
-        interp:
-          - shape:
-              - 2
-            data:
-              - 0
-          - shape:
-              - 2
-            data:
-              - 1
+        - signature:
+            sorts: []
+            relations:
+              - mutable: true
+                name: p
+                args: []
+                sort: Bool
+              - mutable: true
+                name: q
+                args: []
+                sort: Bool
+          universe: []
+          interp:
+            - shape:
+                - 2
+              data:
+                - 0
+            - shape:
+                - 2
+              data:
+                - 1
+        - signature:
+            sorts: []
+            relations:
+              - mutable: true
+                name: p
+                args: []
+                sort: Bool
+              - mutable: true
+                name: q
+                args: []
+                sort: Bool
+          universe: []
+          interp:
+            - shape:
+                - 2
+              data:
+                - 1
+            - shape:
+                - 2
+              data:
+                - 1
 


### PR DESCRIPTION
Verify now returns all states instead of just the first one. This greatly improves debugging UX, because the user can look at what's changed between the two states.