### PR TITLE
Refactor model printing into a std::fmt::Display impl

### DIFF
--- a/fly/src/lib.rs
+++ b/fly/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::useless_format)]
 #![deny(clippy::uninlined_format_args)]
 // documentation-related lints (only checked when running rustdoc)
 #![warn(missing_docs)]

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -6,6 +6,7 @@
 use crate::{ouritertools::OurItertools, syntax::*};
 use itertools::Itertools;
 use serde::Serialize;
+use std::borrow::Borrow;
 
 use BinOp::*;
 use NOp::*;
@@ -383,7 +384,7 @@ impl std::fmt::Display for Model {
                     .map(|(typ, &idx)| fmt_element(typ, idx))
                     .collect::<Vec<_>>();
                 let args_s = if args_s.is_empty() {
-                    "".to_string()
+                    format!("")
                 } else {
                     format!("({})", args_s.join(","))
                 };
@@ -401,7 +402,6 @@ impl std::fmt::Display for Model {
     }
 }
 
-use std::borrow::Borrow;
 /// Print a list of models in a format suitable for display to the user.
 // ODED: I think we should also print the universe here
 pub fn models_to_string<I>(models: I) -> String

--- a/fly/src/semantics.rs
+++ b/fly/src/semantics.rs
@@ -3,14 +3,9 @@
 
 //! Model the semantics of flyvy functions under finite universes.
 
-use std::fmt::Write;
-use std::iter::zip;
-
+use crate::{ouritertools::OurItertools, syntax::*};
 use itertools::Itertools;
 use serde::Serialize;
-
-use crate::ouritertools::OurItertools;
-use crate::syntax::*;
 
 use BinOp::*;
 use NOp::*;
