### PR TITLE
Opt-in to clippy suggestion to inline format! args

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -592,7 +592,7 @@ pub fn bdd_to_term<'a>(
     let mut bindings: HashMap<(&str, usize), String> = HashMap::new();
     for (sort, bound) in context.universe {
         for i in 0..*bound {
-            bindings.insert((sort, i), format!("${}", next_binding));
+            bindings.insert((sort, i), format!("${next_binding}"));
             next_binding += 1;
         }
     }

--- a/bounded/src/lib.rs
+++ b/bounded/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![warn(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)]

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -40,7 +40,7 @@ pub fn check(
                         Trace::Trace(..) => unreachable!(),
                         Trace::CompressedTrace(state, depth) => (state, depth),
                     };
-                    println!("counterexample is at depth {}, not 0", depth);
+                    println!("counterexample is at depth {depth}, not 0");
                     vec![state]
                 }
                 TraceCompression::No => match trace {
@@ -110,7 +110,7 @@ impl Elements {
     pub fn new(vec: Vec<usize>) -> Elements {
         let len = vec.len();
         if len > ELEMENT_LEN {
-            panic!("raise ELEMENT_LEN to be at least {}", len);
+            panic!("raise ELEMENT_LEN to be at least {len}");
         }
         let mut out = Elements {
             len: len as u8,
@@ -120,10 +120,7 @@ impl Elements {
             if let Ok(xu8) = x.try_into() {
                 out.data[i] = xu8;
             } else {
-                panic!(
-                    "vec[{}] = {} size was too large (must be less than 256)",
-                    i, x
-                );
+                panic!("vec[{i}] = {x} size was too large (must be less than 256)");
             }
         }
         out
@@ -135,7 +132,7 @@ impl std::fmt::Debug for Elements {
         if self.len > 0 {
             write!(f, "{:?}", self.data[0])?;
             for x in &self.data[1..self.len as usize] {
-                write!(f, ", {:?}", x)?;
+                write!(f, ", {x:?}")?;
             }
         }
         write!(f, "]")
@@ -718,8 +715,7 @@ fn translate<'a>(
 
     if unconstrained_delta > 0 {
         println!(
-            "some relations were unconstrained, added {} transitions to constrain them",
-            unconstrained_delta
+            "some relations were unconstrained, added {unconstrained_delta} transitions to constrain them"
         );
     }
 
@@ -760,7 +756,7 @@ fn translate<'a>(
                     Guard { index: b, value: false, },
                 ) if a == b)
             }) {
-                panic!("found an untakeable transition\n{:?}", tr);
+                panic!("found an untakeable transition\n{tr:?}");
             }
         }
         // check that all redundant updates have been removed

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -471,9 +471,8 @@ fn interpret(
                 print!("({:0.1}s since start) ", start_time.elapsed().as_secs_f64());
             }
             println!(
-                "considering new depth: {}. \
+                "considering new depth: {current_depth}. \
                  queue length is {}. seen {} unique states.",
-                current_depth,
                 queue.len(),
                 seen.len()
             );
