### PR TITLE
Modify qalpha execution modes and command-line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ correctness properties, including safety and liveness.
 Run `./tools/download-solvers.sh` to get compatible versions of the supported SMT solvers (Z3, CVC5, and CVC4).
 
 ```sh
-cargo run -- verify examples/lockserver.fly`
+cargo run -- verify temporal-verifier/examples/lockserver.fly
 
-cargo run -- infer qalpha examples/lockserver.fly --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3
+cargo run -- infer qalpha temporal-verifier/examples/lockserver.fly --max-exist 0 --until-safe
 
 env RUST_LOG=info cargo run --release -- \
-  infer qalpha examples/consensus_epr.fly  --time \
-  --quantifier "E quorum 1" --quantifier "F node 3" --quantifier "F value 1" \
-  --max-size 3 --qf-body cnf --clauses 1 --clause-size 3
-# note: this last example takes about two minutes to run
+  infer qalpha temporal-verifier/examples/consensus_epr.fly --time \
+  --custom-prefix --sort quorum --sort node --sort value \
+  --max-exist 1 --abort-unsafe --until-safe --minimal-smt \
+  --extend-depth 1 --extend-width 10
+# note: this last example takes several minutes to run
 ```
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cargo run -- infer qalpha temporal-verifier/examples/lockserver.fly --max-exist 
 
 env RUST_LOG=info cargo run --release -- \
   infer qalpha temporal-verifier/examples/consensus_epr.fly --time \
-  --custom-prefix --sort quorum --sort node --sort value \
+  --custom-quant --sort quorum --sort node --sort value \
   --max-exist 1 --abort-unsafe --until-safe --minimal-smt \
   --extend-depth 1 --extend-width 10
 # note: this last example takes several minutes to run

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -586,16 +586,16 @@ impl FOModule {
         }
     }
 
-    pub fn trans_safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> Option<Model> {
+    pub fn trans_safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> TransCexResult {
+        let mut core = HashSet::new();
         for s in self.module.proofs.iter() {
-            if let TransCexResult::CTI(model, _) =
-                self.trans_cex(conf, hyp, &s.safety.x, false, true, None)
-            {
-                return Some(model);
+            match self.trans_cex(conf, hyp, &s.safety.x, false, true, None) {
+                TransCexResult::UnsatCore(new_core) => core.extend(new_core),
+                res => return res,
             }
         }
 
-        None
+        TransCexResult::UnsatCore(core)
     }
 
     pub fn safe_cex(&self, conf: &SolverConf, hyp: &[Term]) -> Option<Model> {

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -89,8 +89,6 @@ impl FoundFixpoint {
             println!("}}");
         };
 
-        println!("Fixpoint runtime = {:.2}s", self.time_taken.as_secs_f64());
-
         if self.safe {
             println!("Fixpoint SAFE!");
         } else {
@@ -101,16 +99,16 @@ impl FoundFixpoint {
             println!("Fixpoint size = {}", proof.len());
             if let Some((covered_handwritten, size_handwritten)) = self.covering {
                 println!(
-                    "Covers {} / {} of handwritten invariant.",
-                    covered_handwritten, size_handwritten
+                    "Covers {covered_handwritten} / {size_handwritten} of handwritten invariant."
                 );
             }
 
             if print_invariant {
-                print_inv(&proof);
+                println!("Fixpoint runtime = {:.2}s", self.time_taken.as_secs_f64());
+                print_inv(proof);
                 if let Some(minimized_proof) = &self.minimized_proof {
                     println!("Safety invariant size = {}", minimized_proof.len());
-                    print_inv(&minimized_proof);
+                    print_inv(minimized_proof);
                 }
             }
         }
@@ -238,7 +236,7 @@ pub fn qalpha<O, L, B>(
             extend,
         );
 
-        fixpoint.report(fixpoint.safe && print_invariant);
+        fixpoint.report(print_invariant);
 
         if (fixpoint.safe && infer_cfg.until_safe) || domains.is_empty() {
             break;
@@ -250,8 +248,6 @@ pub fn qalpha<O, L, B>(
                 .growth_factor
                 .unwrap_or(defaults::DOMAIN_GROWTH_FACTOR);
     }
-
-    println!();
 }
 
 pub fn qalpha_by_qf_body(

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -210,7 +210,7 @@ pub fn qalpha<O, L, B>(
         }
 
         println!();
-        println!("({iteration}) Running aqlpha algorithm...");
+        println!("({iteration}) Running qalpha algorithm...");
         println!(
             "Approximate domain size: 10^{:.2} ({domain_size})",
             (domain_size as f64).log10()

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -4,26 +4,39 @@
 //! Find a fixpoint invariant expressing reachable states in a given
 //! lemma domain.
 
+use itertools::Itertools;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::VecDeque, fmt::Debug};
-
-use itertools::Itertools;
 
 use crate::basics::QfBody;
 use crate::{atoms, lemma, subsume};
 use crate::{
     atoms::{restrict, restrict_by_prefix, Atoms, RestrictedAtoms},
     basics::{FOModule, InferenceConfig},
-    lemma::{Frontier, IndividualLemmaSearch},
+    lemma::Frontier,
     quant::QuantifierPrefix,
     subsume::OrderSubsumption,
-    weaken::{LemmaQf, LemmaSet, WeakenLemmaSet},
+    weaken::{LemmaQf, WeakenLemmaSet},
 };
 use fly::syntax::{Module, Term, ThmStmt};
 use solver::conf::SolverConf;
 
 use rayon::prelude::*;
+
+pub mod defaults {
+    use super::QfBody;
+    pub const MIN_DOMAIN_SIZE: usize = 100;
+    pub const DOMAIN_GROWTH_FACTOR: usize = 5;
+    pub const MAX_QUANT: usize = 6;
+    pub const MAX_SAME_SORT: usize = 3;
+    pub const QF_BODY: QfBody = QfBody::PDnf;
+    pub const MAX_CLAUSES: Option<usize> = None;
+    pub const MAX_CLAUSE_SIZE: Option<usize> = None;
+    pub const MAX_CUBES: Option<usize> = Some(6);
+    pub const MAX_CUBE_SIZE: Option<usize> = Some(4);
+    pub const MAX_NON_UNIT: Option<usize> = Some(6);
+}
 
 type Domain<L> = (Arc<QuantifierPrefix>, Arc<L>, Arc<RestrictedAtoms>);
 
@@ -55,157 +68,54 @@ fn invariant_cover(
 
 /// An inductive fixpoint
 pub struct FoundFixpoint {
-    /// The fixpoint term (the conjunction of these lemmas)
-    pub proof: Vec<Term>,
+    /// The fixpoint term (the conjunction of these lemmas).
+    /// If `None`, the run has been abort before reaching the fixpoint
+    pub proof: Option<Vec<Term>>,
     /// Whether the discovered fixpoint implies the safety predicates
     pub safe: bool,
     /// Total time for fixpoint calculation
     pub time_taken: Duration,
     /// Number of terms of handwritten invariant covered
-    pub covered_handwritten: usize,
-    /// Total number of terms in the handwritten invariant
-    pub size_handwritten: usize,
-}
-
-pub fn fixpoint_single<O, L, B>(
-    infer_cfg: InferenceConfig,
-    conf: &SolverConf,
-    m: &Module,
-) -> FoundFixpoint
-where
-    O: OrderSubsumption<Base = B>,
-    L: LemmaQf<Base = B>,
-    B: Clone + Debug + Send,
-{
-    let fo = FOModule::new(
-        m,
-        infer_cfg.disj,
-        infer_cfg.gradual_smt,
-        infer_cfg.minimal_smt,
-    );
-    let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
-    let unrestricted = Arc::new(restrict(&atoms, |_| true));
-    let domains: Vec<Domain<L>> = infer_cfg
-        .cfg
-        .exact_prefixes(
-            0,
-            infer_cfg.max_existentials.unwrap_or(infer_cfg.cfg.len()),
-            infer_cfg.max_size.unwrap_or(infer_cfg.cfg.num_vars()),
-        )
-        .into_iter()
-        .map(|prefix| {
-            let prefix = Arc::new(prefix);
-            let restricted = Arc::new(restrict_by_prefix(&atoms, &infer_cfg.cfg, &prefix));
-            let lemma_qf = Arc::new(L::new(
-                &infer_cfg,
-                restricted.clone(),
-                prefix.non_universal_vars(),
-            ));
-            (prefix, lemma_qf, restricted)
-        })
-        .collect_vec();
-    let infer_cfg = Arc::new(infer_cfg);
-    let extend = match (infer_cfg.extend_width, infer_cfg.extend_depth) {
-        (None, None) => None,
-        (Some(width), Some(depth)) => Some((width, depth)),
-        (_, _) => panic!("Only one of extend-width and extend-depth is specified."),
-    };
-
-    log::info!("Running fixpoint algorithm...");
-    let total_preds: usize = domains
-        .iter()
-        .map(|(_, lemma_qf, _)| lemma_qf.approx_space_size())
-        .sum();
-    log::info!("    Approximate domain size: {}", total_preds);
-    log::info!("    Prefixes:");
-    for (prefix, lemma_qf, _) in &domains {
-        log::info!("        {:?} ~ {}", prefix, lemma_qf.approx_space_size());
-    }
-
-    let start = std::time::Instant::now();
-
-    let fixpoint = if infer_cfg.indiv {
-        run_individual::<O, L, B>(infer_cfg, conf, &fo, unrestricted, domains, extend).unwrap()
-    } else {
-        run_fixpoint::<O, L, B>(infer_cfg, conf, &fo, unrestricted, domains, extend).unwrap()
-    };
-    let time_taken = start.elapsed();
-    let proof = fixpoint.to_terms();
-    let safe = fo.trans_safe_cex(conf, &proof).is_none();
-    let (covered, size) = invariant_cover(m, conf, &fo, &proof);
-
-    FoundFixpoint {
-        proof,
-        safe,
-        time_taken,
-        covered_handwritten: covered,
-        size_handwritten: size,
-    }
-}
-
-pub fn fixpoint_single_qf_body(
-    infer_cfg: InferenceConfig,
-    conf: &SolverConf,
-    m: &Module,
-) -> FoundFixpoint {
-    match infer_cfg.qf_body {
-        QfBody::CNF => {
-            fixpoint_single::<subsume::Cnf<atoms::Literal>, lemma::LemmaCnf, Vec<Vec<atoms::Literal>>>(
-                infer_cfg, conf, m,
-            )
-        }
-        QfBody::PDnf => fixpoint_single::<
-            subsume::PDnf<atoms::Literal>,
-            lemma::LemmaPDnf,
-            (Vec<atoms::Literal>, Vec<Vec<atoms::Literal>>),
-        >(infer_cfg, conf, m),
-        QfBody::PDnfNaive => fixpoint_single::<
-            subsume::Dnf<atoms::Literal>,
-            lemma::LemmaPDnfNaive,
-            Vec<Vec<atoms::Literal>>,
-        >(infer_cfg, conf, m),
-    }
+    /// and total number of terms in the handwritten invariant
+    pub covering: Option<(usize, usize)>,
 }
 
 impl FoundFixpoint {
-    pub fn report(&self) {
-        println!("proof {{");
-        for lemma in &self.proof {
-            println!("  invariant {lemma}");
-        }
-        println!("}}");
-
-        if self.safe {
-            println!("Fixpoint SAFE!");
-        } else {
-            println!("Fixpoint UNSAFE!");
-        }
-
-        println!("Fixpoint size = {}", self.proof.len());
+    pub fn report(&self, print_invariant: bool) {
         println!("Fixpoint runtime = {:.2}s", self.time_taken.as_secs_f64());
-        println!(
-            "Covers {} / {} of handwritten invariant.",
-            self.covered_handwritten, self.size_handwritten
-        );
-    }
 
-    pub fn test_report(&self) {
         if self.safe {
             println!("Fixpoint SAFE!");
         } else {
             println!("Fixpoint UNSAFE!");
         }
 
-        println!("Fixpoint size = {}", self.proof.len());
-        println!(
-            "Covers {} / {} of handwritten invariant.",
-            self.covered_handwritten, self.size_handwritten
-        );
+        if let Some((covered_handwritten, size_handwritten)) = self.covering {
+            println!(
+                "Covers {} / {} of handwritten invariant.",
+                covered_handwritten, size_handwritten
+            );
+        }
+
+        if let Some(proof) = &self.proof {
+            println!("Fixpoint size = {}", proof.len());
+            if print_invariant {
+                println!("proof {{");
+                for lemma in proof {
+                    println!("  invariant {lemma}");
+                }
+                println!("}}");
+            }
+        }
     }
 }
 
-pub fn fixpoint_multi<O, L, B>(infer_cfg: InferenceConfig, conf: &SolverConf, m: &Module)
-where
+pub fn qalpha<O, L, B>(
+    infer_cfg: InferenceConfig,
+    conf: &SolverConf,
+    m: &Module,
+    print_invariant: bool,
+) where
     O: OrderSubsumption<Base = B>,
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
@@ -218,21 +128,6 @@ where
     );
     let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
-    let domains: Vec<Domain<L>> = infer_cfg
-        .cfg
-        .all_prefixes(&infer_cfg)
-        .into_iter()
-        .flat_map(|prefix| {
-            let prefix = Arc::new(prefix);
-            let restricted = Arc::new(restrict_by_prefix(&atoms, &infer_cfg.cfg, &prefix));
-            let lemma_qf_full = L::new(&infer_cfg, restricted.clone(), prefix.non_universal_vars());
-            lemma_qf_full
-                .sub_spaces()
-                .into_iter()
-                .map(move |lemma_qf| (prefix.clone(), Arc::new(lemma_qf), restricted.clone()))
-        })
-        .sorted_by_key(|(p, lemma_qf, _)| (p.existentials(), lemma_qf.approx_space_size()))
-        .collect_vec();
     let infer_cfg = Arc::new(infer_cfg);
     let extend = match (infer_cfg.extend_width, infer_cfg.extend_depth) {
         (None, None) => None,
@@ -240,82 +135,153 @@ where
         (_, _) => panic!("Only one of extend-width and extend-depth is specified."),
     };
 
-    log::info!("Number of individual domains: {}", domains.len());
+    let mut domains: VecDeque<Domain<L>>;
+    let mut active_domains: Vec<Domain<L>>;
 
-    let mut active_domains: Vec<Domain<L>> = vec![];
-    for (i, dom) in domains.iter().enumerate() {
-        active_domains.retain(|d| !(dom.0.contains(&d.0) && dom.1.contains(&d.1)));
-        active_domains.push(dom.clone());
-
-        log::info!("");
-        log::info!("({}) Running fixpoint algorithm...", i + 1);
-        let total_preds: usize = active_domains
-            .iter()
+    let domain_size_of = |doms: &[Domain<L>]| {
+        doms.iter()
             .map(|(_, lemma_qf, _)| lemma_qf.approx_space_size())
-            .sum();
-        log::info!("    Approximate domain size: {}", total_preds);
-        log::info!("    Prefixes:");
-        for (prefix, lemma_qf, _) in &active_domains {
-            log::info!("        {:?} ~ {}", prefix, lemma_qf.approx_space_size());
+            .sum()
+    };
+
+    if infer_cfg.no_search {
+        domains = VecDeque::new();
+        active_domains = infer_cfg
+            .cfg
+            .exact_prefixes(
+                0,
+                infer_cfg
+                    .max_existentials
+                    .unwrap_or(infer_cfg.cfg.num_vars()),
+                infer_cfg.max_size,
+            )
+            .into_iter()
+            .map(|prefix| {
+                let prefix = Arc::new(prefix);
+                let restricted = Arc::new(restrict_by_prefix(&atoms, &infer_cfg.cfg, &prefix));
+                let lemma_qf = Arc::new(L::new(
+                    &infer_cfg,
+                    restricted.clone(),
+                    prefix.non_universal_vars(),
+                ));
+                (prefix, lemma_qf, restricted)
+            })
+            .collect_vec();
+    } else {
+        domains = infer_cfg
+            .cfg
+            .all_prefixes(&infer_cfg)
+            .into_iter()
+            .flat_map(|prefix| {
+                let prefix = Arc::new(prefix);
+                let restricted = Arc::new(restrict_by_prefix(&atoms, &infer_cfg.cfg, &prefix));
+                let lemma_qf_full =
+                    L::new(&infer_cfg, restricted.clone(), prefix.non_universal_vars());
+                lemma_qf_full
+                    .sub_spaces()
+                    .into_iter()
+                    .map(move |lemma_qf| (prefix.clone(), Arc::new(lemma_qf), restricted.clone()))
+            })
+            .filter(|(_, lemma_qf, _)| lemma_qf.approx_space_size() > 1)
+            .sorted_by_key(|(p, lemma_qf, _)| (lemma_qf.approx_space_size(), p.existentials()))
+            .collect();
+        active_domains = vec![];
+    }
+
+    println!(
+        "Number of individual domains: {}",
+        domains.len() + active_domains.len()
+    );
+
+    let mut domain_size: usize = domain_size_of(&active_domains);
+    let mut next_domain_size = defaults::MIN_DOMAIN_SIZE;
+    let mut iteration: usize = 1;
+    loop {
+        while !domains.is_empty() && domain_size < next_domain_size {
+            let dom = domains.pop_front().unwrap();
+            active_domains.retain(|d| !(dom.0.contains(&d.0) && dom.1.contains(&d.1)));
+            active_domains.push(dom);
+            domain_size = domain_size_of(&active_domains);
         }
 
-        let start = std::time::Instant::now();
-        let fixpoint = run_fixpoint::<O, L, B>(
+        println!();
+        println!("({iteration}) Running aqlpha algorithm...");
+        println!(
+            "Approximate domain size: 10^{:.2} ({domain_size})",
+            (domain_size as f64).log10()
+        );
+        println!("Prefixes:");
+        for (prefix, lemma_qf, atoms) in &active_domains {
+            println!(
+                "    {:?} --- {} atoms --- {:?} ~ {}",
+                prefix,
+                atoms.len(),
+                lemma_qf,
+                lemma_qf.approx_space_size()
+            );
+        }
+
+        let fixpoint = run_qalpha::<O, L, B>(
             infer_cfg.clone(),
             conf,
+            m,
             &fo,
             unrestricted.clone(),
             active_domains.clone(),
             extend,
-        )
-        .unwrap();
-        let total_time = start.elapsed().as_secs_f32();
-        let proof = fixpoint.to_terms();
-        if fo.trans_safe_cex(conf, &proof).is_none() {
-            println!("({}) Fixpoint SAFE!", i + 1);
-        } else {
-            println!("({}) Fixpoint UNSAFE!", i + 1);
+        );
+
+        fixpoint.report(fixpoint.safe && print_invariant);
+
+        if (fixpoint.safe && infer_cfg.until_safe) || domains.is_empty() {
+            break;
         }
 
-        let (covered, size) = invariant_cover(m, conf, &fo, &proof);
-
-        println!("    Fixpoint size = {}", proof.len());
-        println!("    Fixpoint runtime = {total_time:.2}s");
-        println!("    Covers {covered} / {size} of handwritten invariant.");
+        iteration += 1;
+        next_domain_size = domain_size
+            * infer_cfg
+                .growth_factor
+                .unwrap_or(defaults::DOMAIN_GROWTH_FACTOR);
     }
 
     println!();
 }
 
-pub fn fixpoint_multi_qf_body(infer_cfg: InferenceConfig, conf: &SolverConf, m: &Module) {
+pub fn qalpha_by_qf_body(
+    infer_cfg: InferenceConfig,
+    conf: &SolverConf,
+    m: &Module,
+    print_invariant: bool,
+) {
     match infer_cfg.qf_body {
-        QfBody::CNF => {
-            fixpoint_multi::<subsume::Cnf<atoms::Literal>, lemma::LemmaCnf, Vec<Vec<atoms::Literal>>>(
-                infer_cfg, conf, m,
-            )
-        }
-        QfBody::PDnf => fixpoint_multi::<
+        QfBody::CNF => qalpha::<
+            subsume::Cnf<atoms::Literal>,
+            lemma::LemmaCnf,
+            Vec<Vec<atoms::Literal>>,
+        >(infer_cfg, conf, m, print_invariant),
+        QfBody::PDnf => qalpha::<
             subsume::PDnf<atoms::Literal>,
             lemma::LemmaPDnf,
             (Vec<atoms::Literal>, Vec<Vec<atoms::Literal>>),
-        >(infer_cfg, conf, m),
-        QfBody::PDnfNaive => fixpoint_multi::<
+        >(infer_cfg, conf, m, print_invariant),
+        QfBody::PDnfNaive => qalpha::<
             subsume::Dnf<atoms::Literal>,
             lemma::LemmaPDnfNaive,
             Vec<Vec<atoms::Literal>>,
-        >(infer_cfg, conf, m),
+        >(infer_cfg, conf, m, print_invariant),
     }
 }
 
-/// Run a simple fixpoint algorithm on the configured lemma domains.
-fn run_fixpoint<O, L, B>(
+/// Run the qalpha algorithm on the configured lemma domains.
+fn run_qalpha<O, L, B>(
     infer_cfg: Arc<InferenceConfig>,
     conf: &SolverConf,
+    m: &Module,
     fo: &FOModule,
     atoms: Arc<RestrictedAtoms>,
     domains: Vec<Domain<L>>,
     extend: Option<(usize, usize)>,
-) -> Option<LemmaSet<O, L, B>>
+) -> FoundFixpoint
 where
     O: OrderSubsumption<Base = B>,
     L: LemmaQf<Base = B>,
@@ -353,8 +319,7 @@ where
         domains,
     );
     weaken_set.init();
-    let mut frontier: Frontier<O, L, B> =
-        Frontier::new(weaken_set.minimized(), infer_cfg.gradual_advance, extend);
+    let mut frontier: Frontier<O, L, B> = Frontier::new(weaken_set.minimized(), extend);
 
     // Begin by overapproximating the initial states.
     print(&frontier, &weaken_set, "Finding CTI...".to_string());
@@ -367,22 +332,39 @@ where
 
         print(&frontier, &weaken_set, "Weakening...".to_string());
         weaken_set.weaken(&cti);
-
         print(&frontier, &weaken_set, "Finding CTI...".to_string());
     }
 
-    print(&frontier, &weaken_set, "Advancing...".to_string());
-    while frontier.advance(&weaken_set, true) {
-        // If enabled, extend CTI traces.
+    // Handle transition CTI's.
+    loop {
+        // If enabled, extend CTI traces using simulations.
         if extend.is_some() {
+            print(
+                &frontier,
+                &weaken_set,
+                "Simulating CTI traces...".to_string(),
+            );
             frontier.extend(fo, conf, &mut weaken_set);
-            print(&frontier, &weaken_set, "Advancing...".to_string());
-            frontier.advance(&weaken_set, false);
         }
 
-        // Handle transition CTI's.
+        print(&frontier, &weaken_set, "Advancing...".to_string());
+        frontier.advance(&weaken_set);
+
+        if infer_cfg.abort_unsafe {
+            print(&frontier, &weaken_set, "Checking safety...".to_string());
+            let proof = frontier.lemmas.to_terms();
+            if fo.trans_safe_cex(conf, &proof).is_some() {
+                return FoundFixpoint {
+                    proof: None,
+                    safe: false,
+                    time_taken: start.elapsed(),
+                    covering: None,
+                };
+            }
+        }
+
         print(&frontier, &weaken_set, "Finding CTI...".to_string());
-        while let Some(cti) = frontier.trans_cex(fo, conf, &weaken_set) {
+        if let Some(cti) = frontier.trans_cex(fo, conf, &weaken_set) {
             print(
                 &frontier,
                 &weaken_set,
@@ -391,101 +373,21 @@ where
 
             print(&frontier, &weaken_set, "Weakening...".to_string());
             weaken_set.weaken(&cti);
-
-            // If enabled, extend CTI traces.
-            if extend.is_some() {
-                frontier.extend(fo, conf, &mut weaken_set);
-            }
-
-            print(&frontier, &weaken_set, "Advancing...".to_string());
-            frontier.advance(&weaken_set, false);
-
-            print(&frontier, &weaken_set, "Finding CTI...".to_string());
-        }
-
-        print(&frontier, &weaken_set, "Advancing...".to_string());
-    }
-
-    Some(weaken_set.minimized())
-}
-
-/// Run a simple fixpoint algorithm on the configured lemma domains.
-fn run_individual<O, L, B>(
-    infer_cfg: Arc<InferenceConfig>,
-    conf: &SolverConf,
-    fo: &FOModule,
-    atoms: Arc<RestrictedAtoms>,
-    domains: Vec<Domain<L>>,
-    extend: Option<(usize, usize)>,
-) -> Option<LemmaSet<O, L, B>>
-where
-    O: OrderSubsumption<Base = B>,
-    L: LemmaQf<Base = B>,
-    B: Clone + Debug + Send,
-{
-    let start = std::time::Instant::now();
-
-    log::debug!("Axioms:");
-    for a in fo.module.axioms.iter() {
-        log::debug!("    {a}");
-    }
-    log::debug!("Initial states:");
-    for a in fo.module.inits.iter() {
-        log::debug!("    {a}");
-    }
-    log::debug!("Transitions:");
-    for a in fo.module.transitions.iter() {
-        log::debug!("    {a}");
-    }
-
-    let print = |search: &IndividualLemmaSearch<O, L, B>, s: String| {
-        let len = search.len();
-        log::info!(
-            "[{:.2}s] [{} | {}] {}",
-            start.elapsed().as_secs_f32(),
-            len.1,
-            len.0,
-            s
-        );
-    };
-
-    let config = Arc::new(infer_cfg.cfg.clone());
-    let mut weaken_set: WeakenLemmaSet<O, L, B> =
-        WeakenLemmaSet::new(config.clone(), infer_cfg.clone(), atoms.clone(), domains);
-    weaken_set.init();
-    let empty: LemmaSet<O, L, B> = LemmaSet::new(config, &infer_cfg, atoms);
-    let mut individual_search = IndividualLemmaSearch {
-        weaken_set,
-        initial: empty.clone(),
-        inductive: empty,
-        extend,
-        ctis: VecDeque::new(),
-    };
-
-    // Begin by overapproximating the initial states.
-    print(&individual_search, "Initiation cycle...".to_string());
-    while individual_search.init_cycle(fo, conf) {
-        print(&individual_search, "Initiation cycle...".to_string());
-    }
-    print(
-        &individual_search,
-        "Initiation cycles complete.".to_string(),
-    );
-
-    loop {
-        print(&individual_search, "Extending CTI traces...".to_string());
-        if extend.is_some() {
-            individual_search.extend(fo, conf);
-        }
-        print(&individual_search, "Transition cycle...".to_string());
-        if !individual_search.trans_cycle(fo, conf) {
+        } else {
             break;
         }
     }
-    print(
-        &individual_search,
-        "Transition cycles complete.".to_string(),
-    );
 
-    Some(individual_search.inductive)
+    let proof = frontier.lemmas.to_terms();
+    print(&frontier, &weaken_set, "Checking safety...".to_string());
+    let safe = fo.trans_safe_cex(conf, &proof).is_none();
+    let time_taken = start.elapsed();
+    let covering = Some(invariant_cover(m, conf, fo, &proof));
+
+    FoundFixpoint {
+        proof: Some(proof),
+        safe,
+        time_taken,
+        covering,
+    }
 }

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -34,7 +34,7 @@ pub mod defaults {
     pub const MAX_CLAUSE_SIZE: Option<usize> = None;
     pub const MAX_CUBES: Option<usize> = Some(6);
     pub const MAX_CUBE_SIZE: Option<usize> = Some(4);
-    pub const MAX_NON_UNIT: Option<usize> = Some(6);
+    pub const MAX_NON_UNIT: Option<usize> = Some(3);
 }
 
 /// Check how much of the handwritten invariant the given lemmas cover.
@@ -81,6 +81,14 @@ pub struct FoundFixpoint {
 
 impl FoundFixpoint {
     pub fn report(&self, print_invariant: bool) {
+        let print_inv = |inv: &[Term]| {
+            println!("proof {{");
+            for lemma in inv {
+                println!("  invariant {lemma}");
+            }
+            println!("}}");
+        };
+
         println!("Fixpoint runtime = {:.2}s", self.time_taken.as_secs_f64());
 
         if self.safe {
@@ -97,23 +105,13 @@ impl FoundFixpoint {
                     covered_handwritten, size_handwritten
                 );
             }
-            if print_invariant {
-                println!("proof {{");
-                for lemma in proof {
-                    println!("  invariant {lemma}");
-                }
-                println!("}}");
-            }
-        }
 
-        if let Some(minimized_proof) = &self.minimized_proof {
-            println!("Minimized invariant size = {}", minimized_proof.len());
             if print_invariant {
-                println!("proof {{");
-                for lemma in minimized_proof {
-                    println!("  invariant {lemma}");
+                print_inv(&proof);
+                if let Some(minimized_proof) = &self.minimized_proof {
+                    println!("Safety invariant size = {}", minimized_proof.len());
+                    print_inv(&minimized_proof);
                 }
-                println!("}}");
             }
         }
     }

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -880,9 +880,7 @@ where
     /// Get a minimized inductive set of lemmas in the frame which inductively implies safety,
     /// provided that `is_safe` has been called and returned `true`.
     pub fn minimized_proof(&self) -> Option<Vec<Term>> {
-        if self.safety_core.is_none() {
-            return None;
-        }
+        self.safety_core.as_ref()?;
 
         let mut extended_core = HashSet::default();
         let mut new_ids = self.safety_core.as_ref().unwrap().clone();

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -1141,7 +1141,7 @@ where
         self.log_info("Finding CTI...");
         match self.trans_cex(fo, conf) {
             Some(cti) => {
-                self.log_info("CTI found, type=initial");
+                self.log_info("CTI found, type=transition");
                 self.log_info("Weakening...");
                 self.weaken_lemmas.weaken(&cti);
                 self.log_info("Updating frame...");

--- a/inference/src/lib.rs
+++ b/inference/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::new_without_default)]
 #![deny(clippy::uninlined_format_args)]
+#![allow(clippy::len_without_is_empty)]
 // documentation-related lints (only checked when running rustdoc)
 #![allow(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/inference/src/weaken.rs
+++ b/inference/src/weaken.rs
@@ -27,6 +27,8 @@ use fly::{
 
 use rayon::prelude::*;
 
+pub type Domain<L> = (Arc<QuantifierPrefix>, Arc<L>, Arc<RestrictedAtoms>);
+
 /// Extend an assignment by all possible assignments to the given variables
 /// over a domain containing the given number of elements.
 fn extend_assignment(
@@ -589,7 +591,7 @@ where
     pub fn minimized(&self) -> LemmaSet<O, L, B> {
         let mut lemmas: LemmaSet<O, L, B> =
             LemmaSet::new(self.config.clone(), &self.infer_cfg, self.atoms.clone());
-        for (prefix, body) in self.as_vec() {
+        for (prefix, body) in self.as_iter() {
             lemmas.insert_minimized(prefix.clone(), body.clone());
         }
 

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -397,11 +397,8 @@ impl<B: Backend> Solver<B> {
 
     /// Returns an unsat core as a set of indicator variables (a subset of the
     /// assumptions passed to `check_sat`).
-    pub fn get_unsat_core(&mut self) -> HashMap<Term, bool> {
-        let indicators = self
-            .proc
-            .get_unsat_assumptions()
-            .expect("could not get unsat assumptions");
+    pub fn get_unsat_core(&mut self) -> Result<HashMap<Term, bool>, SolverError> {
+        let indicators = self.proc.get_unsat_assumptions()?;
         let mut assumptions = HashMap::new();
         for t in indicators {
             // TODO: this is very ugly, replace with Sexp destructor methods
@@ -428,14 +425,14 @@ impl<B: Backend> Solver<B> {
             }
         }
         self.last_assumptions = None;
-        assumptions
+        Ok(assumptions)
     }
 
     /// After a call to check-sat returns unsat, get a minimized unsat core: a
     /// minimal set of indicator variables which still result in unsat.
     ///
     /// Not yet implemented so there is no algorithm here.
-    pub fn get_minimal_unsat_core(&mut self) -> HashMap<Term, bool> {
+    pub fn get_minimal_unsat_core(&mut self) -> Result<HashMap<Term, bool>, SolverError> {
         eprintln!("unsat code minimization is not yet implemented");
         self.get_unsat_core()
     }

--- a/temporal-verifier/examples/lockserver.fly
+++ b/temporal-verifier/examples/lockserver.fly
@@ -3,8 +3,8 @@
 
 # Lock server example, translated from mypyvy
 # TEST --all-solvers -- verify
-# TEST --name infer-z3 -- infer --no-print-invariant qalpha --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
-# TEST --name infer-cvc5 -- infer --no-print-invariant qalpha --solver cvc5 --quantifier "F node 2" --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance
+# TEST --name infer-z3 -- infer --no-print-invariant qalpha --until-safe --max-exist 0
+# TEST --name infer-cvc5 -- infer --no-print-invariant qalpha --solver cvc5 --until-safe --max-exist 0
 
 sort node
 

--- a/temporal-verifier/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
+++ b/temporal-verifier/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
@@ -1,8 +1,23 @@
 ---
 source: temporal-verifier/tests/test_examples.rs
-description: "--name=infer-cvc5.2 -- infer --no-print-invariant qalpha --solver cvc5 --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
+description: "--name=infer-cvc5.2 -- infer --no-print-invariant qalpha --solver cvc5 --until-safe --max-exist 0 examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
+Number of individual domains: 23
+
+(1) Running aqlpha algorithm...
+Approximate domain size: 10^2.12 (131)
+Prefixes:
+    forall node_1 --- 5 atoms --- pDNF { cubes: 3, cube_size: 0, non_unit: 0 } ~ 131
+Fixpoint UNSAFE!
+Fixpoint size = 0
+Covers 0 / 9 of handwritten invariant.
+
+(2) Running aqlpha algorithm...
+Approximate domain size: 10^3.15 (1404)
+Prefixes:
+    forall node_1 --- 5 atoms --- pDNF { cubes: 5, cube_size: 0, non_unit: 0 } ~ 243
+    forall node_1, node_2 --- 10 atoms --- pDNF { cubes: 3, cube_size: 0, non_unit: 0 } ~ 1161
 Fixpoint SAFE!
 Fixpoint size = 12
 Covers 9 / 9 of handwritten invariant.

--- a/temporal-verifier/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
+++ b/temporal-verifier/examples/snapshots/lockserver.fly.infer-cvc5.2.snap
@@ -5,7 +5,7 @@ expression: combined_stdout_stderr
 ---
 Number of individual domains: 23
 
-(1) Running aqlpha algorithm...
+(1) Running qalpha algorithm...
 Approximate domain size: 10^2.12 (131)
 Prefixes:
     forall node_1 --- 5 atoms --- pDNF { cubes: 3, cube_size: 0, non_unit: 0 } ~ 131
@@ -13,7 +13,7 @@ Fixpoint UNSAFE!
 Fixpoint size = 0
 Covers 0 / 9 of handwritten invariant.
 
-(2) Running aqlpha algorithm...
+(2) Running qalpha algorithm...
 Approximate domain size: 10^3.15 (1404)
 Prefixes:
     forall node_1 --- 5 atoms --- pDNF { cubes: 5, cube_size: 0, non_unit: 0 } ~ 243

--- a/temporal-verifier/examples/snapshots/lockserver.fly.infer-z3.1.snap
+++ b/temporal-verifier/examples/snapshots/lockserver.fly.infer-z3.1.snap
@@ -5,7 +5,7 @@ expression: combined_stdout_stderr
 ---
 Number of individual domains: 23
 
-(1) Running aqlpha algorithm...
+(1) Running qalpha algorithm...
 Approximate domain size: 10^2.12 (131)
 Prefixes:
     forall node_1 --- 5 atoms --- pDNF { cubes: 3, cube_size: 0, non_unit: 0 } ~ 131
@@ -13,7 +13,7 @@ Fixpoint UNSAFE!
 Fixpoint size = 0
 Covers 0 / 9 of handwritten invariant.
 
-(2) Running aqlpha algorithm...
+(2) Running qalpha algorithm...
 Approximate domain size: 10^3.15 (1404)
 Prefixes:
     forall node_1 --- 5 atoms --- pDNF { cubes: 5, cube_size: 0, non_unit: 0 } ~ 243

--- a/temporal-verifier/examples/snapshots/lockserver.fly.infer-z3.1.snap
+++ b/temporal-verifier/examples/snapshots/lockserver.fly.infer-z3.1.snap
@@ -1,8 +1,23 @@
 ---
 source: temporal-verifier/tests/test_examples.rs
-description: "--name=infer-z3.1 -- infer --no-print-invariant qalpha --quantifier 'F node 2' --qf-body cnf --clauses 1 --clause-size 3 --gradual-advance examples/lockserver.fly"
+description: "--name=infer-z3.1 -- infer --no-print-invariant qalpha --until-safe --max-exist 0 examples/lockserver.fly"
 expression: combined_stdout_stderr
 ---
+Number of individual domains: 23
+
+(1) Running aqlpha algorithm...
+Approximate domain size: 10^2.12 (131)
+Prefixes:
+    forall node_1 --- 5 atoms --- pDNF { cubes: 3, cube_size: 0, non_unit: 0 } ~ 131
+Fixpoint UNSAFE!
+Fixpoint size = 0
+Covers 0 / 9 of handwritten invariant.
+
+(2) Running aqlpha algorithm...
+Approximate domain size: 10^3.15 (1404)
+Prefixes:
+    forall node_1 --- 5 atoms --- pDNF { cubes: 5, cube_size: 0, non_unit: 0 } ~ 243
+    forall node_1, node_2 --- 10 atoms --- pDNF { cubes: 3, cube_size: 0, non_unit: 0 } ~ 1161
 Fixpoint SAFE!
 Fixpoint size = 12
 Covers 9 / 9 of handwritten invariant.

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -108,7 +108,7 @@ impl QuantifierConfigArgs {
             sorts = self
                 .sort
                 .iter()
-                .map(|s| sig.sort_idx(&Sort::Id(s.clone())))
+                .map(|s| sig.sort_idx(&Sort::Uninterpreted(s.clone())))
                 .collect();
             quantifiers = vec![None; sorts.len()];
             counts = vec![fixpoint::defaults::MAX_SAME_SORT; sorts.len()];

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -258,9 +258,9 @@ impl InferenceConfigArgs {
 
         if self.qf_body.is_none() {
             cfg.clauses = cfg.clauses.or(fixpoint::defaults::MAX_CLAUSES);
-            cfg.clause_size = cfg.clauses.or(fixpoint::defaults::MAX_CLAUSE_SIZE);
-            cfg.cubes = cfg.clauses.or(fixpoint::defaults::MAX_CUBES);
-            cfg.cube_size = cfg.clauses.or(fixpoint::defaults::MAX_CUBE_SIZE);
+            cfg.clause_size = cfg.clause_size.or(fixpoint::defaults::MAX_CLAUSE_SIZE);
+            cfg.cubes = cfg.cubes.or(fixpoint::defaults::MAX_CUBES);
+            cfg.cube_size = cfg.cube_size.or(fixpoint::defaults::MAX_CUBE_SIZE);
             cfg.non_unit = cfg.non_unit.or(fixpoint::defaults::MAX_NON_UNIT);
         }
 

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -196,10 +196,6 @@ struct InferenceConfigArgs {
     minimal_smt: bool,
 
     #[arg(long)]
-    /// Advance the prestate frontier gradually
-    gradual_advance: bool,
-
-    #[arg(long)]
     /// Try to extend model traces before looking for CEX in the frame
     extend_width: Option<usize>,
 

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -19,10 +19,10 @@ use codespan_reporting::{
         termcolor::{ColorChoice, StandardStream},
     },
 };
-use fly::syntax::Signature;
+use fly::syntax::{Signature, Sort};
 use fly::{self, parser::parse_error_diagnostic, printer, sorts, timing};
 use inference::basics::{parse_quantifier, InferenceConfig, QfBody};
-use inference::fixpoint::{fixpoint_multi_qf_body, fixpoint_single_qf_body};
+use inference::fixpoint::{self, qalpha_by_qf_body};
 use inference::houdini;
 use inference::quant::QuantifierConfig;
 use inference::updr::Updr;
@@ -81,25 +81,51 @@ struct VerifyArgs {
 
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
 struct QuantifierConfigArgs {
+    #[arg(long)]
+    /// Use a custom prefix, given either by the sort ordering (via `--sort`) or by exact quantifiers (via `--quantifier`).
+    /// Otherwise, use the sort ordering found in the loaded module
+    custom_prefix: bool,
+
     #[arg(short, long)]
-    /// Quantifier in the form `<quantifier: F/E/*> <sort> <var1> <var2> ...`.
+    /// Sorts in the order they should appear in the quantifier prefix
+    sort: Vec<String>,
+
+    #[arg(short, long)]
+    /// Quantifiers in the form `<quantifier: F/E/*> <sort> <var1> <var2> ...`
     quantifier: Vec<String>,
 }
 
 impl QuantifierConfigArgs {
     fn to_cfg(&self, sig: &Signature) -> QuantifierConfig {
-        let mut quantifiers = vec![];
-        let mut sorts = vec![];
-        let mut counts = vec![];
-        for quantifier_spec in &self.quantifier {
-            let r = parse_quantifier(sig, quantifier_spec);
-            match r {
-                Ok((q, sort, count)) => {
-                    quantifiers.push(q);
-                    sorts.push(sig.sort_idx(&sort));
-                    counts.push(count);
+        let mut quantifiers;
+        let mut sorts: Vec<usize>;
+        let mut counts: Vec<usize>;
+        if !self.custom_prefix {
+            sorts = (0..sig.sorts.len()).collect();
+            quantifiers = vec![None; sorts.len()];
+            counts = vec![fixpoint::defaults::MAX_SAME_SORT; sorts.len()];
+        } else if !self.sort.is_empty() {
+            sorts = self
+                .sort
+                .iter()
+                .map(|s| sig.sort_idx(&Sort::Id(s.clone())))
+                .collect();
+            quantifiers = vec![None; sorts.len()];
+            counts = vec![fixpoint::defaults::MAX_SAME_SORT; sorts.len()];
+        } else {
+            quantifiers = vec![];
+            sorts = vec![];
+            counts = vec![];
+            for quantifier_spec in &self.quantifier {
+                let r = parse_quantifier(sig, quantifier_spec);
+                match r {
+                    Ok((q, sort, count)) => {
+                        quantifiers.push(q);
+                        sorts.push(sig.sort_idx(&sort));
+                        counts.push(count);
+                    }
+                    Err(err) => panic!("{err}"),
                 }
-                Err(err) => panic!("{err}"),
             }
         }
         QuantifierConfig::new(Arc::new(sig.clone()), quantifiers, sorts, &counts)
@@ -112,41 +138,54 @@ struct InferenceConfigArgs {
     q_cfg_args: QuantifierConfigArgs,
 
     #[arg(long)]
-    qf_body: String,
+    /// Defines the type of quantifier-free body (cnf/pdnf/pdnf-naive)
+    qf_body: Option<String>,
 
     #[arg(long)]
+    /// Do not search gradually for the quantified serach space needed to find an invariant,
+    /// and instead begin with the maximal domain matching the specification.
+    no_search: bool,
+
+    #[arg(long)]
+    /// Defines the maximal size of the quantifier prefix
     max_size: Option<usize>,
 
     #[arg(long)]
+    /// Defines the maximal number of existential quantifiers
     max_exist: Option<usize>,
 
     #[arg(long)]
+    /// For a quantifier-free body in CNF, determines the maximal number of clauses
     clauses: Option<usize>,
 
     #[arg(long)]
+    /// For a quantifier-free body in CNF, determines the maximal size of each clause
     clause_size: Option<usize>,
 
     #[arg(long)]
+    /// For a quantifier-free body in DNF, determines the maximal number of cubes
     cubes: Option<usize>,
 
     #[arg(long)]
+    /// For a quantifier-free body in DNF, determines the maximal size of each cube
     cube_size: Option<usize>,
 
     #[arg(long)]
+    /// For a quantifier-free body which supports unit clauses/cubes, like pDNF,
+    /// this determines the maximal size of non-unit clauses/cubes
     non_unit: Option<usize>,
 
     #[arg(long)]
+    /// The maximal nesting depth of terms in the vocabulary (unbounded if not provided)
     nesting: Option<usize>,
 
     #[arg(long, action)]
+    /// Do not include equality terms in the vocabulary
     no_include_eq: bool,
 
-    #[arg(long, action)]
-    search: bool,
-
     #[arg(long)]
-    /// Try to decompose the transition relation disjunctively
-    disj: bool,
+    /// Do not try to decompose the transition relation disjunctively
+    no_disj: bool,
 
     #[arg(long)]
     /// Perform SMT queries gradually
@@ -161,34 +200,47 @@ struct InferenceConfigArgs {
     gradual_advance: bool,
 
     #[arg(long)]
-    /// Try to find individually inductive lemmas
-    indiv: bool,
-
-    #[arg(long)]
     /// Try to extend model traces before looking for CEX in the frame
     extend_width: Option<usize>,
 
     #[arg(long)]
     /// Try to extend model traces before looking for CEX in the frame
     extend_depth: Option<usize>,
+
+    #[arg(long)]
+    /// Launch no new runs after safety has been proven
+    until_safe: bool,
+
+    #[arg(long)]
+    /// Abort a run once it is evident that safety cannot be proven
+    abort_unsafe: bool,
+
+    #[arg(long)]
+    /// Grow the domain of quantified lemmas by this factor each iteration (default: 5)
+    growth_factor: Option<usize>,
 }
 
 impl InferenceConfigArgs {
     fn to_cfg(&self, sig: &Signature) -> InferenceConfig {
-        let qf_body = if self.qf_body.to_lowercase() == *"cnf" {
-            QfBody::CNF
-        } else if self.qf_body.to_lowercase() == *"pdnf" {
-            QfBody::PDnf
-        } else if self.qf_body.to_lowercase() == *"pdnf-naive" {
-            QfBody::PDnfNaive
-        } else {
-            panic!("Invalid choice of quantifier-free body!")
+        let qf_body = match &self.qf_body {
+            None => fixpoint::defaults::QF_BODY,
+            Some(qf_body_str) => {
+                if qf_body_str.to_lowercase() == *"cnf" {
+                    QfBody::CNF
+                } else if qf_body_str.to_lowercase() == *"pdnf" {
+                    QfBody::PDnf
+                } else if qf_body_str.to_lowercase() == *"pdnf-naive" {
+                    QfBody::PDnfNaive
+                } else {
+                    panic!("Invalid choice of quantifier-free body!")
+                }
+            }
         };
 
-        InferenceConfig {
+        let mut cfg = InferenceConfig {
             cfg: self.q_cfg_args.to_cfg(sig),
             qf_body,
-            max_size: self.max_size,
+            max_size: self.max_size.unwrap_or(fixpoint::defaults::MAX_QUANT),
             max_existentials: self.max_exist,
             clauses: self.clauses,
             clause_size: self.clause_size,
@@ -197,14 +249,26 @@ impl InferenceConfigArgs {
             non_unit: self.non_unit,
             nesting: self.nesting,
             include_eq: !self.no_include_eq,
-            disj: self.disj,
+            disj: !self.no_disj,
             gradual_smt: self.gradual_smt || self.minimal_smt,
             minimal_smt: self.minimal_smt,
-            gradual_advance: self.gradual_advance,
-            indiv: self.indiv,
             extend_width: self.extend_width,
             extend_depth: self.extend_depth,
+            no_search: self.no_search,
+            until_safe: self.until_safe,
+            abort_unsafe: self.abort_unsafe,
+            growth_factor: self.growth_factor,
+        };
+
+        if self.qf_body.is_none() {
+            cfg.clauses = cfg.clauses.or(fixpoint::defaults::MAX_CLAUSES);
+            cfg.clause_size = cfg.clauses.or(fixpoint::defaults::MAX_CLAUSE_SIZE);
+            cfg.cubes = cfg.clauses.or(fixpoint::defaults::MAX_CUBES);
+            cfg.cube_size = cfg.clauses.or(fixpoint::defaults::MAX_CUBE_SIZE);
+            cfg.non_unit = cfg.non_unit.or(fixpoint::defaults::MAX_NON_UNIT);
         }
+
+        cfg
     }
 }
 
@@ -539,16 +603,7 @@ impl App {
                 let conf = args.get_solver_conf();
                 m.inline_defs();
                 let infer_cfg = qargs.infer_cfg.to_cfg(&m.signature);
-                if qargs.infer_cfg.search {
-                    fixpoint_multi_qf_body(infer_cfg, &conf, &m)
-                } else {
-                    let fixpoint = fixpoint_single_qf_body(infer_cfg, &conf, &m);
-                    if args.no_print_invariant {
-                        fixpoint.test_report();
-                    } else {
-                        fixpoint.report();
-                    }
-                }
+                qalpha_by_qf_body(infer_cfg, &conf, &m, !args.no_print_invariant);
                 if args.time {
                     timing::report();
                 }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -84,7 +84,7 @@ struct QuantifierConfigArgs {
     #[arg(long)]
     /// Use a custom prefix, given either by the sort ordering (via `--sort`) or by exact quantifiers (via `--quantifier`).
     /// Otherwise, use the sort ordering found in the loaded module
-    custom_prefix: bool,
+    custom_quant: bool,
 
     #[arg(short, long)]
     /// Sorts in the order they should appear in the quantifier prefix
@@ -100,7 +100,7 @@ impl QuantifierConfigArgs {
         let mut quantifiers;
         let mut sorts: Vec<usize>;
         let mut counts: Vec<usize>;
-        if !self.custom_prefix {
+        if !self.custom_quant {
             sorts = (0..sig.sorts.len()).collect();
             quantifiers = vec![None; sorts.len()];
             counts = vec![fixpoint::defaults::MAX_SAME_SORT; sorts.len()];


### PR DESCRIPTION
This is an overhaul of the qalpha execution modes and their command-line arguments, as well as a clean-up and reorganization of the inference code. This includes:
- Removal of unused functionality which requires excessive maintenance and code duplication, such as searching for individually inductive lemmas via `--indiv` or gradually weakening the `Frontier` using `--gradual-advance`.
- Simplification of remaining functionality, such as replacing `Frontier` with the much simpler `InductionFrame`, and simplifying the `run_qalpha` code as a result.
- Changes to command-line arguments:
    - Instead of inputting the precise quantifier configuration using a sequence of `--quantifier`, the default mode now uses the sort order in the module file to generate a default quantifier configuration which should be enough to prove safety for all EPR examples, (provided that their sorts are ordered correctly.) This also includes a default for the quantifier-free body, although these can be set manually as before using `--qf-body`, `--cube-size`, etc.
    - To manually set the quantifier configuration, a new flag `--custom-quant` is introduced. It can be used to define a sort ordering different than the one in the file, using a sequence of `--sort` arguments, or to define a precise configuration using a sequence of `--quantifier` arguments as before.
    - `--disj` and `--search` have been replaced with `--no-disj` and `--no-search`, respectively, which means that by default, qalpha now splits the transition relation disjunctively when making SMT queries, and executes a gradual search over sub-domains of the quantifier configuration rather than using the precise, maximal specification (which is now accessible via `--no-search`.)
    - Added `--until-safe`, which halts the execution once a fixpoint was found which proves safety.
    - Added `--abort-unsafe`, which aborts a fixpoint computation once it is evident that it cannot prove safety.
- Additionally, due to the heavier use of the _search_ functionality, the exploration of sub-domains has been modified. Specifically, the domain of the fixpoint computation begins from some size (currently 100), and each iteration grows by some factor which can be set using `--growth-factor` (current default: 5). Growing the domain involves adding the smallest uncovered sub-domains until it passes the threshold for that iteration.
- Lastly, if a fixpoint has been found which proves safety, qalpha now prints both the entire fixpoint, as well as a minimized subset of it which is inductive and proves safety. This requires no extra computation, as this information exists in the UNSAT-cores generated by the safety check and by the inductiveness check of the fixpoint.