### PR TITLE
Backwards bdd

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -251,6 +251,7 @@ pub fn check<'a>(
 
 /// The same as `check`, but instead of starting at `init` and going until it gets to `not_safe`,
 /// it starts at `not_safe` and goes backwards until it gets to `init`.
+/// It also returns a negated Bdd if it returns Convergence.
 pub fn check_reversed<'a>(
     module: &'a Module,
     universe: &'a Universe,

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -289,7 +289,7 @@ fn check_internal<'a>(
             init,
             Box::new(|current: &mut Bdd, context: &Context| {
                 let primed = context.mutables..context.mutables * 2;
-                for i in primed.clone().into_iter().rev() {
+                for i in primed.clone().rev() {
                     unsafe {
                         current
                             .rename_variable(context.vars[i - context.mutables], context.vars[i]);
@@ -633,6 +633,95 @@ mod tests {
         let universe = std::collections::HashMap::new();
         assert!(matches!(
             check(&module, &universe, None, false)?,
+            CheckerAnswer::Convergence(..),
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_basic_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/tests/examples/basic2.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = HashMap::from([]);
+
+        assert!(matches!(
+            check_reversed(&module, &universe, Some(0), false)?,
+            CheckerAnswer::Unknown,
+        ));
+        assert!(matches!(
+            check_reversed(&module, &universe, Some(1), false)?,
+            CheckerAnswer::Counterexample(_),
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_lockserver_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = HashMap::from([("node".to_string(), 2)]);
+
+        assert!(matches!(
+            check_reversed(&module, &universe, None, false)?,
+            CheckerAnswer::Convergence(..),
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_lockserver_buggy_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = HashMap::from([("node".to_string(), 2)]);
+
+        let bug = check_reversed(&module, &universe, Some(12), false)?;
+        assert!(matches!(bug, CheckerAnswer::Counterexample(_)));
+        let bug = check_reversed(&module, &universe, None, false)?;
+        assert!(matches!(bug, CheckerAnswer::Counterexample(_)));
+
+        let too_short = check_reversed(&module, &universe, Some(11), false)?;
+        assert!(matches!(too_short, CheckerAnswer::Unknown));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_consensus_reversed() -> Result<(), CheckerError> {
+        let source = include_str!("../../temporal-verifier/examples/consensus.fly");
+
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = std::collections::HashMap::from([
+            ("node".to_string(), 1),
+            ("quorum".to_string(), 1),
+            ("value".to_string(), 1),
+        ]);
+
+        assert!(matches!(
+            check_reversed(&module, &universe, Some(0), false)?,
+            CheckerAnswer::Unknown,
+        ));
+
+        Ok(())
+    }
+
+    #[test]
+    fn checker_bdd_immutability_reversed() -> Result<(), CheckerError> {
+        let source =
+            include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
+        let mut module = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut module).unwrap();
+        let universe = std::collections::HashMap::new();
+        assert!(matches!(
+            check_reversed(&module, &universe, None, false)?,
             CheckerAnswer::Convergence(..),
         ));
         Ok(())


### PR DESCRIPTION
The BDD checker can now be run backwards, starting with the unsafe states and taking reverse steps to try and reach an initial state.