### PR TITLE
Add smart constructors for terms, and other improvements to fly/src/syntax.rs

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -527,10 +527,13 @@ fn term_to_bdd(
             }
         }
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
-        | Term::UnaryOp(UOp::Next | UOp::Previously, _)
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..) => {
             return Err(CheckerError::CouldNotTranslateToBdd(term.clone()))
         }
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
+        | Term::BinOp(BinOp::Until | BinOp::Since, ..)
+        | Term::Id(_) => return Err(CheckerError::CouldNotTranslateToBdd(term.clone())),
     };
     Ok(bdd)
 }
@@ -560,7 +563,7 @@ fn term_to_element(
             _ => unreachable!(),
         },
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
-        | Term::UnaryOp(UOp::Next | UOp::Previously, _)
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..)
         | Term::App(..) => return Err(CheckerError::CouldNotTranslateToElement(term.clone())),
     };

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -531,9 +531,6 @@ fn term_to_bdd(
         | Term::BinOp(BinOp::Until | BinOp::Since, ..) => {
             return Err(CheckerError::CouldNotTranslateToBdd(term.clone()))
         }
-        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
-        | Term::BinOp(BinOp::Until | BinOp::Since, ..)
-        | Term::Id(_) => return Err(CheckerError::CouldNotTranslateToBdd(term.clone())),
     };
     Ok(bdd)
 }

--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -250,7 +250,7 @@ type Universe = HashMap<String, usize>;
 fn cardinality(universe: &Universe, sort: &Sort) -> usize {
     match sort {
         Sort::Bool => 2,
-        Sort::Id(id) => universe[id],
+        Sort::Uninterpreted(id) => universe[id],
     }
 }
 
@@ -612,7 +612,9 @@ pub fn bdd_to_term<'a>(
                 .iter()
                 .zip(elements)
                 .map(|(sort, element)| match sort {
-                    Sort::Id(sort) => Term::Id(bindings[&(sort.as_str(), *element)].clone()),
+                    Sort::Uninterpreted(sort) => {
+                        Term::Id(bindings[&(sort.as_str(), *element)].clone())
+                    }
                     Sort::Bool => match element {
                         0 => Term::Literal(false),
                         1 => Term::Literal(true),

--- a/bounded/src/sat.rs
+++ b/bounded/src/sat.rs
@@ -402,7 +402,7 @@ fn term_to_ast(
             }
         }
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
-        | Term::UnaryOp(UOp::Next | UOp::Previously, _)
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..) => {
             return Err(CheckerError::CouldNotTranslateToAst(term.clone()))
         }
@@ -435,7 +435,7 @@ fn term_to_element(
             _ => unreachable!(),
         },
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
-        | Term::UnaryOp(UOp::Next | UOp::Previously, _)
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..)
         | Term::App(..) => return Err(CheckerError::CouldNotTranslateToElement(term.clone())),
     };

--- a/bounded/src/sat.rs
+++ b/bounded/src/sat.rs
@@ -138,7 +138,7 @@ type Universe = HashMap<String, usize>;
 fn cardinality(universe: &Universe, sort: &Sort) -> usize {
     match sort {
         Sort::Bool => 2,
-        Sort::Id(id) => universe[id],
+        Sort::Uninterpreted(id) => universe[id],
     }
 }
 

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -1115,7 +1115,7 @@ fn term_to_ast(
             }
         }
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
-        | Term::UnaryOp(UOp::Next | UOp::Previously, _)
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..)
         | Term::App(..) => return Err(TranslationError::CouldNotTranslateToAst(term.clone())),
     };
