### PR TITLE
Non bool relations

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -316,6 +316,7 @@ fn check_internal<'a>(
     let translate = |term| {
         let term = nullary_id_to_app(term, &module.signature.relations);
         let term = fly::term::prime::Next::new(&module.signature).normalize(&term);
+        println!("{}\n", term);
         term_to_bdd(&term, &context, &HashMap::new())
     };
 

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -294,12 +294,12 @@ fn check_internal<'a>(
 
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
-            todo!("non-bool relations")
+            panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions in checker (use Module::inline_defs)")
     }
 
     let d = extract(module).map_err(CheckerError::ExtractionError)?;

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -316,7 +316,6 @@ fn check_internal<'a>(
     let translate = |term| {
         let term = nullary_id_to_app(term, &module.signature.relations);
         let term = fly::term::prime::Next::new(&module.signature).normalize(&term);
-        println!("{}\n", term);
         term_to_bdd(&term, &context, &HashMap::new())
     };
 

--- a/bounded/src/sat.rs
+++ b/bounded/src/sat.rs
@@ -168,12 +168,12 @@ pub fn check(
 
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
-            todo!("non-bool relations")
+            panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions in checker (use Module::inline_defs)")
     }
 
     let d = extract(module).map_err(CheckerError::ExtractionError)?;

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -563,7 +563,7 @@ fn translate<'a>(
 ) -> Result<(BoundedProgram, Indices<'a>), TranslationError> {
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
-            todo!("non-bool relations")
+            panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
@@ -579,7 +579,7 @@ fn translate<'a>(
     }
 
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions in checker (use Module::inline_defs)")
     }
 
     let d = extract(module).map_err(TranslationError::ExtractionError)?;