@@ -45,7 +40,7 @@ impl Interpretation {
     pub fn get(&self, args: &[Element]) -> Element {
         assert_eq!(self.shape.len() - 1, args.len());
         let mut index: usize = 0;
-        for (a, s) in zip(args, &self.shape) {
+        for (a, s) in args.iter().zip(&self.shape) {
             assert!(a < s);
             index = index * s + a;
         }
@@ -126,54 +121,6 @@ impl Model {
         };
         model.wf();
         model
-    }
-
-    fn fmt_element(sort: &Sort, element: Element) -> String {
-        match sort {
-            Sort::Bool => {
-                if element == 0 {
-                    "false".to_string()
-                } else {
-                    "true".to_string()
-                }
-            }
-            Sort::Uninterpreted(s) => format!("@{s}_{element}"),
-        }
-    }
-
-    fn fmt_rel(&self, decl: &RelationDecl, interp: &Interpretation) -> String {
-        let mut lines = vec![];
-        let arg_shape = &interp.shape[..interp.shape.len() - 1];
-        let args_list = arg_shape
-            .iter()
-            .map(|&card| (0..card).collect::<Vec<Element>>())
-            .multi_cartesian_product_fixed()
-            .collect::<Vec<_>>();
-        for args in args_list {
-            let name = &decl.name;
-            let args_s = zip(&decl.args, args.iter())
-                .map(|(typ, &idx)| Self::fmt_element(typ, idx))
-                .collect::<Vec<_>>();
-            let args_s = if args_s.is_empty() {
-                "".to_string()
-            } else {
-                format!("({})", args_s.join(","))
-            };
-            let ret_s = Self::fmt_element(&decl.sort, interp.get(&args));
-            lines.push(format!("{name}{args_s} = {ret_s}"));
-        }
-        lines.join("\n")
-    }
-
-    /// Print a model in a format suitable for display to the user.
-    // ODED: I think we should also print the universe here
-    pub fn fmt(&self) -> String {
-        let mut w = String::new();
-        for (rel, interp) in zip(&self.signature.relations, &self.interp) {
-            let rel_s = self.fmt_rel(rel, interp);
-            _ = writeln!(&mut w, "{rel_s}");
-        }
-        w
     }
 
     /// Evaluate a term to a model element.
@@ -279,7 +226,7 @@ impl Model {
                     .map(|elements| {
                         // extend assignment with all variables bound to these `elements`
                         let mut assignment = assignment.clone();
-                        for (name, element) in zip(&names, elements) {
+                        for (name, element) in names.iter().zip(elements) {
                             assignment.insert(name.to_string(), element);
                         }
                         self.eval_assign(body, assignment) == 1
@@ -405,6 +352,68 @@ impl Model {
             body: Box::new(Term::NAryOp(NOp::And, terms.pop().unwrap())),
         }
     }
+}
+
+impl std::fmt::Display for Model {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn fmt_rel(decl: &RelationDecl, interp: &Interpretation) -> String {
+            fn fmt_element(sort: &Sort, element: Element) -> String {
+                match sort {
+                    Sort::Bool => match element {
+                        0 => "false".to_string(),
+                        1 => "true".to_string(),
+                        _ => unreachable!(),
+                    },
+                    Sort::Uninterpreted(s) => format!("@{s}_{element}"),
+                }
+            }
+
+            let mut lines = vec![];
+            let args_list = interp.shape[..interp.shape.len() - 1]
+                .iter()
+                .map(|&card| (0..card).collect::<Vec<Element>>())
+                .multi_cartesian_product_fixed()
+                .collect::<Vec<_>>();
+            for args in args_list {
+                let name = &decl.name;
+                let args_s = decl
+                    .args
+                    .iter()
+                    .zip(&args)
+                    .map(|(typ, &idx)| fmt_element(typ, idx))
+                    .collect::<Vec<_>>();
+                let args_s = if args_s.is_empty() {
+                    "".to_string()
+                } else {
+                    format!("({})", args_s.join(","))
+                };
+                let ret_s = fmt_element(&decl.sort, interp.get(&args));
+                lines.push(format!("{name}{args_s} = {ret_s}"));
+            }
+            lines.join("\n")
+        }
+
+        assert_eq!(self.signature.relations.len(), self.interp.len());
+        for (rel, interp) in self.signature.relations.iter().zip(&self.interp) {
+            writeln!(f, "{}", fmt_rel(rel, interp))?;
+        }
+        Ok(())
+    }
+}
+
+use std::borrow::Borrow;
+/// Print a list of models in a format suitable for display to the user.
+// ODED: I think we should also print the universe here
+pub fn models_to_string<I>(models: I) -> String
+where
+    I: IntoIterator,
+    I::Item: Borrow<Model>,
+{
+    models
+        .into_iter()
+        .enumerate()
+        .map(|(i, model)| format!("state {i}:\n{}", model.borrow()))
+        .join("\n")
 }
 
 #[cfg(test)]
@@ -585,7 +594,7 @@ mod tests {
 
         model.wf();
 
-        println!("model is:\n{}\n", model.fmt());
+        println!("model is:\n{model}\n");
 
         let f = Literal(false);
         let t = Literal(true);

--- a/inference/src/updr.rs
+++ b/inference/src/updr.rs
@@ -179,10 +179,10 @@ impl Updr {
                         num_steps_to_bad: steps_from_cex,
                     };
                     if let TermOrModel::Model(m) = bstate.term_or_model.clone() {
-                        println!("managed to reach {}", m.fmt());
+                        println!("managed to reach {m}");
                     }
                     if let TermOrModel::Term(t) = bstate.term_or_model.clone() {
-                        println!("managed to reach {}", &t);
+                        println!("managed to reach {t}");
                     }
                     self.backwards_reachable_states.push(bstate);
                     trace.push((trans.clone(), TermOrModel::Model(pred.clone())));

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -19,6 +19,7 @@ use codespan_reporting::{
         termcolor::{ColorChoice, StandardStream},
     },
 };
+use fly::semantics::models_to_string;
 use fly::syntax::{Signature, Sort};
 use fly::{self, parser::parse_error_diagnostic, printer, sorts, timing};
 use inference::basics::{parse_quantifier, InferenceConfig, QfBody};
@@ -630,11 +631,10 @@ impl App {
                     bounded.print_timing.unwrap_or(true),
                 ) {
                     Ok(bounded::set::CheckerAnswer::Counterexample(models)) => {
-                        println!("found counterexample:");
-                        for (i, model) in models.iter().enumerate() {
-                            println!("state {i}:");
-                            println!("{}", back_convert_model(model).fmt());
-                        }
+                        println!(
+                            "found counterexample:\n{}",
+                            models_to_string(models.iter().map(back_convert_model))
+                        )
                     }
                     Ok(bounded::set::CheckerAnswer::Unknown) => {
                         println!(
@@ -664,11 +664,10 @@ impl App {
                 let univ = bounded.get_universe(&m.signature);
                 match bounded::sat::check(&m, &univ, depth, bounded.print_timing.unwrap_or(true)) {
                     Ok(bounded::sat::CheckerAnswer::Counterexample(models)) => {
-                        println!("found counterexample:");
-                        for (i, model) in models.iter().enumerate() {
-                            println!("state {i}:");
-                            println!("{}", back_convert_model(model).fmt());
-                        }
+                        println!(
+                            "found counterexample:\n{}",
+                            models_to_string(models.iter().map(back_convert_model))
+                        )
                     }
                     Ok(bounded::sat::CheckerAnswer::Unknown) => {
                         println!("answer: safe up to depth {depth} for given sort bounds")
@@ -691,11 +690,10 @@ impl App {
                     bounded.print_timing.unwrap_or(true),
                 ) {
                     Ok(bounded::bdd::CheckerAnswer::Counterexample(models)) => {
-                        println!("found counterexample:");
-                        for (i, model) in models.iter().enumerate() {
-                            println!("state {i}:");
-                            println!("{}", back_convert_model(model).fmt());
-                        }
+                        println!(
+                            "found counterexample:\n{}",
+                            models_to_string(models.iter().map(back_convert_model))
+                        )
                     }
                     Ok(bounded::bdd::CheckerAnswer::Unknown) => {
                         println!(
@@ -728,11 +726,7 @@ impl App {
                     bounded.print_timing.unwrap_or(true),
                 ) {
                     Ok(bounded::smt::CheckerAnswer::Counterexample(models)) => {
-                        println!("found counterexample:");
-                        for (i, model) in models.iter().enumerate() {
-                            println!("state {i}:");
-                            println!("{}", model.fmt());
-                        }
+                        println!("found counterexample:\n{}", models_to_string(models))
                     }
                     Ok(bounded::smt::CheckerAnswer::Unknown) => {
                         println!("answer: safe up to depth {depth} for given sort bounds")

--- a/verify/src/error.rs
+++ b/verify/src/error.rs
@@ -4,7 +4,7 @@
 //! Contains error types for verification.
 
 use codespan_reporting::diagnostic::{Diagnostic, Label};
-use fly::semantics::Model;
+use fly::semantics::{models_to_string, Model};
 use fly::syntax::Span;
 use serde::Serialize;
 
@@ -53,12 +53,7 @@ impl AssertionFailure {
             .with_message(msg)
             .with_notes(vec![match &self.error {
                 QueryError::Sat(models) => {
-                    let mut message = "counter example:".to_string();
-                    for (i, model) in models.iter().enumerate() {
-                        message.push_str(&format!("\nstate {i}:\n"));
-                        message.push_str(&model.fmt());
-                    }
-                    message
+                    format!("counter example:\n{}", models_to_string(models))
                 }
                 QueryError::Unknown(err) => format!("smt solver returned unknown: {err}"),
             }]);


### PR DESCRIPTION
This PR moves `Model` formatting from a `.fmt` method to a `std::fmt::Display` impl. It also adds a `models_to_string` method which consolidates the code for printing a list of models from `command.rs` and `error.rs`.