@@ -1147,7 +1147,7 @@ fn term_to_element(
             _ => unreachable!(),
         },
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
-        | Term::UnaryOp(UOp::Next | UOp::Previously, _)
+        | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..)
         | Term::App(..) => return Err(TranslationError::CouldNotTranslateToElement(term.clone())),
     };

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -811,7 +811,7 @@ fn nullary_id_to_app(term: Term, relations: &[RelationDecl]) -> Term {
 fn cardinality(universe: &UniverseBounds, sort: &Sort) -> usize {
     match sort {
         Sort::Bool => 2,
-        Sort::Id(sort) => *universe.get(sort).unwrap(),
+        Sort::Uninterpreted(sort) => *universe.get(sort).unwrap(),
     }
 }
 

--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -7,11 +7,15 @@ use crate::syntax::*;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use peg::{error::ParseError, str::LineCol};
 
+// TODO(oded): Use smart constructors in this module. In principle, no Term
+// should be constructed directly by a (non-smart) constructor. I expect this
+// will simplify the code, and if there are exceptions then we can revisit the
+// design of the smart consturctors.
+
 peg::parser! {
 
 grammar parser() for str {
     use BinOp::*;
-    use NOp::*;
     use UOp::*;
     use Quantifier::*;
 
@@ -59,9 +63,9 @@ grammar parser() for str {
             Term::Ite { cond: Box::new(cond), then: Box::new(then), else_: Box::new(else_) }
         }
         --
-        x:(@) _ "|" _ y:@ { Term::nary(Or, x, y) }
+        x:(@) _ "|" _ y:@ { Term::or([x, y]) }
         --
-        x:(@) _ "&" _ y:@ { Term::nary(And, x, y) }
+        x:(@) _ "&" _ y:@ { Term::and([x, y]) }
         --
         // NOTE(tej): precedence of these operators was an arbitrary choice
         x:@ _ "until" _ y:(@) { Term::BinOp(BinOp::Until, Box::new(x), Box::new(y)) }

--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -37,7 +37,7 @@ grammar parser() for str {
     =  "(" name:ident() _ ":" _ sort:sort() ")" { Binder {name, sort } } /
         name:ident() sort:(_ ":" _ s:sort() { s })? { Binder {
             name,
-            sort: sort.unwrap_or(Sort::uninterp(""))
+            sort: sort.unwrap_or(Sort::uninterpreted(""))
         } }
 
     pub(super) rule term() -> Term = precedence!{

--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -37,7 +37,7 @@ grammar parser() for str {
     =  "(" name:ident() _ ":" _ sort:sort() ")" { Binder {name, sort } } /
         name:ident() sort:(_ ":" _ s:sort() { s })? { Binder {
             name,
-            sort: sort.unwrap_or(Sort::Uninterpreted("".to_owned()))
+            sort: sort.unwrap_or(Sort::uninterp(""))
         } }
 
     pub(super) rule term() -> Term = precedence!{

--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -37,7 +37,7 @@ grammar parser() for str {
     =  "(" name:ident() _ ":" _ sort:sort() ")" { Binder {name, sort } } /
         name:ident() sort:(_ ":" _ s:sort() { s })? { Binder {
             name,
-            sort: sort.unwrap_or(Sort::Id("".to_owned()))
+            sort: sort.unwrap_or(Sort::Uninterpreted("".to_owned()))
         } }
 
     pub(super) rule term() -> Term = precedence!{
@@ -95,7 +95,7 @@ grammar parser() for str {
 
     rule sort() -> Sort
     = ("bool" word_boundary() { Sort::Bool }) /
-      s:ident() { Sort::Id(s) }
+      s:ident() { Sort::Uninterpreted(s) }
 
     rule sort_decl() -> String
     = "sort" __ s:ident() { s }

--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -73,7 +73,7 @@ grammar parser() for str {
         --
         // NOTE(tej): precedence of these operators was an arbitrary choice
         "X" __ x:@ { Term::UnaryOp(UOp::Next, Box::new(x)) }
-        "X^-1" __ x:@ { Term::UnaryOp(UOp::Previously, Box::new(x)) }
+        "X^-1" __ x:@ { Term::UnaryOp(UOp::Previous, Box::new(x)) }
         --
         x:(@) _ "=" _ y:@ { Term::BinOp(Equals, Box::new(x), Box::new(y)) }
         x:(@) _ "!=" _ y:@ { Term::BinOp(NotEquals, Box::new(x), Box::new(y)) }

--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -37,7 +37,7 @@ grammar parser() for str {
     =  "(" name:ident() _ ":" _ sort:sort() ")" { Binder {name, sort } } /
         name:ident() sort:(_ ":" _ s:sort() { s })? { Binder {
             name,
-            sort: sort.unwrap_or(Sort::uninterpreted(""))
+            sort: sort.unwrap_or(Sort::unknown())
         } }
 
     pub(super) rule term() -> Term = precedence!{

--- a/fly/src/printer.rs
+++ b/fly/src/printer.rs
@@ -21,7 +21,7 @@ fn precedence(t: &Term) -> usize {
         NAryOp(Or, _) => 40,
         NAryOp(And, _) => 50,
         BinOp(Until | Since, _, _) => 52,
-        UnaryOp(Next | Previously, _) => 54,
+        UnaryOp(Next | Previous, _) => 54,
         BinOp(Equals | NotEquals, _, _) => 60,
         UnaryOp(Not, _) => 70,
         UnaryOp(Prime, _) => 80,
@@ -71,7 +71,7 @@ pub fn term(t: &Term) -> String {
                 UOp::Always => format!("always {arg}"),
                 UOp::Eventually => format!("eventually {arg}"),
                 UOp::Next => format!("X {arg}"),
-                UOp::Previously => format!("X^-1 {arg}"),
+                UOp::Previous => format!("X^-1 {arg}"),
             }
         }
         Term::BinOp(op, arg1, arg2) => {

--- a/fly/src/printer.rs
+++ b/fly/src/printer.rs
@@ -202,7 +202,7 @@ mod tests {
 fn sort(s: &Sort) -> String {
     match s {
         Sort::Bool => "bool".to_string(),
-        Sort::Id(i) => i.to_string(),
+        Sort::Uninterpreted(i) => i.to_string(),
     }
 }
 

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -137,7 +137,7 @@ impl Model {
                     "true".to_string()
                 }
             }
-            Sort::Id(s) => format!("@{s}_{element}"),
+            Sort::Uninterpreted(s) => format!("@{s}_{element}"),
         }
     }
 
@@ -344,7 +344,7 @@ impl Model {
                 assignment.insert(name.clone(), j);
                 exists_binders.push(Binder {
                     name: name.clone(),
-                    sort: Sort::Id(self.signature.sorts[i].clone()),
+                    sort: Sort::Uninterpreted(self.signature.sorts[i].clone()),
                 });
             }
         }
@@ -379,7 +379,7 @@ impl Model {
                     quantifier: Quantifier::Forall,
                     binders: vec![Binder {
                         name: univ_vars[i].clone(),
-                        sort: Sort::Id(self.signature.sorts[i].clone()),
+                        sort: Sort::Uninterpreted(self.signature.sorts[i].clone()),
                     }],
                     body: Box::new(Term::NAryOp(
                         NOp::Or,
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn test_wf() {
-        let sort = |n: usize| Sort::Id(format!("T{n}"));
+        let sort = |n: usize| Sort::Uninterpreted(format!("T{n}"));
 
         let sig = Signature {
             sorts: vec!["T1".to_string(), "T2".to_string()],
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     #[allow(clippy::redundant_clone)]
     fn test_eval() {
-        let sort = |n: usize| Sort::Id(format!("T{n}"));
+        let sort = |n: usize| Sort::Uninterpreted(format!("T{n}"));
 
         let sig = Signature {
             sorts: vec!["T1".to_string(), "T2".to_string()],
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_to_term() {
-        let sort = |n: usize| Sort::Id(format!("T{n}"));
+        let sort = |n: usize| Sort::Uninterpreted(format!("T{n}"));
 
         let sig = Signature {
             sorts: vec!["T1".to_string(), "T2".to_string()],

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -344,7 +344,7 @@ impl Model {
                 assignment.insert(name.clone(), j);
                 exists_binders.push(Binder {
                     name: name.clone(),
-                    sort: Sort::uninterp(&self.signature.sorts[i]),
+                    sort: Sort::uninterpreted(&self.signature.sorts[i]),
                 });
             }
         }

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -344,7 +344,7 @@ impl Model {
                 assignment.insert(name.clone(), j);
                 exists_binders.push(Binder {
                     name: name.clone(),
-                    sort: Sort::Uninterpreted(self.signature.sorts[i].clone()),
+                    sort: Sort::uninterp(&self.signature.sorts[i]),
                 });
             }
         }

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -295,7 +295,7 @@ impl Model {
                     0
                 }
             }
-            Term::UnaryOp(Always | Eventually | Prime | Next | Previously, _)
+            Term::UnaryOp(Always | Eventually | Prime | Next | Previous, _)
             | Term::BinOp(Until | Since, _, _) => {
                 panic!("tried to eval temporal {t}")
             }

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -254,7 +254,7 @@ pub fn term_has_all_sort_annotations(term: &Term) -> bool {
         Term::Literal(_) | Term::Id(_) => true,
         Term::App(_f, _p, xs) => xs.iter().all(term_has_all_sort_annotations),
         Term::UnaryOp(
-            UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime | UOp::Next | UOp::Previously,
+            UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime | UOp::Next | UOp::Previous,
             x,
         ) => term_has_all_sort_annotations(x),
         Term::BinOp(
@@ -472,7 +472,7 @@ impl Context<'_> {
                 Ok(())
             }
             Term::UnaryOp(
-                UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime | UOp::Next | UOp::Previously,
+                UOp::Not | UOp::Always | UOp::Eventually | UOp::Prime | UOp::Next | UOp::Previous,
                 x,
             ) => self.fix_sorts_in_term(x),
             Term::BinOp(
@@ -567,7 +567,7 @@ impl Context<'_> {
                 None => Err(SortError::UnknownFunction(f.clone())),
             },
             Term::UnaryOp(
-                UOp::Not | UOp::Always | UOp::Eventually | UOp::Next | UOp::Previously,
+                UOp::Not | UOp::Always | UOp::Eventually | UOp::Next | UOp::Previous,
                 x,
             ) => {
                 let x = self.sort_of_term(x)?;

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -280,7 +280,7 @@ pub fn term_has_all_sort_annotations(term: &Term) -> bool {
         } => {
             binders
                 .iter()
-                .all(|binder| binder.sort != Sort::Uninterpreted("".to_owned()))
+                .all(|binder| binder.sort != Sort::uninterp(""))
                 && term_has_all_sort_annotations(body)
         }
     }

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -280,7 +280,7 @@ pub fn term_has_all_sort_annotations(term: &Term) -> bool {
         } => {
             binders
                 .iter()
-                .all(|binder| binder.sort != Sort::uninterp(""))
+                .all(|binder| binder.sort != Sort::uninterpreted(""))
                 && term_has_all_sort_annotations(body)
         }
     }

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -280,7 +280,7 @@ pub fn term_has_all_sort_annotations(term: &Term) -> bool {
         } => {
             binders
                 .iter()
-                .all(|binder| binder.sort != Sort::Id("".to_owned()))
+                .all(|binder| binder.sort != Sort::Uninterpreted("".to_owned()))
                 && term_has_all_sort_annotations(body)
         }
     }
@@ -364,8 +364,8 @@ impl Context<'_> {
     ) -> Result<(), SortError> {
         match sort {
             Sort::Bool => Ok(()),
-            Sort::Id(a) if a.is_empty() && empty_allowed => Ok(()),
-            Sort::Id(a) => {
+            Sort::Uninterpreted(a) if a.is_empty() && empty_allowed => Ok(()),
+            Sort::Uninterpreted(a) => {
                 if !self.sorts.contains(a) {
                     Err(SortError::UnknownSort(a.clone()))
                 } else {
@@ -418,9 +418,9 @@ impl Context<'_> {
                 return Err(SortError::RedeclaredName(binder.name.clone()));
             }
             self.check_sort_exists_or_empty(&binder.sort)?;
-            let sort = if binder.sort == Sort::Id("".to_owned()) {
+            let sort = if binder.sort == Sort::Uninterpreted("".to_owned()) {
                 let var = self.vars.new_key(OptionSort(None));
-                binder.sort = Sort::Id(format!("var {}", var.0));
+                binder.sort = Sort::Uninterpreted(format!("var {}", var.0));
                 NamedSort::Unknown(var)
             } else {
                 NamedSort::Known(vec![], binder.sort.clone())
@@ -507,7 +507,7 @@ impl Context<'_> {
                 body,
             } => {
                 for binder in binders {
-                    if let Sort::Id(s) = binder.sort.clone() {
+                    if let Sort::Uninterpreted(s) = binder.sort.clone() {
                         let s: Vec<&str> = s.split_whitespace().collect();
                         match s[..] {
                             [_] => {} // user sort annotation

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -66,6 +66,26 @@ pub struct Binder {
     pub sort: Sort,
 }
 
+impl From<&str> for Sort {
+    fn from(value: &str) -> Self {
+        Sort::Id(value.to_string())
+    }
+}
+
+impl Binder {
+    /// Smart constructor for a Binder that takes arguments by reference.
+    pub fn new<N, S>(name: N, sort: S) -> Self
+    where
+        N: AsRef<str>,
+        S: Into<Sort>,
+    {
+        Binder {
+            name: name.as_ref().to_string(),
+            sort: sort.into(),
+        }
+    }
+}
+
 /// A Term is a temporal-logical formula (in LTL), which can be interpreted as
 /// being a sequence of values of some sort (often bool for example) under a
 /// given signature and an infinite sequence of states (consisting of values for
@@ -121,6 +141,11 @@ impl Term {
             }
             _ => self,
         }
+    }
+
+    /// Smart constructor for function applications
+    pub fn app(f: &str, n_primes: usize, args: &[Term]) -> Self {
+        Self::App(f.to_string(), n_primes, args.to_vec())
     }
 
     /// Smart constructor for an n-ary op from two arguments

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -22,7 +22,12 @@ pub enum Sort {
 impl Sort {
     /// Smart constructor for uninterpreted sort that takes &str
     pub fn uninterpreted(name: &str) -> Self {
-        Sort::Uninterpreted(name.to_string())
+        Self::Uninterpreted(name.to_string())
+    }
+
+    /// Unknown sort (used in sort inference) is represented as Uninterpreted("")
+    pub fn unknown() -> Self {
+        Self::uninterpreted("")
     }
 }
 

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -21,7 +21,7 @@ pub enum Sort {
 
 impl Sort {
     /// Smart constructor for uninterpreted sort that takes &str
-    pub fn unintereted(name: &str) -> Self {
+    pub fn uninterp(name: &str) -> Self {
         Sort::Uninterpreted(name.to_string())
     }
 }
@@ -30,7 +30,7 @@ impl From<&str> for Sort {
     /// This is mostly for the Binder smart constructor, making it possible to
     /// pass either Sort, &Sort, or &str
     fn from(value: &str) -> Self {
-        Self::unintereted(value)
+        Self::uninterp(value)
     }
 }
 

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -16,13 +16,13 @@ use crate::ouritertools::OurItertools;
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, PartialOrd, Ord)]
 pub enum Sort {
     Bool,
-    Id(String), // TODO(oded): rename to Uninterpreted
+    Uninterpreted(String), // TODO(oded): rename to Uninterpreted
 }
 
 impl Sort {
-    /// Smart constructor for Sord::Id that takes &str
-    pub fn id(name: &str) -> Self {
-        Sort::Id(name.to_string())
+    /// Smart constructor for uninterpreted sort that takes &str
+    pub fn unintereted(name: &str) -> Self {
+        Sort::Uninterpreted(name.to_string())
     }
 }
 
@@ -30,7 +30,7 @@ impl From<&str> for Sort {
     /// This is mostly for the Binder smart constructor, making it possible to
     /// pass either Sort, &Sort, or &str
     fn from(value: &str) -> Self {
-        Self::id(value)
+        Self::unintereted(value)
     }
 }
 
@@ -46,7 +46,7 @@ impl fmt::Display for Sort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
             Sort::Bool => "bool".to_string(),
-            Sort::Id(i) => i.to_string(),
+            Sort::Uninterpreted(i) => i.to_string(),
         };
         write!(f, "{s}")
     }
@@ -532,7 +532,7 @@ impl Signature {
     pub fn sort_idx(&self, sort: &Sort) -> usize {
         match sort {
             Sort::Bool => panic!("invalid sort {sort}"),
-            Sort::Id(sort) => self
+            Sort::Uninterpreted(sort) => self
                 .sorts
                 .iter()
                 .position(|x| x == sort)
@@ -762,7 +762,7 @@ mod tests {
 
     #[test]
     fn test_terms_by_sort() {
-        let sort = |n: usize| Sort::Id(format!("T{n}"));
+        let sort = |n: usize| Sort::Uninterpreted(format!("T{n}"));
 
         let mut sig = Signature {
             sorts: vec!["T1".to_string(), "T2".to_string()],

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -21,7 +21,7 @@ pub enum Sort {
 
 impl Sort {
     /// Smart constructor for uninterpreted sort that takes &str
-    pub fn uninterp(name: &str) -> Self {
+    pub fn uninterpreted(name: &str) -> Self {
         Sort::Uninterpreted(name.to_string())
     }
 }
@@ -30,7 +30,7 @@ impl From<&str> for Sort {
     /// This is mostly for the Binder smart constructor, making it possible to
     /// pass either Sort, &Sort, or &str
     fn from(value: &str) -> Self {
-        Self::uninterp(value)
+        Self::uninterpreted(value)
     }
 }
 

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -12,11 +12,19 @@ use crate::ouritertools::OurItertools;
 
 /// A Sort represents a collection of values, which can be the built-in boolean
 /// sort or a named sort (coming from a Signature).
-#[allow(missing_docs)]
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, PartialOrd, Ord)]
 pub enum Sort {
+    /// Boolean sort
     Bool,
+    /// Uninterpreted sort identified by its name
     Uninterpreted(String),
+    /*
+    /// Unspecified sort
+    ///
+    /// This is used in sort inference, and assumed to not occur anywhere after
+    /// sort inference.
+    Unknown,
+    */
 }
 
 impl Sort {
@@ -192,7 +200,6 @@ impl Term {
     }
 
     /// Smart constructor for Id
-    /// TODO(oded): should this take AsRef<str>?
     pub fn id(name: &str) -> Self {
         Self::Id(name.to_string())
     }

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -20,13 +20,9 @@ pub enum Sort {
 }
 
 impl Sort {
-    /// Smart constructor for uninterpreted sort
-    ///
-    /// TODO(oded): I'm not sure we need to keep this. Even if we do, I'm not
-    ///             sure we need AsRef<str> and not just &str, which seems
-    ///             simpler.
-    pub fn new<S: AsRef<str>>(s: S) -> Self {
-        Self::Id(s.as_ref().to_string())
+    /// Smart constructor for Sord::Id that takes &str
+    pub fn id(name: &str) -> Self {
+        Sort::Id(name.to_string())
     }
 }
 
@@ -34,7 +30,7 @@ impl From<&str> for Sort {
     /// This is mostly for the Binder smart constructor, making it possible to
     /// pass either Sort, &Sort, or &str
     fn from(value: &str) -> Self {
-        Sort::Id(value.to_string())
+        Self::id(value)
     }
 }
 
@@ -53,6 +49,31 @@ impl fmt::Display for Sort {
             Sort::Id(i) => i.to_string(),
         };
         write!(f, "{s}")
+    }
+}
+
+/// A binder is a variable name and a sort (used e.g. for a quantifier)
+#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
+pub struct Binder {
+    /// Bound name
+    pub name: String,
+    /// Sort for this binder
+    pub sort: Sort,
+}
+
+impl Binder {
+    /// Smart constructor for a Binder that takes arguments by reference.
+    ///
+    /// TODO(oded): Tej, I made name &str instead of AsRef<str> and everything
+    ///             seems fine. Is that okay?
+    pub fn new<T>(name: &str, sort: T) -> Self
+    where
+        T: Into<Sort>,
+    {
+        Binder {
+            name: name.to_string(),
+            sort: sort.into(),
+        }
     }
 }
 
@@ -102,31 +123,6 @@ pub enum NOp {
 pub enum Quantifier {
     Forall,
     Exists,
-}
-
-/// A binder for a quantifier
-#[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
-pub struct Binder {
-    /// Bound name
-    pub name: String,
-    /// Sort for this binder
-    pub sort: Sort,
-}
-
-impl Binder {
-    /// Smart constructor for a Binder that takes arguments by reference.
-    ///
-    /// TODO(oded): Tej, I made name &str instead of AsRef<str> and everything
-    ///             seems fine. Is that okay?
-    pub fn new<T>(name: &str, sort: T) -> Self
-    where
-        T: Into<Sort>,
-    {
-        Binder {
-            name: name.to_string(),
-            sort: sort.into(),
-        }
-    }
 }
 
 /// A Term is an FO-LTL (first-order linear temporal logic) term or formula. The

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -74,14 +74,13 @@ impl From<&str> for Sort {
 
 impl Binder {
     /// Smart constructor for a Binder that takes arguments by reference.
-    pub fn new<N, S>(name: N, sort: S) -> Self
+    pub fn new<N>(name: N, sort: &Sort) -> Self
     where
         N: AsRef<str>,
-        S: Into<Sort>,
     {
         Binder {
             name: name.as_ref().to_string(),
-            sort: sort.into(),
+            sort: sort.clone(),
         }
     }
 }

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -400,6 +400,11 @@ impl Term {
     /// Helper function for forall, exists. Special handling for zero binders
     /// and one level flattening.
     fn quantify(quantifier: Quantifier, binders: Vec<Binder>, body: Self) -> Self {
+        // debug_assert that all binders have distinct names
+        debug_assert!(binders
+            .iter()
+            .enumerate()
+            .all(|(i, b1)| binders[(i + 1)..].iter().all(|b2| b1.name != b2.name)));
         if binders.is_empty() {
             body
         } else {

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -10,6 +10,52 @@ use serde::Serialize;
 
 use crate::ouritertools::OurItertools;
 
+/// A Sort represents a collection of values, which can be the built-in boolean
+/// sort or a named sort (coming from a Signature).
+#[allow(missing_docs)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, PartialOrd, Ord)]
+pub enum Sort {
+    Bool,
+    Id(String), // TODO(oded): rename to Uninterpreted
+}
+
+impl Sort {
+    /// Smart constructor for uninterpreted sort
+    ///
+    /// TODO(oded): I'm not sure we need to keep this. Even if we do, I'm not
+    ///             sure we need AsRef<str> and not just &str, which seems
+    ///             simpler.
+    pub fn new<S: AsRef<str>>(s: S) -> Self {
+        Self::Id(s.as_ref().to_string())
+    }
+}
+
+impl From<&str> for Sort {
+    /// This is mostly for the Binder smart constructor, making it possible to
+    /// pass either Sort, &Sort, or &str
+    fn from(value: &str) -> Self {
+        Sort::Id(value.to_string())
+    }
+}
+
+impl From<&Sort> for Sort {
+    /// This is mostly for the Binder smart constructor, making it possible to
+    /// pass either Sort, &Sort, or &str
+    fn from(value: &Self) -> Self {
+        value.clone()
+    }
+}
+
+impl fmt::Display for Sort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Sort::Bool => "bool".to_string(),
+            Sort::Id(i) => i.to_string(),
+        };
+        write!(f, "{s}")
+    }
+}
+
 /// Unary operators
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
 pub enum UOp {
@@ -24,6 +70,7 @@ pub enum UOp {
     /// Used for the l2s construction (may end up replaced with just Prime)
     Next,
     /// Past operator, used only for the l2s construction
+    /// TODO(oded): rename this to Previous, I think it's more standard
     Previously,
 }
 
@@ -66,29 +113,25 @@ pub struct Binder {
     pub sort: Sort,
 }
 
-impl From<&str> for Sort {
-    fn from(value: &str) -> Self {
-        Sort::Id(value.to_string())
-    }
-}
-
 impl Binder {
     /// Smart constructor for a Binder that takes arguments by reference.
-    pub fn new<N>(name: N, sort: &Sort) -> Self
+    ///
+    /// TODO(oded): Tej, I made name &str instead of AsRef<str> and everything
+    ///             seems fine. Is that okay?
+    pub fn new<T>(name: &str, sort: T) -> Self
     where
-        N: AsRef<str>,
+        T: Into<Sort>,
     {
         Binder {
-            name: name.as_ref().to_string(),
-            sort: sort.clone(),
+            name: name.to_string(),
+            sort: sort.into(),
         }
     }
 }
 
-/// A Term is a temporal-logical formula (in LTL), which can be interpreted as
-/// being a sequence of values of some sort (often bool for example) under a
-/// given signature and an infinite sequence of states (consisting of values for
-/// all the functions in the signature at each point in time).
+/// A Term is an FO-LTL (first-order linear temporal logic) term or formula. The
+/// temporal operators supported are: Prime, Next, Prev, Until, Since, Always,
+/// Eventually (see [`UOp`] and [`BinOp`]).
 #[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub enum Term {
     /// A constant true or false
@@ -124,80 +167,314 @@ pub enum Term {
     },
 }
 
+impl From<&Term> for Term {
+    /// This is mostly for smart constructor, making it possible to
+    /// pass either Sort or &Sort with an automatic clone if needed
+    fn from(value: &Self) -> Self {
+        value.clone()
+    }
+}
+
+/// Smart constructors for Term. These generally take arguments by reference and
+/// clone them. Should this become a performence concern we can revisit this
+/// choice.
 impl Term {
-    /// Flatten an n-ary relation one level deep.
-    fn flatten_nary(self) -> Self {
-        match self {
-            Self::NAryOp(op, ts) => {
-                let new_ts = ts
-                    .into_iter()
-                    .flat_map(|t| match t {
-                        Self::NAryOp(op2, ts2) if op == op2 => ts2,
-                        _ => vec![t],
-                    })
-                    .collect();
-                Self::NAryOp(op, new_ts)
-            }
-            _ => self,
+    /// Smart constructor for Literal. Mainly here for uniformity.
+    pub fn literal(value: bool) -> Self {
+        Self::Literal(value)
+    }
+
+    /// Smart constructor for Literal(true)
+    pub fn true_() -> Self {
+        Self::Literal(true)
+    }
+
+    /// Smart constructor for Literal(false)
+    pub fn false_() -> Self {
+        Self::Literal(false)
+    }
+
+    /// Smart constructor for Id
+    /// TODO(oded): should this take AsRef<str>?
+    pub fn id(name: &str) -> Self {
+        Self::Id(name.to_string())
+    }
+
+    /// Smart constructor for function application
+    ///
+    /// TODO(oded): I think in case args is empty we should return Id, but maybe
+    /// we do that after Id has n_primes
+    pub fn app<I>(f: &str, n_primes: usize, args: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<Term>,
+    {
+        Self::App(
+            f.to_string(),
+            n_primes,
+            args.into_iter().map(|x| x.into()).collect(),
+        )
+    }
+
+    //////////////////
+    // Unary operations: Not, Prime, Always, Eventually, Next, Previously
+    //////////////////
+
+    /// Smart constructor for not. Note this does not push negation inwards, but
+    /// it does cancel double negation and flips Equals and NotEquals
+    pub fn not<T>(t: T) -> Self
+    where
+        T: Into<Term>,
+    {
+        let t = t.into();
+        match t {
+            Self::UnaryOp(UOp::Not, body) => *body,
+            Self::BinOp(BinOp::Equals, lhs, rhs) => Self::BinOp(BinOp::NotEquals, lhs, rhs),
+            Self::BinOp(BinOp::NotEquals, lhs, rhs) => Self::BinOp(BinOp::Equals, lhs, rhs),
+            _ => Self::UnaryOp(UOp::Not, Box::new(t)),
         }
     }
 
-    /// Smart constructor for function applications
-    pub fn app(f: &str, n_primes: usize, args: &[Term]) -> Self {
-        Self::App(f.to_string(), n_primes, args.to_vec())
+    /// Smart constructor for prime. Note this does not push primes (which would
+    /// require a signature and context)
+    pub fn prime<T>(t: T) -> Self
+    where
+        T: Into<Term>,
+    {
+        Self::UnaryOp(UOp::Prime, Box::new(t.into()))
     }
 
-    /// Smart constructor for an n-ary op from two arguments
-    pub fn nary(op: NOp, lhs: Term, rhs: Term) -> Self {
-        Self::NAryOp(op, vec![lhs, rhs]).flatten_nary()
+    /// Smart constructor for always
+    pub fn always<T>(t: T) -> Self
+    where
+        T: Into<Term>,
+    {
+        Self::UnaryOp(UOp::Always, Box::new(t.into()))
     }
 
-    /// Smart constructor equivalent to the And of an iterator of terms
+    /// Smart constructor for eventually
+    pub fn eventually<T>(t: T) -> Self
+    where
+        T: Into<Term>,
+    {
+        Self::UnaryOp(UOp::Eventually, Box::new(t.into()))
+    }
+
+    /// Smart constructor for next
+    pub fn next<T>(t: T) -> Self
+    where
+        T: Into<Term>,
+    {
+        Self::UnaryOp(UOp::Next, Box::new(t.into()))
+    }
+
+    /// Smart constructor for previously
+    pub fn previously<T>(t: T) -> Self
+    where
+        T: Into<Term>,
+    {
+        Self::UnaryOp(UOp::Previously, Box::new(t.into()))
+    }
+
+    //////////////////
+    // Binary operations: Equals, NotEquals, Implies, Iff, Until, Since
+    //////////////////
+
+    /// Smart constructor for `lhs = rhs`
+    pub fn equals<T1, T2>(lhs: T1, rhs: T2) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+    {
+        Self::BinOp(BinOp::Equals, Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    /// Smart constructor for `lhs != rhs`
+    pub fn not_equals<T1, T2>(lhs: T1, rhs: T2) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+    {
+        Self::BinOp(BinOp::NotEquals, Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    /// Smart constructor for `lhs -> rhs`
+    pub fn implies<T1, T2>(lhs: T1, rhs: T2) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+    {
+        Self::BinOp(BinOp::Implies, Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    /// Smart constructor for `lhs <-> rhs`
+    pub fn iff<T1, T2>(lhs: T1, rhs: T2) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+    {
+        Self::BinOp(BinOp::Iff, Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    /// Smart constructor for `lhs until rhs`
+    pub fn until<T1, T2>(lhs: T1, rhs: T2) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+    {
+        Self::BinOp(BinOp::Until, Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    /// Smart constructor for `lhs since rhs`
+    pub fn since<T1, T2>(lhs: T1, rhs: T2) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+    {
+        Self::BinOp(BinOp::Since, Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    //////////////////
+    // N-ary operations: And, Or
+    //////////////////
+
+    /// Helper function for [`and`] and [`or`]
+    fn flatten_terms_of_op(ts: Vec<Term>, op: NOp) -> Vec<Term> {
+        ts.into_iter()
+            .flat_map(|t| match t {
+                Self::NAryOp(op2, ts2) if op == op2 => ts2,
+                _ => vec![t],
+            })
+            .collect()
+    }
+
+    /// Smart constructor for And. Zero and one conjuncts are handled specially, and
+    /// conjuncts that are And are flattened (but not recursively).
     pub fn and<I>(ts: I) -> Self
     where
         I: IntoIterator,
-        I::IntoIter: Iterator<Item = Term>,
+        I::Item: Into<Term>,
     {
-        let mut ts: Vec<Term> = ts.into_iter().collect();
+        let mut ts = ts.into_iter().map(|x| x.into()).collect_vec();
         if ts.is_empty() {
-            return Term::Literal(true);
+            Self::true_()
         } else if ts.len() == 1 {
             return ts.pop().unwrap();
+        } else {
+            Self::NAryOp(NOp::And, Self::flatten_terms_of_op(ts, NOp::And))
         }
-        Self::NAryOp(NOp::And, ts)
     }
 
-    /// Smart constructor equivalent to the Or of an iterator of terms
+    /// Smart constructor for Or. Zero and one disjuncts are handled specially,
+    /// and disjuncts that are Or are flattened (but not recursively).
     pub fn or<I>(ts: I) -> Self
     where
         I: IntoIterator,
-        I::IntoIter: Iterator<Item = Term>,
+        I::Item: Into<Term>,
     {
-        let mut ts: Vec<Term> = ts.into_iter().collect();
+        let mut ts = ts.into_iter().map(|x| x.into()).collect_vec();
         if ts.is_empty() {
-            return Term::Literal(false);
+            Self::false_()
         } else if ts.len() == 1 {
             return ts.pop().unwrap();
+        } else {
+            Self::NAryOp(NOp::Or, Self::flatten_terms_of_op(ts, NOp::Or))
         }
-        Self::NAryOp(NOp::Or, ts)
     }
 
-    /// Convenience function to create `lhs ==> rhs`
-    pub fn implies(lhs: Term, rhs: Term) -> Self {
-        Self::BinOp(BinOp::Implies, Box::new(lhs), Box::new(rhs))
+    //////////////////
+    // Remaining operations: Ite, Forall, Exists
+    //////////////////
+
+    /// Smart constructor for Ite
+    pub fn ite<T1, T2, T3>(cond: T1, then: T2, else_: T3) -> Self
+    where
+        T1: Into<Term>,
+        T2: Into<Term>,
+        T3: Into<Term>,
+    {
+        Self::Ite {
+            cond: Box::new(cond.into()),
+            then: Box::new(then.into()),
+            else_: Box::new(else_.into()),
+        }
     }
 
-    /// Convenience function to create `lhs == rhs`
-    pub fn equals(lhs: Term, rhs: Term) -> Self {
-        Self::BinOp(BinOp::Equals, Box::new(lhs), Box::new(rhs))
+    /// Helper function for forall, exists. Special handling for zero binders
+    /// and one level flattening.
+    fn quantify(quantifier: Quantifier, binders: Vec<Binder>, body: Self) -> Self {
+        if binders.is_empty() {
+            body
+        } else {
+            match body {
+                Term::Quantified {
+                    quantifier: quantifier2,
+                    binders: binders2,
+                    body: body2,
+                } if quantifier == quantifier2 => {
+                    // Handle shadowing
+                    let mut combined_binders = binders
+                        .into_iter()
+                        .filter(|b| binders2.iter().all(|b2| b.name != b2.name))
+                        .collect_vec();
+                    combined_binders.extend(binders2);
+                    Self::Quantified {
+                        quantifier,
+                        binders: combined_binders,
+                        body: body2,
+                    }
+                }
+                _ => Self::Quantified {
+                    quantifier,
+                    binders,
+                    body: Box::new(body),
+                },
+            }
+        }
     }
 
+    /// Smart constructor for `forall binders. body`. Zero binders is handled
+    /// specially, and nested forall is kept flat (but not recursively).
+    pub fn forall<I, T>(binders: I, body: T) -> Self
+    where
+        I: IntoIterator,
+        I::IntoIter: Iterator<Item = Binder>,
+        T: Into<Term>,
+    {
+        let binders = binders.into_iter().collect_vec();
+        let body = body.into();
+        Self::quantify(Quantifier::Forall, binders, body)
+    }
+
+    /// Smart constructor for `exists binders. body`. Zero binders is handled
+    /// specially, and nested exists is kept flat (but not recursively).
+    pub fn exists<I, T>(binders: I, body: T) -> Self
+    where
+        I: IntoIterator,
+        I::IntoIter: Iterator<Item = Binder>,
+        T: Into<Term>,
+    {
+        let binders = binders.into_iter().collect_vec();
+        let body = body.into();
+        Self::quantify(Quantifier::Exists, binders, body)
+    }
+}
+
+/// Leftovers that should be eliminated
+impl Term {
     /// Convenience function to create `!t`
+    ///
+    /// TODO(oded): eliminate this in favor of not, or maybe make it a "method"
     pub fn negate(t: Term) -> Self {
         Self::UnaryOp(UOp::Not, Box::new(t))
     }
 
     /// Construct a simplified term logically equivalent to `!t`
+    ///
+    /// TODO(oded): I think this should be eliminated once we have NNF
+    ///             conversion (or even before). This is a very strange function
+    ///             anyway, used only once in UPDR. Note that it supports
+    ///             negating forall but not exists. Maybe for now it should be moved to updr.rs.
     pub fn negate_and_simplify(t: Term) -> Self {
         match t {
             Term::Literal(b) => Term::Literal(!b),
@@ -225,58 +502,6 @@ impl Term {
             },
             _ => panic!("got illegal operator in negate and simplify"),
         }
-    }
-
-    /// Convenience to construct `exists (binders), body`
-    pub fn exists<I>(binders: I, body: Term) -> Self
-    where
-        I: IntoIterator,
-        I::IntoIter: Iterator<Item = Binder>,
-    {
-        Self::Quantified {
-            quantifier: Quantifier::Exists,
-            binders: binders.into_iter().collect(),
-            body: Box::new(body),
-        }
-    }
-
-    /// Convenience to construct `forall (binders), body`
-    pub fn forall<I>(binders: I, body: Term) -> Self
-    where
-        I: IntoIterator,
-        I::IntoIter: Iterator<Item = Binder>,
-    {
-        Self::Quantified {
-            quantifier: Quantifier::Forall,
-            binders: binders.into_iter().collect(),
-            body: Box::new(body),
-        }
-    }
-}
-
-/// A Sort represents a collection of values, which can be the built-in boolean
-/// sort or a named sort (coming from a Signature).
-#[allow(missing_docs)]
-#[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, PartialOrd, Ord)]
-pub enum Sort {
-    Bool,
-    Id(String),
-}
-
-impl Sort {
-    /// Smart constructor for a named sort
-    pub fn new<S: AsRef<str>>(s: S) -> Self {
-        Self::Id(s.as_ref().to_string())
-    }
-}
-
-impl fmt::Display for Sort {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Sort::Bool => "bool".to_string(),
-            Sort::Id(i) => i.to_string(),
-        };
-        write!(f, "{s}")
     }
 }
 

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -16,7 +16,7 @@ use crate::ouritertools::OurItertools;
 #[derive(PartialEq, Eq, Clone, Debug, Hash, Serialize, PartialOrd, Ord)]
 pub enum Sort {
     Bool,
-    Uninterpreted(String), // TODO(oded): rename to Uninterpreted
+    Uninterpreted(String),
 }
 
 impl Sort {
@@ -91,8 +91,7 @@ pub enum UOp {
     /// Used for the l2s construction (may end up replaced with just Prime)
     Next,
     /// Past operator, used only for the l2s construction
-    /// TODO(oded): rename this to Previous, I think it's more standard
-    Previously,
+    Previous,
 }
 
 /// Binary operators
@@ -264,12 +263,12 @@ impl Term {
         Self::UnaryOp(UOp::Next, Box::new(t.into()))
     }
 
-    /// Smart constructor for previously
-    pub fn previously<T>(t: T) -> Self
+    /// Smart constructor for previous
+    pub fn previous<T>(t: T) -> Self
     where
         T: Into<Term>,
     {
-        Self::UnaryOp(UOp::Previously, Box::new(t.into()))
+        Self::UnaryOp(UOp::Previous, Box::new(t.into()))
     }
 
     //////////////////

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -338,7 +338,7 @@ impl Term {
     // N-ary operations: And, Or
     //////////////////
 
-    /// Helper function for [`and`] and [`or`]
+    /// Helper function for [`Self::and`] and [`Self::or`]
     fn flatten_terms_of_op(ts: Vec<Term>, op: NOp) -> Vec<Term> {
         ts.into_iter()
             .flat_map(|t| match t {

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -68,9 +68,6 @@ pub struct Binder {
 
 impl Binder {
     /// Smart constructor for a Binder that takes arguments by reference.
-    ///
-    /// TODO(oded): Tej, I made name &str instead of AsRef<str> and everything
-    ///             seems fine. Is that okay?
     pub fn new<T>(name: &str, sort: T) -> Self
     where
         T: Into<Sort>,

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -134,9 +134,20 @@ pub enum Quantifier {
     Exists,
 }
 
-/// A Term is an FO-LTL (first-order linear temporal logic) term or formula. The
-/// temporal operators supported are: Prime, Next, Prev, Until, Since, Always,
-/// Eventually (see [`UOp`] and [`BinOp`]).
+/// FO-LTL term or formula
+///
+/// FO-LTL (first-order linear temporal logic) is an extension of
+/// first-order logic where the semantics is given in terms of
+/// infinite sequences of models (over a shared universe). A term is
+/// interpreted at a particular point (time) in the sequence, and
+/// using temporal operators it can also query the past or future. For
+/// example: `exists x. p(x) & (previous !p(x)) & always r(x)` means
+/// that there exists some element for which `p` now holds, but it
+/// didn't hold a moment ago, and from this point onwards `r` keeps
+/// holding for it.
+///
+/// The temporal operators supported are: Prime, Next, Prev, Until,
+/// Since, Always, Eventually (see [`UOp`] and [`BinOp`]).
 #[derive(PartialEq, Eq, Clone, Debug, Hash, PartialOrd, Ord)]
 pub enum Term {
     /// A constant true or false

--- a/fly/src/term/fo.rs
+++ b/fly/src/term/fo.rs
@@ -65,7 +65,7 @@ fn unrolling(t: &Term) -> Unrolling {
         Term::UnaryOp(Always | Eventually, _) => Unrolling::Infinite,
         Term::UnaryOp(Not, t) => unrolling(t),
         Term::UnaryOp(Prime, t) | Term::UnaryOp(Next, t) => Finite(1) + unrolling(t),
-        Term::UnaryOp(Previously, _) | Term::BinOp(BinOp::Since, _, _) => {
+        Term::UnaryOp(Previous, _) | Term::BinOp(BinOp::Since, _, _) => {
             panic!("attempt to get unrolling of past operator")
         }
         Term::BinOp(BinOp::Until, _, _) => Unrolling::Infinite,

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -637,7 +637,7 @@ pub fn parse_quantifier(
 
     let sort_id = parts.next().unwrap().to_string();
     let sort = if sig.sorts.contains(&sort_id) {
-        Sort::Id(sort_id)
+        Sort::Uninterpreted(sort_id)
     } else {
         return Err(format!("invalid sort {sort_id}"));
     };

--- a/inference/src/quant.rs
+++ b/inference/src/quant.rs
@@ -283,7 +283,7 @@ impl QuantifierPrefix {
                     if present_ids.contains(name) {
                         Some(Binder {
                             name: name.clone(),
-                            sort: Sort::Id(self.signature.sorts[self.sorts[i]].clone()),
+                            sort: Sort::Uninterpreted(self.signature.sorts[self.sorts[i]].clone()),
                         })
                     } else {
                         None

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -74,7 +74,7 @@ impl GenericBackend {
 fn sort_cardinality(universes: &HashMap<String, usize>, sort: &Sort) -> usize {
     match sort {
         Sort::Bool => 2,
-        Sort::Id(s) => *universes
+        Sort::Uninterpreted(s) => *universes
             .get(s)
             .unwrap_or_else(|| panic!("unknown sort {s}")),
     }
@@ -177,7 +177,7 @@ impl Backend for &GenericBackend {
                                 Atom::S("true".to_string())
                             }
                         }
-                        Sort::Id(sort) => {
+                        Sort::Uninterpreted(sort) => {
                             let elements = &model.universes[sort];
                             let element = elements[e_idx].clone();
                             Atom::S(element)
@@ -200,7 +200,7 @@ impl Backend for &GenericBackend {
                             panic!("unexpected bool {res}")
                         }
                     }
-                    Sort::Id(sort) => {
+                    Sort::Uninterpreted(sort) => {
                         let elements = &model.universes[sort];
                         let res_idx = elements
                             .iter()

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -248,7 +248,7 @@ impl<B: Backend> Solver<B> {
             .comment_with(|| format!("setting {univ} to cardinality {card}"));
         let ind = self.get_indicator(&format!("{univ}_card_{card}"));
 
-        let univ: Sort = Sort::unintereted(univ);
+        let univ: Sort = Sort::uninterp(univ);
 
         // (exists ((x0 univ) ... (xn univ)) (forall ((x univ)) (or (= x x1) ... (= x xn))))
         let univ_card =

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -248,7 +248,7 @@ impl<B: Backend> Solver<B> {
             .comment_with(|| format!("setting {univ} to cardinality {card}"));
         let ind = self.get_indicator(&format!("{univ}_card_{card}"));
 
-        let univ: Sort = Sort::uninterp(univ);
+        let univ: Sort = Sort::uninterpreted(univ);
 
         // (exists ((x0 univ) ... (xn univ)) (forall ((x univ)) (or (= x x1) ... (= x xn))))
         let univ_card =

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -248,7 +248,7 @@ impl<B: Backend> Solver<B> {
             .comment_with(|| format!("setting {univ} to cardinality {card}"));
         let ind = self.get_indicator(&format!("{univ}_card_{card}"));
 
-        let univ: Sort = Sort::new(univ);
+        let univ: Sort = Sort::id(univ);
 
         // (exists ((x0 univ) ... (xn univ)) (forall ((x univ)) (or (= x x1) ... (= x xn))))
         let univ_card =

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -248,7 +248,7 @@ impl<B: Backend> Solver<B> {
             .comment_with(|| format!("setting {univ} to cardinality {card}"));
         let ind = self.get_indicator(&format!("{univ}_card_{card}"));
 
-        let univ: Sort = Sort::id(univ);
+        let univ: Sort = Sort::unintereted(univ);
 
         // (exists ((x0 univ) ... (xn univ)) (forall ((x univ)) (or (= x x1) ... (= x xn))))
         let univ_card =

--- a/solver/src/models.rs
+++ b/solver/src/models.rs
@@ -89,7 +89,7 @@ fn parse_sort(sort: &Sexp) -> Sort {
     if sort_name == "Bool" {
         Sort::Bool
     } else {
-        Sort::uninterp(sort_name)
+        Sort::uninterpreted(sort_name)
     }
 }
 

--- a/solver/src/models.rs
+++ b/solver/src/models.rs
@@ -89,7 +89,7 @@ fn parse_sort(sort: &Sexp) -> Sort {
     if sort_name == "Bool" {
         Sort::Bool
     } else {
-        Sort::Uninterpreted(sort_name.to_string())
+        Sort::uninterp(sort_name)
     }
 }
 

--- a/solver/src/models.rs
+++ b/solver/src/models.rs
@@ -89,7 +89,7 @@ fn parse_sort(sort: &Sexp) -> Sort {
     if sort_name == "Bool" {
         Sort::Bool
     } else {
-        Sort::Id(sort_name.to_string())
+        Sort::Uninterpreted(sort_name.to_string())
     }
 }
 
@@ -277,7 +277,7 @@ impl PartialInterp {
                     "false".to_string()
                 }
             }
-            Sort::Id(sort) => self.universes[sort][result_el].clone(),
+            Sort::Uninterpreted(sort) => self.universes[sort][result_el].clone(),
         }
     }
 }

--- a/solver/src/sexp.rs
+++ b/solver/src/sexp.rs
@@ -11,7 +11,7 @@ use smtlib::sexp::{app, atom_s, sexp_l, Sexp};
 pub fn sort(s: &Sort) -> Sexp {
     match s {
         Sort::Bool => atom_s("Bool"),
-        Sort::Id(s) => atom_s(s),
+        Sort::Uninterpreted(s) => atom_s(s),
     }
 }
 

--- a/solver/src/sexp.rs
+++ b/solver/src/sexp.rs
@@ -49,7 +49,7 @@ fn term_primes(t: &Term, num_primes: usize) -> Sexp {
                     term_primes(arg, num_primes + 1)
                 }
                 // TODO: temporal stuff should be eliminated before here
-                UOp::Always | UOp::Eventually | UOp::Next | UOp::Previously => {
+                UOp::Always | UOp::Eventually | UOp::Next | UOp::Previous => {
                     panic!("attempt to encode a temporal formula for smt")
                 }
             }

--- a/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
+++ b/temporal-verifier/tests/examples/snapshots/fail/lockserver_bug.fly.z3.snap
@@ -14,23 +14,23 @@ error: invariant is not inductive
    │
    = counter example:
      state 0:
-     lock_msg(@node_0) = true
-     lock_msg(@node_1) = true
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = false
      grant_msg(@node_0) = true
      grant_msg(@node_1) = true
-     unlock_msg(@node_0) = true
-     unlock_msg(@node_1) = true
+     unlock_msg(@node_0) = false
+     unlock_msg(@node_1) = false
      holds_lock(@node_0) = true
      holds_lock(@node_1) = false
      server_holds_lock = true
      
      state 1:
-     lock_msg(@node_0) = true
-     lock_msg(@node_1) = true
+     lock_msg(@node_0) = false
+     lock_msg(@node_1) = false
      grant_msg(@node_0) = true
      grant_msg(@node_1) = false
-     unlock_msg(@node_0) = true
-     unlock_msg(@node_1) = true
+     unlock_msg(@node_0) = false
+     unlock_msg(@node_1) = false
      holds_lock(@node_0) = true
      holds_lock(@node_1) = true
      server_holds_lock = true
@@ -45,15 +45,15 @@ error: invariant is not inductive
      state 0:
      lock_msg(@node_0) = true
      grant_msg(@node_0) = true
-     unlock_msg(@node_0) = false
-     holds_lock(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = false
      server_holds_lock = true
      
      state 1:
      lock_msg(@node_0) = false
      grant_msg(@node_0) = true
-     unlock_msg(@node_0) = false
-     holds_lock(@node_0) = true
+     unlock_msg(@node_0) = true
+     holds_lock(@node_0) = false
      server_holds_lock = false
 
 

--- a/verify/src/snapshots/verify__module__tests__verify_failing2.snap
+++ b/verify/src/snapshots/verify__module__tests__verify_failing2.snap
@@ -16,7 +16,7 @@ fails:
               - mutable: false
                 name: p
                 args:
-                  - Id: thread
+                  - Uninterpreted: thread
                 sort: Bool
               - mutable: false
                 name: q
@@ -26,7 +26,7 @@ fails:
                 name: t0
                 args: []
                 sort:
-                  Id: thread
+                  Uninterpreted: thread
           universe:
             - 1
           interp:


### PR DESCRIPTION
Add smart constructors for `Sort`, `Binder`, and all `Term` cases. The smart constructors can take either something owned, and then they don't clone, or a reference, and then they clone. This is meant to make code for programmatically constructing Terms nicer, without a bunch of `.clone` everywhere. In a few (documented) cases, the smart constructors do a bit more normalization (e.g., `Term::and([])` returns true and not an actual `Term::And`).

For now, these smart constructors are only used in code I still haven't pushed (in the liveness to safety), but I think they should be used everywhere. Basically, there's no reason to directly construct a `Term`.

To convert existing code, change the constructor to a smart constructor, and try to replace `arg.clone()` by `&arg` to make calling code look nicer.

Other small changes:
* Rename `Sort::Id` to `Sort::Uninterpreted`
* Rename `UOp::Previously` to `UOp::Previous`, which I think is more standard ("previously" is sometimes used for the past version of eventually)
* Documentation improvements

Minor issues and future TODOs:
* Binders passed to `forall` and `exist` still need to be owned. We can change this by having `impl From<&Binder> for <Binder>` similarly to what we do for `Sort` and `Term`.
* `Term::and` and `Term::or` take an `IntoIterator` which forces uniformity. So you cannot do `Term::and([&t1, t2])` (where you can do `Term::iff(&t1, t2)`, and must instead do `Term::and([&t1, &t2])` which introduces an unnecessary clone. I don't think this clone gets optimized away. If we think this is a concern, we can implement variadic `and` and `or`, either with specialized functions (say for 2-9 arguments) or perhaps with a macro.