--- a/bounded/src/smt.rs
+++ b/bounded/src/smt.rs
@@ -37,7 +37,7 @@ pub fn check(
     print_timing: bool,
 ) -> Result<CheckerAnswer, CheckerError> {
     if !module.defs.is_empty() {
-        todo!("definitions are not supported yet");
+        panic!("definitions are not supported yet");
     }
 
     let d = extract(module).map_err(CheckerError::ExtractionError)?;

--- a/fly/src/lib.rs
+++ b/fly/src/lib.rs
@@ -18,6 +18,7 @@ pub mod defs;
 pub mod ouritertools;
 pub mod parser;
 pub mod printer;
+pub mod rets;
 pub mod semantics;
 pub mod sorts;
 pub mod syntax;

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -143,6 +143,19 @@ fn fix_term(term: &mut Term, changed: &[RelationDecl], to_quantify: &mut Vec<ToB
     };
 
     match term {
+        Term::Id(r) => {
+            if let Some(c) = changed.iter().find(|c| r == &c.name) {
+                let name = new_id();
+                to_quantify.push(ToBeQuantified {
+                    name: name.clone(),
+                    sort: c.sort.clone(),
+                    r: r.to_string(),
+                    p: 0,
+                    xs: vec![],
+                });
+                *term = Term::Id(name);
+            }
+        }
         Term::App(r, p, xs) => {
             xs.iter_mut()
                 .for_each(|x| fix_term(x, changed, to_quantify));
@@ -188,7 +201,7 @@ fn fix_term(term: &mut Term, changed: &[RelationDecl], to_quantify: &mut Vec<ToB
             fix_term(body, changed, to_quantify);
             quantify(body, to_quantify);
         }
-        Term::Literal(_) | Term::Id(_) => {}
+        Term::Literal(_) => {}
     }
 }
 

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -4,7 +4,6 @@
 //! Utility to convert all non-boolean-returning relations in a Module to boolean-returning ones.
 
 use crate::syntax::*;
-use crate::term::prime::Next;
 
 impl Module {
     /// Converts all non-boolean-returning relations to boolean-returning ones
@@ -84,10 +83,7 @@ impl Module {
 
         let mut to_quantify = vec![];
         let mut name = 0;
-        let mut go = |term: &mut Term| {
-            *term = Next::new(&self.signature).normalize(term);
-            fix_term(term, &changed, &mut to_quantify, &mut name);
-        };
+        let mut go = |term: &mut Term| fix_term(term, &changed, &mut to_quantify, &mut name);
         for statement in &mut self.statements {
             match statement {
                 ThmStmt::Assume(term) => go(term),

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -3,23 +3,12 @@
 
 //! Utility to convert all non-boolean-returning relations in a Module to boolean-returning ones.
 
-use crate::semantics::Model;
 use crate::syntax::*;
 
 impl Module {
     /// Converts all non-boolean-returning relations to boolean-returning ones
     /// by adding an extra argument and axioms.
-    /// Returns a closure that can take a Model in the new Module and back-convert it to
-    /// a Model in the old Module.
-    pub fn convert_non_bool_relations(&mut self) -> Box<dyn Fn(&Model) -> Model> {
-        let old_relations: Vec<RelationDecl> = self
-            .signature
-            .relations
-            .iter()
-            .filter(|r| r.sort != Sort::Bool)
-            .cloned()
-            .collect();
-
+    pub fn convert_non_bool_relations(&mut self) {
         let mut axioms = vec![];
         for relation in &mut self.signature.relations {
             if relation.sort != Sort::Bool {
@@ -78,13 +67,7 @@ impl Module {
             }
         }
         self.statements.splice(0..0, axioms);
-
-        Box::new(move |model| back_convert_model(model, old_relations.clone()))
     }
-}
-
-fn back_convert_model(_model: &Model, _old_changed_relations: Vec<RelationDecl>) -> Model {
-    todo!()
 }
 
 #[cfg(test)]
@@ -92,7 +75,7 @@ mod tests {
     use crate::parser::parse;
 
     #[test]
-    fn non_bool_relations_conversion() {
+    fn non_bool_relations_module_conversion() {
         let source1 = "
 sort s
 mutable f(sort, bool): sort
@@ -107,7 +90,7 @@ assume always forall __0:sort, __1: bool. forall __2:sort, __3:sort.
         ";
 
         let mut module1 = parse(source1).unwrap();
-        let _back_convert_model = module1.convert_non_bool_relations();
+        module1.convert_non_bool_relations();
 
         let module2 = parse(source2).unwrap();
 

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -171,10 +171,7 @@ fn fix_term(term: &mut Term, changed: &[RelationDecl], to_quantify: &mut Vec<ToB
                 *term = Term::Id(name);
             }
         }
-        Term::UnaryOp(
-            UOp::Prime | UOp::Always | UOp::Eventually | UOp::Next | UOp::Previously,
-            a,
-        ) => {
+        Term::UnaryOp(UOp::Always | UOp::Eventually, a) => {
             fix_term(a, changed, to_quantify);
             quantify(a, to_quantify);
         }
@@ -215,7 +212,7 @@ mod tests {
 sort s
 mutable f(sort, bool): sort
 
-assume always forall s:sort. f(s, true) = s
+assume always forall s:sort. (f(s, true))' = s
         ";
         let source2 = "
 sort s
@@ -225,7 +222,7 @@ assume always forall __0:sort, __1: bool. exists __2:sort. f(__0, __1, __2)
 assume always forall __0:sort, __1: bool. forall __2:sort, __3:sort.
     (f(__0, __1, __2) & f(__0, __1, __3)) -> (__2 = __3)
 
-assume always forall s:sort. exists ___1:sort. f(s, true, ___1) & ___1 = s
+assume always forall s:sort. exists ___1:sort. f(s, true, ___1) & ___1' = s
         ";
 
         let mut module1 = parse(source1).unwrap();

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -277,7 +277,7 @@ sort s
 mutable f(s, bool, s): bool
 
 assume always forall __0:s, __1: bool. exists __2:s. f(__0, __1, __2)
-assume always forall __0:s, __1: bool. forall __2:s, __3:s.
+assume always forall __0:s, __1: bool, __2:s, __3:s.
     (f(__0, __1, __2) & f(__0, __1, __3)) -> (__2 = __3)
 
 assume always forall s:s. exists ___1:s. f(s, true, ___1) & ___1 = s
@@ -304,7 +304,7 @@ sort s
 mutable f(s, s): bool
 
 assume always forall __0:s. exists __1:s. f(__0, __1)
-assume always forall __0:s. forall __1:s, __2:s. (f(__0, __1) & f(__0, __2)) -> (__1 = __2)
+assume always forall __0:s, __1:s, __2:s. (f(__0, __1) & f(__0, __2)) -> (__1 = __2)
 
 assume always forall s:s. exists ___1:s. (f(s, ___1))' & ___1' = s
         ";

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -32,34 +32,40 @@ impl Module {
                 *all_args_new_alt.last_mut().unwrap() =
                     Term::Id(binders.last().unwrap().name.clone());
 
+                let at_least_one = Term::exists(
+                    [binders[relation.args.len()].clone()],
+                    Term::App(relation.name.clone(), 0, all_args_new.clone()),
+                );
+                let at_most_one = Term::forall(
+                    new_arg_twice.iter().cloned(),
+                    Term::implies(
+                        Term::and([
+                            Term::App(relation.name.clone(), 0, all_args_new),
+                            Term::App(relation.name.clone(), 0, all_args_new_alt),
+                        ]),
+                        Term::equals(
+                            Term::Id(new_arg_twice[0].name.clone()),
+                            Term::Id(new_arg_twice[1].name.clone()),
+                        ),
+                    ),
+                );
+
+                let at_least_one = match relation.args.len() {
+                    0 => at_least_one,
+                    _ => Term::forall(other_args.iter().cloned(), at_least_one),
+                };
+                let at_most_one = match relation.args.len() {
+                    0 => at_most_one,
+                    _ => Term::forall(other_args.iter().cloned(), at_most_one),
+                };
+
                 axioms.push(ThmStmt::Assume(Term::UnaryOp(
                     UOp::Always,
-                    Box::new(Term::forall(
-                        other_args.iter().cloned(),
-                        Term::exists(
-                            [binders[relation.args.len()].clone()],
-                            Term::App(relation.name.clone(), 0, all_args_new.clone()),
-                        ),
-                    )),
+                    Box::new(at_least_one),
                 )));
                 axioms.push(ThmStmt::Assume(Term::UnaryOp(
                     UOp::Always,
-                    Box::new(Term::forall(
-                        other_args.iter().cloned(),
-                        Term::forall(
-                            new_arg_twice.iter().cloned(),
-                            Term::implies(
-                                Term::and([
-                                    Term::App(relation.name.clone(), 0, all_args_new),
-                                    Term::App(relation.name.clone(), 0, all_args_new_alt),
-                                ]),
-                                Term::equals(
-                                    Term::Id(new_arg_twice[0].name.clone()),
-                                    Term::Id(new_arg_twice[1].name.clone()),
-                                ),
-                            ),
-                        ),
-                    )),
+                    Box::new(at_most_one),
                 )));
 
                 relation.args.push(relation.sort.clone());

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -122,7 +122,7 @@ fn fix_term(
         if !to_quantify.is_empty() {
             let mut binders = vec![];
             let mut clauses = vec![term.clone()];
-            for mut tbq in to_quantify.drain(..) {
+            for mut tbq in to_quantify.drain(..).rev() {
                 tbq.xs.push(Term::Id(tbq.name.clone()));
                 binders.insert(
                     0,

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -1,0 +1,116 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+//! Utility to convert all non-boolean-returning relations in a Module to boolean-returning ones.
+
+use crate::semantics::Model;
+use crate::syntax::*;
+
+impl Module {
+    /// Converts all non-boolean-returning relations to boolean-returning ones
+    /// by adding an extra argument and axioms.
+    /// Returns a closure that can take a Model in the new Module and back-convert it to
+    /// a Model in the old Module.
+    pub fn convert_non_bool_relations(&mut self) -> Box<dyn Fn(&Model) -> Model> {
+        let old_relations: Vec<RelationDecl> = self
+            .signature
+            .relations
+            .iter()
+            .filter(|r| r.sort != Sort::Bool)
+            .cloned()
+            .collect();
+
+        let mut axioms = vec![];
+        for relation in &mut self.signature.relations {
+            if relation.sort != Sort::Bool {
+                let binders: Vec<Binder> = relation
+                    .args
+                    .iter()
+                    .chain([&relation.sort, &relation.sort])
+                    .enumerate()
+                    .map(|(i, sort)| Binder {
+                        sort: sort.clone(),
+                        name: format!("__{}", i),
+                    })
+                    .collect();
+                let other_args = &binders[0..relation.args.len()];
+                let new_arg_twice = &binders[relation.args.len()..];
+                let all_args_new: Vec<_> = binders[0..=relation.args.len()]
+                    .iter()
+                    .map(|b| Term::Id(b.name.clone()))
+                    .collect();
+                let mut all_args_new_alt = all_args_new.clone();
+                *all_args_new_alt.last_mut().unwrap() =
+                    Term::Id(binders.last().unwrap().name.clone());
+
+                axioms.push(ThmStmt::Assume(Term::UnaryOp(
+                    UOp::Always,
+                    Box::new(Term::forall(
+                        other_args.iter().cloned(),
+                        Term::exists(
+                            [binders[relation.args.len()].clone()],
+                            Term::App(relation.name.clone(), 0, all_args_new.clone()),
+                        ),
+                    )),
+                )));
+                axioms.push(ThmStmt::Assume(Term::UnaryOp(
+                    UOp::Always,
+                    Box::new(Term::forall(
+                        other_args.iter().cloned(),
+                        Term::forall(
+                            new_arg_twice.iter().cloned(),
+                            Term::implies(
+                                Term::and([
+                                    Term::App(relation.name.clone(), 0, all_args_new),
+                                    Term::App(relation.name.clone(), 0, all_args_new_alt),
+                                ]),
+                                Term::equals(
+                                    Term::Id(new_arg_twice[0].name.clone()),
+                                    Term::Id(new_arg_twice[1].name.clone()),
+                                ),
+                            ),
+                        ),
+                    )),
+                )));
+
+                relation.args.push(relation.sort.clone());
+                relation.sort = Sort::Bool;
+            }
+        }
+        self.statements.splice(0..0, axioms);
+
+        Box::new(move |model| back_convert_model(model, old_relations.clone()))
+    }
+}
+
+fn back_convert_model(_model: &Model, _old_changed_relations: Vec<RelationDecl>) -> Model {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::parse;
+
+    #[test]
+    fn non_bool_relations_conversion() {
+        let source1 = "
+sort s
+mutable f(sort, bool): sort
+        ";
+        let source2 = "
+sort s
+mutable f(sort, bool, sort): bool
+
+assume always forall __0:sort, __1: bool. exists __2:sort. f(__0, __1, __2)
+assume always forall __0:sort, __1: bool. forall __2:sort, __3:sort.
+    (f(__0, __1, __2) & f(__0, __1, __3)) -> (__2 = __3)
+        ";
+
+        let mut module1 = parse(source1).unwrap();
+        let _back_convert_model = module1.convert_non_bool_relations();
+
+        let module2 = parse(source2).unwrap();
+
+        assert_eq!(module1, module2);
+    }
+}

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -27,7 +27,7 @@ impl Module {
                     .enumerate()
                     .map(|(i, sort)| Binder {
                         sort: sort.clone(),
-                        name: format!("__{}", i),
+                        name: format!("__{i}"),
                     })
                     .collect();
                 let other_args = &binders[0..relation.args.len()];
@@ -84,7 +84,7 @@ impl Module {
         let mut name = 0;
         let mut go = |term: &mut Term| {
             let to_quantify = fix_term(term, &changed, &mut name);
-            assert!(to_quantify.is_empty(), "{:?}", to_quantify);
+            assert!(to_quantify.is_empty(), "{to_quantify:?}");
         };
         for statement in &mut self.statements {
             match statement {

--- a/fly/src/rets.rs
+++ b/fly/src/rets.rs
@@ -81,21 +81,22 @@ impl Module {
             }
         }
 
-        let mut to_quantify = vec![];
         let mut name = 0;
-        let mut go = |term: &mut Term| fix_term(term, &changed, &mut to_quantify, &mut name);
+        let mut go = |term: &mut Term| {
+            let to_quantify = fix_term(term, &changed, &mut name);
+            assert!(to_quantify.is_empty(), "{:?}", to_quantify);
+        };
         for statement in &mut self.statements {
             match statement {
                 ThmStmt::Assume(term) => go(term),
                 ThmStmt::Assert(Proof { assert, invariants }) => {
                     go(&mut assert.x);
-                    invariants
-                        .iter_mut()
-                        .for_each(|invariant| go(&mut invariant.x));
+                    for invariant in invariants {
+                        go(&mut invariant.x);
+                    }
                 }
             }
         }
-        assert!(to_quantify.is_empty(), "{:?}", to_quantify);
 
         self.statements.splice(0..0, axioms);
     }
@@ -111,18 +112,13 @@ struct ToBeQuantified {
     primes: usize,
 }
 
-fn fix_term(
-    term: &mut Term,
-    changed: &[RelationDecl],
-    to_quantify: &mut Vec<ToBeQuantified>,
-    name: &mut usize,
-) {
+fn fix_term(term: &mut Term, changed: &[RelationDecl], name: &mut usize) -> Vec<ToBeQuantified> {
     // wraps term with an exists quantifier
-    let quantify = |term: &mut Term, to_quantify: &mut Vec<ToBeQuantified>| {
+    let quantify = |term: &mut Term, to_quantify: Vec<ToBeQuantified>| {
         if !to_quantify.is_empty() {
             let mut binders = vec![];
             let mut clauses = vec![term.clone()];
-            for mut tbq in to_quantify.drain(..).rev() {
+            for mut tbq in to_quantify.into_iter().rev() {
                 tbq.xs.push(Term::Id(tbq.name.clone()));
                 binders.insert(
                     0,
@@ -143,10 +139,11 @@ fn fix_term(
 
     match term {
         Term::Id(r) => {
+            let mut out = vec![];
             if let Some(c) = changed.iter().find(|c| r == &c.name) {
                 *name += 1;
                 let name = format!("___{}", *name);
-                to_quantify.push(ToBeQuantified {
+                out.push(ToBeQuantified {
                     name: name.clone(),
                     sort: c.sort.clone(),
                     r: r.to_string(),
@@ -156,14 +153,17 @@ fn fix_term(
                 });
                 *term = Term::Id(name);
             }
+            out
         }
         Term::App(r, p, xs) => {
-            xs.iter_mut()
-                .for_each(|x| fix_term(x, changed, to_quantify, name));
+            let mut out = vec![];
+            for x in &mut *xs {
+                out.extend(fix_term(x, changed, name));
+            }
             if let Some(c) = changed.iter().find(|c| r == &c.name) {
                 *name += 1;
                 let name = format!("___{}", *name);
-                to_quantify.push(ToBeQuantified {
+                out.push(ToBeQuantified {
                     name: name.clone(),
                     sort: c.sort.clone(),
                     r: r.to_string(),
@@ -173,44 +173,55 @@ fn fix_term(
                 });
                 *term = Term::Id(name);
             }
+            out
         }
         Term::UnaryOp(UOp::Always | UOp::Eventually, a) => {
-            fix_term(a, changed, to_quantify, name);
+            let to_quantify = fix_term(a, changed, name);
             quantify(a, to_quantify);
+            vec![]
         }
-        Term::UnaryOp(UOp::Prime | UOp::Next, a) => {
-            let mut tq = vec![];
-            fix_term(a, changed, &mut tq, name);
-            to_quantify.extend(tq.into_iter().map(|tbq| ToBeQuantified {
+        Term::UnaryOp(UOp::Prime | UOp::Next, a) => fix_term(a, changed, name)
+            .into_iter()
+            .map(|tbq| ToBeQuantified {
                 primes: tbq.primes + 1,
                 ..tbq
-            }));
-        }
-        Term::UnaryOp(UOp::Previously, _) => todo!(),
-        Term::UnaryOp(_, a) => fix_term(a, changed, to_quantify, name),
+            })
+            .collect(),
+        Term::UnaryOp(UOp::Previous, _) => todo!(),
+        Term::UnaryOp(_, a) => fix_term(a, changed, name),
         Term::BinOp(BinOp::Until | BinOp::Since, a, b) => {
-            fix_term(a, changed, to_quantify, name);
+            let to_quantify = fix_term(a, changed, name);
             quantify(a, to_quantify);
-            fix_term(b, changed, to_quantify, name);
+            let to_quantify = fix_term(b, changed, name);
             quantify(b, to_quantify);
+            vec![]
         }
         Term::BinOp(_, a, b) => {
-            fix_term(a, changed, to_quantify, name);
-            fix_term(b, changed, to_quantify, name);
+            let mut out = vec![];
+            out.extend(fix_term(a, changed, name));
+            out.extend(fix_term(b, changed, name));
+            out
         }
-        Term::NAryOp(_, terms) => terms
-            .iter_mut()
-            .for_each(|term| fix_term(term, changed, to_quantify, name)),
+        Term::NAryOp(_, terms) => {
+            let mut out = vec![];
+            for term in terms {
+                out.extend(fix_term(term, changed, name));
+            }
+            out
+        }
         Term::Ite { cond, then, else_ } => {
-            fix_term(cond, changed, to_quantify, name);
-            fix_term(then, changed, to_quantify, name);
-            fix_term(else_, changed, to_quantify, name);
+            let mut out = vec![];
+            out.extend(fix_term(cond, changed, name));
+            out.extend(fix_term(then, changed, name));
+            out.extend(fix_term(else_, changed, name));
+            out
         }
         Term::Quantified { body, .. } => {
-            fix_term(body, changed, to_quantify, name);
+            let to_quantify = fix_term(body, changed, name);
             quantify(body, to_quantify);
+            vec![]
         }
-        Term::Literal(_) => {}
+        Term::Literal(_) => vec![],
     }
 }
 
@@ -286,7 +297,7 @@ mutable f(s): bool
 assume always exists __0:s. f(__0)
 assume always forall __0:s, __1:s. (f(__0) & f(__1)) -> (__0 = __1)
 
-assume always forall s:s. exists ___1:s. f(s, ___1) & ___1 = s & (forall s:s. s=s)
+assume always forall s:s. exists ___1:s. f(___1) & ___1 = s & forall s:s. s=s
         ";
 
         let mut module1 = parse(source1).unwrap();

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -92,7 +92,8 @@ pub struct Model {
 }
 
 impl Model {
-    fn cardinality(&self, sort: &Sort) -> usize {
+    /// Get the cardinality using the universe from this model
+    pub fn cardinality(&self, sort: &Sort) -> usize {
         match sort {
             Sort::Bool => 2,
             _ => self.universe[self.signature.sort_idx(sort)],
@@ -111,8 +112,7 @@ impl Model {
                 &self.cardinality(&relation.sort),
             );
             for j in 0..relation.args.len() {
-                let k = self.signature.sort_idx(&relation.args[j]);
-                assert_eq!(interp.shape[j], self.universe[k]);
+                assert_eq!(self.cardinality(&relation.args[j]), interp.shape[j]);
             }
         }
     }

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -222,6 +222,21 @@ pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Optio
     Ok(())
 }
 
+/// Simple entry point to get the sort of a term. Does not infer any sorts.
+/// This can fail if not enough information is given, e.g. `Term::Id("x")`.
+pub fn sort_of_term(term: &Term, sorts: &HashSet<String>) -> Option<Sort> {
+    let mut context = Context {
+        sorts,
+        names: im::HashMap::new(),
+        vars: &mut UnificationTable::new(),
+    };
+
+    match context.sort_of_term(&mut term.clone()) {
+        Ok(AbstractSort::Known(sort)) => Some(sort),
+        _ => None,
+    }
+}
+
 /// Return whether every quantified variable in every term in the given fly
 /// module has a (non-empty) sort annotation.
 pub fn module_has_all_sort_annotations(module: &Module) -> bool {

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -222,21 +222,6 @@ pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Optio
     Ok(())
 }
 
-/// Simple entry point to get the sort of a term. Does not infer any sorts.
-/// This can fail if not enough information is given, e.g. `Term::Id("x")`.
-pub fn sort_of_term(term: &Term, sorts: &HashSet<String>) -> Option<Sort> {
-    let mut context = Context {
-        sorts,
-        names: im::HashMap::new(),
-        vars: &mut UnificationTable::new(),
-    };
-
-    match context.sort_of_term(&mut term.clone()) {
-        Ok(AbstractSort::Known(sort)) => Some(sort),
-        _ => None,
-    }
-}
-
 /// Return whether every quantified variable in every term in the given fly
 /// module has a (non-empty) sort annotation.
 pub fn module_has_all_sort_annotations(module: &Module) -> bool {

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -568,6 +568,8 @@ impl App {
                 bounded,
                 compress_traces,
             } => {
+                m.inline_defs();
+                m.convert_non_bool_relations();
                 let univ = bounded.get_universe(&m.signature);
                 match bounded::set::check(
                     &m,
@@ -599,6 +601,8 @@ impl App {
                 }
             }
             Command::SatCheck(bounded) => {
+                m.inline_defs();
+                m.convert_non_bool_relations();
                 let depth = match bounded.depth {
                     Some(depth) => depth,
                     None => {
@@ -622,6 +626,8 @@ impl App {
                 }
             }
             Command::BddCheck { bounded, reversed } => {
+                m.inline_defs();
+                m.convert_non_bool_relations();
                 let univ = bounded.get_universe(&m.signature);
                 let check = match reversed {
                     false => bounded::bdd::check,

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -662,6 +662,7 @@ impl App {
                 }
             }
             Command::SmtCheck { bounded, solver } => {
+                m.inline_defs();
                 let depth = match bounded.depth {
                     Some(depth) => depth,
                     None => {

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -569,7 +569,7 @@ impl App {
                 compress_traces,
             } => {
                 m.inline_defs();
-                m.convert_non_bool_relations();
+                let back_convert_model = m.convert_non_bool_relations();
                 let univ = bounded.get_universe(&m.signature);
                 match bounded::set::check(
                     &m,
@@ -582,7 +582,7 @@ impl App {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
                             println!("state {i}:");
-                            println!("{}", model.fmt());
+                            println!("{}", back_convert_model(model).fmt());
                         }
                     }
                     Ok(bounded::set::CheckerAnswer::Unknown) => {
@@ -602,7 +602,7 @@ impl App {
             }
             Command::SatCheck(bounded) => {
                 m.inline_defs();
-                m.convert_non_bool_relations();
+                let back_convert_model = m.convert_non_bool_relations();
                 let depth = match bounded.depth {
                     Some(depth) => depth,
                     None => {
@@ -616,7 +616,7 @@ impl App {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
                             println!("state {i}:");
-                            println!("{}", model.fmt());
+                            println!("{}", back_convert_model(model).fmt());
                         }
                     }
                     Ok(bounded::sat::CheckerAnswer::Unknown) => {
@@ -627,7 +627,7 @@ impl App {
             }
             Command::BddCheck { bounded, reversed } => {
                 m.inline_defs();
-                m.convert_non_bool_relations();
+                let back_convert_model = m.convert_non_bool_relations();
                 let univ = bounded.get_universe(&m.signature);
                 let check = match reversed {
                     false => bounded::bdd::check,
@@ -643,7 +643,7 @@ impl App {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
                             println!("state {i}:");
-                            println!("{}", model.fmt());
+                            println!("{}", back_convert_model(model).fmt());
                         }
                     }
                     Ok(bounded::bdd::CheckerAnswer::Unknown) => {


### PR DESCRIPTION
This adds a source-to-source translation that removes all non-boolean-returning relations. It also changes the todo!s in the checkers to panic!s and updates the checker code paths in command.rs.