@@ -499,11 +498,10 @@ fn interpret(
                 if !seen.contains(&next) {
                     seen.insert(next.clone());
                     if seen.len() % 1_000_000 == 0 {
+                        let elapsed = start_time.elapsed().as_secs_f64();
                         println!(
-                            "progress report: ({:?} since start) considering depth {}. \
+                            "progress report: ({elapsed:0.1}s since start) considering depth {current_depth}. \
                              queue length is {}. visited {} states.",
-                            start_time.elapsed(),
-                            current_depth,
                             queue.len(),
                             seen.len()
                         );

--- a/fly/src/lib.rs
+++ b/fly/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![warn(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)]

--- a/fly/src/printer.rs
+++ b/fly/src/printer.rs
@@ -228,7 +228,7 @@ fn signature(sig: &Signature) -> String {
         .sorts
         .iter()
         // end with trailing newline if there are any sorts
-        .map(|s| format!("sort {}\n", s))
+        .map(|s| format!("sort {s}\n"))
         .collect::<Vec<_>>()
         .join("");
     let relations = sig

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -280,7 +280,7 @@ where
         let (covered, size) = invariant_cover(m, conf, &fo, &proof);
 
         println!("    Fixpoint size = {}", proof.len());
-        println!("    Fixpoint runtime = {:.2}s", total_time);
+        println!("    Fixpoint runtime = {total_time:.2}s");
         println!("    Covers {covered} / {size} of handwritten invariant.");
     }
 

--- a/inference/src/lib.rs
+++ b/inference/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![allow(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/inference/src/quant.rs
+++ b/inference/src/quant.rs
@@ -383,9 +383,9 @@ sort C
             vec![0, 1, 2],
             &[2, 1, 2],
         );
-        let a = |i: usize| format!("A_{}", i);
-        let b = |i: usize| format!("B_{}", i);
-        let c = |i: usize| format!("C_{}", i);
+        let a = |i: usize| format!("A_{i}");
+        let b = |i: usize| format!("B_{i}");
+        let c = |i: usize| format!("C_{i}");
         let ta = |i: usize| Term::Id(a(i));
         let tb = |i: usize| Term::Id(b(i));
         let tc = |i: usize| Term::Id(c(i));

--- a/inference/src/updr.rs
+++ b/inference/src/updr.rs
@@ -369,7 +369,7 @@ impl Updr {
             if inductive_frame.is_some() {
                 println!("inductive_frame");
                 for t in &inductive_frame.as_ref().unwrap().terms {
-                    println!("{}", t);
+                    println!("{t}");
                 }
                 return inductive_frame;
             }
@@ -442,7 +442,7 @@ impl Updr {
         for frame in self.frames.iter() {
             print!("[");
             for term in frame.terms.iter() {
-                print!("{}, ", term);
+                print!("{term}, ");
             }
             println!("]");
         }

--- a/smtlib/src/lib.rs
+++ b/smtlib/src/lib.rs
@@ -13,6 +13,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![warn(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)]

--- a/smtlib/src/tee.rs
+++ b/smtlib/src/tee.rs
@@ -24,7 +24,7 @@ fn calculate_hash<T: Hash>(v: T) -> String {
     let mut hash_state = DefaultHasher::new();
     v.hash(&mut hash_state);
     let h = hash_state.finish();
-    return format!("{:016x}", h)[..8].to_string();
+    return format!("{h:016x}")[..8].to_string();
 }
 
 impl Tee {

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -193,7 +193,7 @@ impl<B: Backend> Solver<B> {
         let start = fly::timing::start();
         let r = if assumptions.is_empty() {
             let sat = self.proc.check_sat()?;
-            self.comment_with(|| format!("check sat result: {:?}", sat));
+            self.comment_with(|| format!("check sat result: {sat:?}"));
             Ok(sat)
         } else {
             self.last_assumptions = Some(assumptions.clone());
@@ -209,7 +209,7 @@ impl<B: Backend> Solver<B> {
                 .sorted()
                 .collect::<Vec<_>>();
             let sat = self.proc.check_sat_assuming(&assumptions)?;
-            self.comment_with(|| format!("check sat result: {:?}", sat));
+            self.comment_with(|| format!("check sat result: {sat:?}"));
             Ok(sat)
         };
         fly::timing::elapsed(

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![warn(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)]

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -579,7 +579,7 @@ impl App {
                     Ok(bounded::set::CheckerAnswer::Counterexample(models)) => {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
-                            println!("state {}:", i);
+                            println!("state {i}:");
                             println!("{}", model.fmt());
                         }
                     }
@@ -595,7 +595,7 @@ impl App {
                     Ok(bounded::set::CheckerAnswer::Convergence) => {
                         println!("answer: safe forever with given sort bounds")
                     }
-                    Err(error) => eprintln!("{}", error),
+                    Err(error) => eprintln!("{error}"),
                 }
             }
             Command::SatCheck(bounded) => {
@@ -611,7 +611,7 @@ impl App {
                     Ok(bounded::sat::CheckerAnswer::Counterexample(models)) => {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
-                            println!("state {}:", i);
+                            println!("state {i}:");
                             println!("{}", model.fmt());
                         }
                     }
@@ -636,7 +636,7 @@ impl App {
                     Ok(bounded::bdd::CheckerAnswer::Counterexample(models)) => {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
-                            println!("state {}:", i);
+                            println!("state {i}:");
                             println!("{}", model.fmt());
                         }
                     }
@@ -672,7 +672,7 @@ impl App {
                     Ok(bounded::smt::CheckerAnswer::Counterexample(models)) => {
                         println!("found counterexample:");
                         for (i, model) in models.iter().enumerate() {
-                            println!("state {}:", i);
+                            println!("state {i}:");
                             println!("{}", model.fmt());
                         }
                     }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -645,7 +645,7 @@ impl App {
                             "answer: safe up to {} for given sort bounds",
                             bounded
                                 .depth
-                                .map(|d| format!("depth {}", d))
+                                .map(|d| format!("depth {d}"))
                                 .unwrap_or("any depth".to_string())
                         );
                     }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -588,7 +588,7 @@ impl App {
                             "answer: safe up to {} for given sort bounds",
                             bounded
                                 .depth
-                                .map(|d| format!("depth {}", d))
+                                .map(|d| format!("depth {d}"))
                                 .unwrap_or("any depth".to_string())
                         );
                     }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -270,24 +270,23 @@ impl BoundedArgs {
             if let [sort_name, bound_size] = b.split('=').collect::<Vec<&str>>()[..] {
                 let sort_name = sort_name.to_string();
                 if !sig.sorts.contains(&sort_name) {
-                    eprintln!("unknown sort name {} in bound {}", sort_name, b);
+                    eprintln!("unknown sort name {sort_name} in bound {b}");
                     process::exit(1);
                 }
                 if let Ok(bound_size) = bound_size.parse::<usize>() {
                     universe.insert(sort_name, bound_size);
                 } else {
-                    eprintln!("could not parse bound as integer in {}", b);
+                    eprintln!("could not parse bound as integer in {b}");
                     process::exit(1);
                 }
             } else {
-                eprintln!("expected exactly one '=' in bound {}", b);
+                eprintln!("expected exactly one '=' in bound {b}");
                 process::exit(1);
             }
         }
         if let Some(unbounded_sort) = sig.sorts.iter().find(|&s| !universe.contains_key(s)) {
             eprintln!(
-                "need a bound for sort {} on the command line, as in --bound {}=N",
-                unbounded_sort, unbounded_sort
+                "need a bound for sort {unbounded_sort} on the command line, as in --bound {unbounded_sort}=N"
             );
             process::exit(1);
         }
@@ -468,7 +467,7 @@ impl App {
         if let Err((err, span)) = r {
             eprintln!("sort checking error:");
 
-            let mut diagnostic = Diagnostic::error().with_message(format!("{}", err));
+            let mut diagnostic = Diagnostic::error().with_message(format!("{err}"));
             if let Some(span) = span {
                 diagnostic = diagnostic.with_labels(vec![Label::primary((), span.start..span.end)]);
             }
@@ -617,9 +616,9 @@ impl App {
                         }
                     }
                     Ok(bounded::sat::CheckerAnswer::Unknown) => {
-                        println!("answer: safe up to depth {} for given sort bounds", depth)
+                        println!("answer: safe up to depth {depth} for given sort bounds")
                     }
-                    Err(error) => eprintln!("{}", error),
+                    Err(error) => eprintln!("{error}"),
                 }
             }
             Command::BddCheck { bounded, reversed } => {
@@ -653,7 +652,7 @@ impl App {
                     Ok(bounded::bdd::CheckerAnswer::Convergence(..)) => {
                         println!("answer: safe forever with given sort bounds")
                     }
-                    Err(error) => eprintln!("{}", error),
+                    Err(error) => eprintln!("{error}"),
                 }
             }
             Command::SmtCheck { bounded, solver } => {
@@ -678,9 +677,9 @@ impl App {
                         }
                     }
                     Ok(bounded::smt::CheckerAnswer::Unknown) => {
-                        println!("answer: safe up to depth {} for given sort bounds", depth)
+                        println!("answer: safe up to depth {depth} for given sort bounds")
                     }
-                    Err(error) => eprintln!("{}", error),
+                    Err(error) => eprintln!("{error}"),
                 }
             }
         }

--- a/temporal-verifier/src/lib.rs
+++ b/temporal-verifier/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![allow(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/verify/src/error.rs
+++ b/verify/src/error.rs
@@ -56,7 +56,7 @@ impl AssertionFailure {
                 QueryError::Sat(models) => {
                     let mut message = "counter example:".to_string();
                     for (i, model) in models.iter().enumerate() {
-                        message.push_str(&format!("\nstate {}:\n", i));
+                        message.push_str(&format!("\nstate {i}:\n"));
                         message.push_str(&model.fmt());
                     }
                     message

--- a/verify/src/lib.rs
+++ b/verify/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![warn(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)]


### PR DESCRIPTION
Suggests changing `format!("hello {}", name)` to `format!("hello {name}")` for example. `cargo clippy --fix` can apply these suggestions automatically.