### PR TITLE
Make Spanned hold an Option<Span>

### DIFF
--- a/fly/src/parser.rs
+++ b/fly/src/parser.rs
@@ -176,7 +176,7 @@ grammar parser() for str {
 
       rule spanned<T>(e: rule<T>) -> Spanned<T>
       = start:position!() x:e() end:position!()
-        { Spanned {x, span: Span{start,end} } }
+        { Spanned {x, span: Some(Span{start,end}) } }
 
      // wrap a rule with tracing support, gated under the trace feature
      rule traced<T>(e: rule<T>) -> T =

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -179,9 +179,9 @@ pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Optio
             ThmStmt::Assume(term) => term_is_bool(&mut context, term, None)?,
             ThmStmt::Assert(proof) => {
                 for invariant in &mut proof.invariants {
-                    term_is_bool(&mut context, &mut invariant.x, Some(invariant.span))?
+                    term_is_bool(&mut context, &mut invariant.x, invariant.span)?
                 }
-                term_is_bool(&mut context, &mut proof.assert.x, Some(proof.assert.span))?
+                term_is_bool(&mut context, &mut proof.assert.x, proof.assert.span)?
             }
         }
     }
@@ -207,9 +207,9 @@ pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Optio
             ThmStmt::Assume(term) => fix_sorts(&mut context, term, None)?,
             ThmStmt::Assert(proof) => {
                 for invariant in &mut proof.invariants {
-                    fix_sorts(&mut context, &mut invariant.x, Some(invariant.span))?
+                    fix_sorts(&mut context, &mut invariant.x, invariant.span)?
                 }
-                fix_sorts(&mut context, &mut proof.assert.x, Some(proof.assert.span))?
+                fix_sorts(&mut context, &mut proof.assert.x, proof.assert.span)?
             }
         }
     }

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -741,7 +741,7 @@ pub struct Span {
 #[derive(PartialEq, Eq, Clone, Debug, Serialize)]
 pub struct Spanned<T> {
     pub x: T,
-    pub span: Span,
+    pub span: Option<Span>,
 }
 
 /// A Proof is an asserted boolean Term and a list of invariants to prove that

--- a/inference/src/houdini.rs
+++ b/inference/src/houdini.rs
@@ -44,7 +44,7 @@ impl Houdini {
     fn new(conf: SolverConf, sig: &Signature, assert: InvariantAssertion) -> Self {
         let mut invs = vec![assert.inv.x.clone()];
         // TODO: support customization of initial candidate invariants
-        invs.extend(assert.proof_invs.iter().map(|inv| inv.as_term().clone()));
+        invs.extend(assert.proof_invs.iter().map(|inv| inv.x.clone()));
         log::info!("Running Houdini, candidate invariants are:");
         for p in &invs {
             log::info!("    {p}")

--- a/temporal-verifier/src/concurrent.rs
+++ b/temporal-verifier/src/concurrent.rs
@@ -72,7 +72,7 @@ mod tests {
         // we'll assume proof_inv (all the invariants) in the pre state and try
         // to prove Next::prime(inv) in the post state for each proof invariant
         // separately
-        let proof_inv = Term::and(pf.invariants.iter().map(|inv| inv.as_term().clone()));
+        let proof_inv = Term::and(pf.invariants.iter().map(|inv| &inv.x));
         let task = Task::new();
         // rayon provides .par_iter(), which performs the invariant checks in
         // parallel; then we gather up a Vec of all the results due to the
@@ -101,7 +101,7 @@ mod tests {
                 solver.assert(&inv_assert.assumed_inv);
                 solver.assert(&Next::new(signature).prime(&inv_assert.assumed_inv));
                 solver.assert(&proof_inv);
-                solver.assert(&Term::negate(Next::new(signature).prime(inv.as_term())));
+                solver.assert(&Term::negate(Next::new(signature).prime(&inv.x)));
                 let resp = solver.check_sat(HashMap::new());
                 // if this check fails, don't start new checks
                 if matches!(resp, Ok(SatResp::Unsat) | Err(_)) {

--- a/verify/src/module.rs
+++ b/verify/src/module.rs
@@ -72,7 +72,7 @@ pub fn verify_destructured_module(
                     solver.save_tee();
                     if let Err(cex) = res {
                         Some(AssertionFailure {
-                            loc: span.unwrap_or(assert.inv.span),
+                            loc: span.or(assert.inv.span),
                             reason: FailureType::NotInductive,
                             error: cex,
                         })


### PR DESCRIPTION
This PR makes `Spanned<T>` hold an `Option<Span>` instead of a `Span`. It also removes `MaybeSpannedTerm` from `transitions.rs`, as it is no longer necessary.