### PR TITLE
Use multiple solvers in qalpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "fly",
  "itertools",
  "lazy_static",
+ "log",
  "pretty_env_logger",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "lazy_static",
  "log",
  "pretty_env_logger",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",

--- a/inference/src/atoms.rs
+++ b/inference/src/atoms.rs
@@ -57,7 +57,7 @@ pub struct Atoms {
 }
 
 impl Atoms {
-    pub fn new(infer_cfg: &InferenceConfig, conf: &SolverConf, fo: &FOModule) -> Self {
+    pub fn new(infer_cfg: &InferenceConfig, confs: &[&SolverConf], fo: &FOModule) -> Self {
         let univ_prefix = infer_cfg.cfg.as_universal();
         let to_term = infer_cfg
             .cfg
@@ -67,8 +67,8 @@ impl Atoms {
                 let univ_t = univ_prefix.quantify(t.clone());
                 let univ_not_t = univ_prefix.quantify(Term::negate(t.clone()));
 
-                fo.implication_cex(conf, &[], &univ_t).is_some()
-                    && fo.implication_cex(conf, &[], &univ_not_t).is_some()
+                fo.implication_cex(confs, &[], &univ_t).is_cex()
+                    && fo.implication_cex(confs, &[], &univ_not_t).is_cex()
             })
             .collect_vec();
         let to_index = to_term

--- a/inference/src/atoms.rs
+++ b/inference/src/atoms.rs
@@ -15,7 +15,7 @@ use crate::{
     lemma::ids,
     quant::{QuantifierConfig, QuantifierPrefix},
 };
-use solver::conf::SolverConf;
+use solver::basics::BasicSolver;
 
 use rayon::prelude::*;
 
@@ -59,7 +59,7 @@ pub struct Atoms {
 }
 
 impl Atoms {
-    pub fn new(infer_cfg: &InferenceConfig, confs: &[&SolverConf], fo: &FOModule) -> Self {
+    pub fn new<B: BasicSolver>(infer_cfg: &InferenceConfig, solver: &B, fo: &FOModule) -> Self {
         let univ_prefix = infer_cfg.cfg.as_universal();
         let to_term: Vec<Term> = infer_cfg
             .cfg
@@ -69,8 +69,8 @@ impl Atoms {
                 let univ_t = univ_prefix.quantify(t.clone());
                 let univ_not_t = univ_prefix.quantify(Term::negate(t.clone()));
 
-                fo.implication_cex(confs, &[], &univ_t).is_cex()
-                    && fo.implication_cex(confs, &[], &univ_not_t).is_cex()
+                fo.implication_cex(solver, &[], &univ_t).is_cex()
+                    && fo.implication_cex(solver, &[], &univ_not_t).is_cex()
             })
             .collect();
         let to_index = to_term

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -592,6 +592,7 @@ pub enum QfBody {
 pub struct InferenceConfig {
     pub fname: String,
 
+    pub fallback: bool,
     pub cfg: QuantifierConfig,
     pub qf_body: QfBody,
 

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -283,7 +283,7 @@ impl FOModule {
         let display = |conf: &SolverConf| -> String {
             format!(
                 "{:?}(timeout={})",
-                conf.get_solver_type(),
+                conf.solver_type(),
                 conf.get_timeout_ms().unwrap_or(0) as f32 / 1000_f32
             )
         };

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -145,7 +145,8 @@ impl<'a> Core<'a> {
 /// Maintains a set of [`SmtPid`]'s which can be canceled whenever necessary.
 /// Composed of a `bool` which tracks whether the set has been canceled, followed by the
 /// [`SmtPid`]'s of the solvers it contains.
-pub struct SolverPids(Mutex<(bool, Vec<SmtPid>)>);
+#[derive(Clone)]
+pub struct SolverPids(Arc<Mutex<(bool, Vec<SmtPid>)>>);
 
 impl Default for SolverPids {
     fn default() -> Self {
@@ -156,7 +157,7 @@ impl Default for SolverPids {
 impl SolverPids {
     /// Create a new empty [`SolverPids`].
     pub fn new() -> Self {
-        SolverPids(Mutex::new((false, vec![])))
+        SolverPids(Arc::new(Mutex::new((false, vec![]))))
     }
 
     /// Add the given [`SmtPid`] to the [`SolverPids`].
@@ -273,7 +274,7 @@ impl FOModule {
         hyp: &[Term],
         t: &Term,
         with_safety: bool,
-        solver_pids: Option<Arc<SolverPids>>,
+        solver_pids: Option<SolverPids>,
     ) -> CexResult {
         let transitions = self.disj_trans();
         let pids = solver_pids.unwrap_or_default();

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -78,12 +78,12 @@ impl<'a> Core<'a> {
             assert_eq!(counter_model.eval(&self.formulas[p_idx]), 1);
         }
 
-        let new_participant = (0..self.formulas.len()).find(|i| {
-            !self.participants.contains(i) && counter_model.eval(&self.formulas[*i]) == 0
+        let new_participant = self.formulas.iter().enumerate().find(|(i, formula)| {
+            !self.participants.contains(i) && counter_model.eval(formula) == 0
         });
 
         match new_participant {
-            Some(p_idx) => {
+            Some((p_idx, _)) => {
                 let model_idx = self.counter_models.len();
                 self.participants.insert(p_idx);
                 self.to_participants.insert(model_idx, HashSet::new());
@@ -386,8 +386,10 @@ impl FOModule {
             .collect();
 
         // Check whether any counterexample has been found
-        if let Some(i) =
-            (0..cex_results.len()).find(|i| matches!(cex_results[*i], CexResult::Cex(_)))
+        if let Some((i, _)) = cex_results
+            .iter()
+            .enumerate()
+            .find(|(_, res)| matches!(res, CexResult::Cex(_)))
         {
             return cex_results.remove(i);
         }

--- a/inference/src/basics.rs
+++ b/inference/src/basics.rs
@@ -273,7 +273,6 @@ impl FOModule {
         confs: &[&SolverConf],
         hyp: &[Term],
         t: &Term,
-        with_init: bool,
         with_safety: bool,
         solver_pids: Option<&SolverPids>,
     ) -> CexResult {
@@ -299,13 +298,8 @@ impl FOModule {
                 ));
             }
 
-            if with_init {
-                let init = Term::and(self.module.inits.iter().cloned());
-                solver.assert(&Term::or([init, Term::and(prestate)]));
-            } else {
-                for p in &prestate {
-                    solver.assert(p)
-                }
+            for p in &prestate {
+                solver.assert(p)
             }
 
             for a in &self.module.axioms {
@@ -321,11 +315,6 @@ impl FOModule {
                 for a in &self.module.proofs {
                     solver.assert(&a.safety.x);
                 }
-            }
-
-            if with_init {
-                let init = Term::and(self.module.inits.iter().cloned());
-                solver.assert(&Term::negate(Next::new(&self.signature).prime(&init)));
             }
 
             solver.assert(&Term::negate(Next::new(&self.signature).prime(t)));
@@ -632,7 +621,7 @@ impl FOModule {
     pub fn trans_safe_cex(&self, confs: &[&SolverConf], hyp: &[Term]) -> CexResult {
         let mut core = HashSet::new();
         for s in self.module.proofs.iter() {
-            match self.trans_cex(confs, hyp, &s.safety.x, false, true, None) {
+            match self.trans_cex(confs, hyp, &s.safety.x, true, None) {
                 CexResult::UnsatCore(new_core) => core.extend(new_core),
                 res => return res,
             }

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -127,14 +127,20 @@ fn parallel_solver(infer_cfg: &InferenceConfig) -> impl BasicSolver {
 }
 
 fn fallback_solver(infer_cfg: &InferenceConfig) -> impl BasicSolver {
+    // For the solvers in fallback fashion we alternate between Z3 and CVC5
+    // with increasing timeouts and varying seeds, ending with a Z3 solver with
+    // no timeout. The idea is to try both Z3 and CVC5 with some timeout to see if any
+    // of them solve the query, and gradually increase the timeout for both,
+    // ending with no timeout at all. The seed changes are meant to add some
+    // variation vis-a-vis previous attempts.
     FallbackSolvers::new(vec![
-        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 3, 1),
-        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 3, 2),
-        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 60, 3),
-        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 60, 4),
-        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 600, 5),
-        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 600, 6),
-        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 0, 7),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 3, 0),
+        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 3, 0),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 60, 1),
+        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 60, 1),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 600, 2),
+        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 600, 2),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 0, 3),
     ])
 }
 

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -19,7 +19,7 @@ use crate::{
     weaken::{Domain, LemmaQf},
 };
 use fly::syntax::{Module, Term, ThmStmt};
-use solver::conf::SolverConf;
+use solver::{backends::SolverType, conf::SolverConf};
 
 use rayon::prelude::*;
 
@@ -40,7 +40,7 @@ pub mod defaults {
 /// Check how much of the handwritten invariant the given lemmas cover.
 fn invariant_cover(
     m: &Module,
-    conf: &SolverConf,
+    confs: &[&SolverConf],
     fo: &FOModule,
     lemmas: &[Term],
 ) -> (usize, usize) {
@@ -57,7 +57,7 @@ fn invariant_cover(
     let covered = proof
         .invariants
         .par_iter()
-        .filter(|inv| fo.implication_cex(conf, lemmas, &inv.x).is_none())
+        .filter(|inv| !fo.implication_cex(confs, lemmas, &inv.x).is_cex())
         .count();
 
     (covered, proof.invariants.len())
@@ -115,23 +115,31 @@ impl FoundFixpoint {
     }
 }
 
-pub fn qalpha<O, L, B>(
-    infer_cfg: InferenceConfig,
-    conf: &SolverConf,
-    m: &Module,
-    print_invariant: bool,
-) where
+pub fn qalpha<O, L, B>(infer_cfg: InferenceConfig, m: &Module, print_invariant: bool)
+where
     O: OrderSubsumption<Base = B>,
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
 {
+    let solver_confs = [
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 3, 1),
+        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 3, 2),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 60, 3),
+        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 60, 4),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 600, 5),
+        SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 600, 6),
+        SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 0, 7),
+    ];
+    let confs = solver_confs.iter().collect_vec();
+    let simulation_conf = SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 3, 0);
+
     let fo = FOModule::new(
         m,
         infer_cfg.disj,
         infer_cfg.gradual_smt,
         infer_cfg.minimal_smt,
     );
-    let atoms = Arc::new(Atoms::new(&infer_cfg, conf, &fo));
+    let atoms = Arc::new(Atoms::new(&infer_cfg, &confs, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let infer_cfg = Arc::new(infer_cfg);
     let extend = match (infer_cfg.extend_width, infer_cfg.extend_depth) {
@@ -228,7 +236,8 @@ pub fn qalpha<O, L, B>(
 
         let fixpoint = run_qalpha::<O, L, B>(
             infer_cfg.clone(),
-            conf,
+            &confs,
+            &simulation_conf,
             m,
             &fo,
             unrestricted.clone(),
@@ -250,35 +259,32 @@ pub fn qalpha<O, L, B>(
     }
 }
 
-pub fn qalpha_by_qf_body(
-    infer_cfg: InferenceConfig,
-    conf: &SolverConf,
-    m: &Module,
-    print_invariant: bool,
-) {
+pub fn qalpha_by_qf_body(infer_cfg: InferenceConfig, m: &Module, print_invariant: bool) {
     match infer_cfg.qf_body {
         QfBody::CNF => qalpha::<
             subsume::Cnf<atoms::Literal>,
             lemma::LemmaCnf,
             Vec<Vec<atoms::Literal>>,
-        >(infer_cfg, conf, m, print_invariant),
+        >(infer_cfg, m, print_invariant),
         QfBody::PDnf => qalpha::<
             subsume::PDnf<atoms::Literal>,
             lemma::LemmaPDnf,
             (Vec<atoms::Literal>, Vec<Vec<atoms::Literal>>),
-        >(infer_cfg, conf, m, print_invariant),
+        >(infer_cfg, m, print_invariant),
         QfBody::PDnfNaive => qalpha::<
             subsume::Dnf<atoms::Literal>,
             lemma::LemmaPDnfNaive,
             Vec<Vec<atoms::Literal>>,
-        >(infer_cfg, conf, m, print_invariant),
+        >(infer_cfg, m, print_invariant),
     }
 }
 
 /// Run the qalpha algorithm on the configured lemma domains.
+#[allow(clippy::too_many_arguments)]
 fn run_qalpha<O, L, B>(
     infer_cfg: Arc<InferenceConfig>,
-    conf: &SolverConf,
+    confs: &[&SolverConf],
+    simulation_conf: &SolverConf,
     m: &Module,
     fo: &FOModule,
     atoms: Arc<RestrictedAtoms>,
@@ -309,18 +315,18 @@ where
         InductionFrame::new(infer_cfg.clone(), atoms, domains, extend);
 
     // Begin by overapproximating the initial states.
-    while frame.init_cycle(fo, conf) {}
+    while frame.init_cycle(fo, confs) {}
 
     // Handle transition CTI's.
     loop {
         // If enabled, extend CTI traces using simulations.
         if extend.is_some() {
-            frame.extend(fo, conf);
+            frame.extend(fo, simulation_conf);
         }
 
         if infer_cfg.abort_unsafe {
             frame.log_info("Checking safety...");
-            if !frame.is_safe(fo, conf) {
+            if !frame.is_safe(fo, confs) {
                 return FoundFixpoint {
                     proof: None,
                     minimized_proof: None,
@@ -331,17 +337,17 @@ where
             }
         }
 
-        if !frame.trans_cycle(fo, conf) {
+        if !frame.trans_cycle(fo, confs) {
             break;
         }
     }
 
     frame.log_info("Checking safety...");
-    let safe = frame.is_safe(fo, conf);
+    let safe = frame.is_safe(fo, confs);
     let time_taken = start.elapsed();
     let proof: Vec<Term> = frame.proof();
     let minimized_proof = frame.minimized_proof();
-    let covering = Some(invariant_cover(m, conf, fo, &proof));
+    let covering = Some(invariant_cover(m, confs, fo, &proof));
 
     FoundFixpoint {
         proof: Some(proof),

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -19,7 +19,11 @@ use crate::{
     weaken::{Domain, LemmaQf},
 };
 use fly::syntax::{Module, Term, ThmStmt};
-use solver::{backends::SolverType, conf::SolverConf};
+use solver::{
+    backends::SolverType,
+    basics::{BasicSolver, FallbackSolvers, SingleSolver},
+    conf::SolverConf,
+};
 
 use rayon::prelude::*;
 
@@ -38,9 +42,9 @@ pub mod defaults {
 }
 
 /// Check how much of the handwritten invariant the given lemmas cover.
-fn invariant_cover(
+fn invariant_cover<S: BasicSolver>(
     m: &Module,
-    confs: &[&SolverConf],
+    solver: &S,
     fo: &FOModule,
     lemmas: &[Term],
 ) -> (usize, usize) {
@@ -57,7 +61,7 @@ fn invariant_cover(
     let covered = proof
         .invariants
         .par_iter()
-        .filter(|inv| !fo.implication_cex(confs, lemmas, &inv.x).is_cex())
+        .filter(|inv| !fo.implication_cex(solver, lemmas, &inv.x).is_cex())
         .count();
 
     (covered, proof.invariants.len())
@@ -121,7 +125,7 @@ where
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
 {
-    let solver_confs = [
+    let main_solver = FallbackSolvers::new(vec![
         SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 3, 1),
         SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 3, 2),
         SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 60, 3),
@@ -129,10 +133,14 @@ where
         SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 600, 5),
         SolverConf::new(SolverType::Cvc5, true, &infer_cfg.fname, 600, 6),
         SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 0, 7),
-    ];
-    let confs = solver_confs.iter().collect_vec();
-    let simulation_conf = SolverConf::new(SolverType::Z3, true, &infer_cfg.fname, 3, 0);
-
+    ]);
+    let simulation_solver = SingleSolver::new(SolverConf::new(
+        SolverType::Z3,
+        true,
+        &infer_cfg.fname,
+        3,
+        0,
+    ));
     let fo = FOModule::new(
         m,
         infer_cfg.disj,
@@ -140,7 +148,7 @@ where
         infer_cfg.minimal_smt,
     );
     log::debug!("Computing atoms...");
-    let atoms = Arc::new(Atoms::new(&infer_cfg, &confs, &fo));
+    let atoms = Arc::new(Atoms::new(&infer_cfg, &main_solver, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let infer_cfg = Arc::new(infer_cfg);
     let extend = match (infer_cfg.extend_width, infer_cfg.extend_depth) {
@@ -236,10 +244,10 @@ where
             );
         }
 
-        let fixpoint = run_qalpha::<O, L, B>(
+        let fixpoint = run_qalpha::<O, L, B, _, _>(
             infer_cfg.clone(),
-            &confs,
-            &simulation_conf,
+            &main_solver,
+            &simulation_solver,
             m,
             &fo,
             unrestricted.clone(),
@@ -283,10 +291,10 @@ pub fn qalpha_by_qf_body(infer_cfg: InferenceConfig, m: &Module, print_invariant
 
 /// Run the qalpha algorithm on the configured lemma domains.
 #[allow(clippy::too_many_arguments)]
-fn run_qalpha<O, L, B>(
+fn run_qalpha<O, L, B, S1, S2>(
     infer_cfg: Arc<InferenceConfig>,
-    confs: &[&SolverConf],
-    simulation_conf: &SolverConf,
+    main_solver: &S1,
+    simulation_solver: &S2,
     m: &Module,
     fo: &FOModule,
     atoms: Arc<RestrictedAtoms>,
@@ -297,6 +305,8 @@ where
     O: OrderSubsumption<Base = B>,
     L: LemmaQf<Base = B>,
     B: Clone + Debug + Send,
+    S1: BasicSolver,
+    S2: BasicSolver,
 {
     let start = std::time::Instant::now();
 
@@ -317,18 +327,18 @@ where
         InductionFrame::new(infer_cfg.clone(), atoms, domains, extend);
 
     // Begin by overapproximating the initial states.
-    while frame.init_cycle(fo, confs) {}
+    while frame.init_cycle(fo, main_solver) {}
 
     // Handle transition CTI's.
     loop {
         // If enabled, extend CTI traces using simulations.
         if extend.is_some() {
-            frame.extend(fo, simulation_conf);
+            frame.extend(fo, simulation_solver);
         }
 
         if infer_cfg.abort_unsafe {
             frame.log_info("Checking safety...");
-            if !frame.is_safe(fo, confs) {
+            if !frame.is_safe(fo, main_solver) {
                 return FoundFixpoint {
                     proof: None,
                     minimized_proof: None,
@@ -339,17 +349,17 @@ where
             }
         }
 
-        if !frame.trans_cycle(fo, confs) {
+        if !frame.trans_cycle(fo, main_solver) {
             break;
         }
     }
 
     frame.log_info("Checking safety...");
-    let safe = frame.is_safe(fo, confs);
+    let safe = frame.is_safe(fo, main_solver);
     let time_taken = start.elapsed();
     let proof: Vec<Term> = frame.proof();
     let minimized_proof = frame.minimized_proof();
-    let covering = Some(invariant_cover(m, confs, fo, &proof));
+    let covering = Some(invariant_cover(m, main_solver, fo, &proof));
 
     FoundFixpoint {
         proof: Some(proof),

--- a/inference/src/fixpoint.rs
+++ b/inference/src/fixpoint.rs
@@ -139,6 +139,7 @@ where
         infer_cfg.gradual_smt,
         infer_cfg.minimal_smt,
     );
+    log::debug!("Computing atoms...");
     let atoms = Arc::new(Atoms::new(&infer_cfg, &confs, &fo));
     let unrestricted = Arc::new(restrict(&atoms, |_| true));
     let infer_cfg = Arc::new(infer_cfg);
@@ -157,6 +158,7 @@ where
             .sum()
     };
 
+    log::debug!("Computing predicate domains...");
     if infer_cfg.no_search {
         domains = VecDeque::new();
         active_domains = infer_cfg

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -5,7 +5,7 @@
 
 use fly::ouritertools::OurItertools;
 use itertools::Itertools;
-use solver::basics::{BasicSolver, SolverCancelers};
+use solver::basics::{BasicSolver, BasicSolverCanceler, SolverCancelers};
 use std::collections::VecDeque;
 use std::fmt::{Debug, Display};
 use std::sync::{Arc, Mutex, RwLock};
@@ -1052,7 +1052,7 @@ where
     fn trans_cex<S: BasicSolver>(&mut self, fo: &FOModule, solver: &S) -> Option<Model> {
         let (pre_ids, pre_terms): (Vec<usize>, Vec<Term>) = self.lemmas.to_terms_ids().unzip();
 
-        let cancelers: SolverCancelers<<S as BasicSolver>::Canceler> = SolverCancelers::new();
+        let cancelers = SolverCancelers::new();
         let unknown = Mutex::new(false);
         let first_sat = Mutex::new(None);
         let total_sat = Mutex::new(0_usize);
@@ -1088,6 +1088,7 @@ where
                     false,
                 ) {
                     CexResult::Cex(mut models) => {
+                        cancelers.cancel();
                         {
                             let mut first_sat_lock = first_sat.lock().unwrap();
                             if first_sat_lock.is_none() {

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -1079,7 +1079,7 @@ where
                 let lemma_id = self.lemmas.get_id(&prefix, body)?;
                 let pre_ids: &[usize] = &[&[lemma_id], &pre_ids[..]].concat();
                 let pre_terms: &[Term] = &[&[term.clone()], &pre_terms[..]].concat();
-                match fo.trans_cex(confs, pre_terms, &term, false, false, Some(&solver_pids)) {
+                match fo.trans_cex(confs, pre_terms, &term, false, Some(&solver_pids)) {
                     CexResult::Cex(mut models) => {
                         solver_pids.cancel();
                         {

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -1052,7 +1052,7 @@ where
     fn trans_cex(&mut self, fo: &FOModule, confs: &[&SolverConf]) -> Option<Model> {
         let (pre_ids, pre_terms): (Vec<usize>, Vec<Term>) = self.lemmas.to_terms_ids().unzip();
 
-        let solver_pids = Arc::new(SolverPids::new());
+        let solver_pids = SolverPids::new();
         let unknown = Mutex::new(false);
         let first_sat = Mutex::new(None);
         let total_sat = Mutex::new(0_usize);

--- a/inference/src/lemma.rs
+++ b/inference/src/lemma.rs
@@ -1074,7 +1074,12 @@ where
             })
             .find_map_any(|(prefix, body)| {
                 let term = prefix.quantify(self.lemmas.body_to_term(body));
-                match fo.trans_cex(confs, &pre_terms, &term, false, false, Some(&solver_pids)) {
+                // If a lemmas is not in `self.lemmas`, there is a stronger lemma in `self.lemmas` that subsumes it,
+                // so it doesn't need to be checked.
+                let lemma_id = self.lemmas.get_id(&prefix, body)?;
+                let pre_ids: &[usize] = &[&[lemma_id], &pre_ids[..]].concat();
+                let pre_terms: &[Term] = &[&[term.clone()], &pre_terms[..]].concat();
+                match fo.trans_cex(confs, pre_terms, &term, false, false, Some(&solver_pids)) {
                     CexResult::Cex(mut models) => {
                         solver_pids.cancel();
                         {

--- a/inference/src/updr.rs
+++ b/inference/src/updr.rs
@@ -7,7 +7,7 @@ use im::{hashset, HashSet};
 use itertools::Itertools;
 use std::sync::Arc;
 
-use crate::basics::{CexOrCore, FOModule, TermOrModel, TransCexResult};
+use crate::basics::{CexOrCore, CexResult, FOModule, TermOrModel};
 use fly::syntax::Term::{NAryOp, Quantified, UnaryOp};
 use fly::syntax::*;
 use fly::term::cnf::term_to_cnf_clauses;
@@ -229,9 +229,14 @@ impl Updr {
                 if self.frames[i + 1].terms.contains(&negated) {
                     continue;
                 }
-                if let TransCexResult::UnsatCore(_) =
-                    module.trans_cex(&self.solver_conf, &prev_terms, &negated, false, true, None)
-                {
+                if let CexResult::UnsatCore(_) = module.trans_cex(
+                    &[&self.solver_conf],
+                    &prev_terms,
+                    &negated,
+                    false,
+                    true,
+                    None,
+                ) {
                     self.frames[i + 1].strengthen(negated.clone());
                 } else {
                     break 'push_frames;
@@ -428,8 +433,8 @@ impl Updr {
                 if self.frames[i + 1].terms.contains(term) {
                     continue;
                 }
-                if let TransCexResult::UnsatCore(_) =
-                    module.trans_cex(&self.solver_conf, &prev_terms, term, false, true, None)
+                if let CexResult::UnsatCore(_) =
+                    module.trans_cex(&[&self.solver_conf], &prev_terms, term, false, true, None)
                 {
                     self.frames[i + 1].strengthen(term.clone());
                 }

--- a/inference/src/updr.rs
+++ b/inference/src/updr.rs
@@ -5,13 +5,13 @@
 
 use im::{hashset, HashSet};
 use itertools::Itertools;
+use solver::basics::SingleSolver;
 use std::sync::Arc;
 
 use crate::basics::{CexOrCore, CexResult, FOModule, TermOrModel};
 use fly::syntax::Term::{NAryOp, Quantified, UnaryOp};
 use fly::syntax::*;
 use fly::term::cnf::term_to_cnf_clauses;
-use solver::conf::SolverConf;
 
 #[derive(Debug, Clone)]
 struct Frame {
@@ -33,7 +33,7 @@ struct BackwardsReachableState {
 
 /// State for a UPDR invariant search
 pub struct Updr {
-    solver_conf: Arc<SolverConf>,
+    solver: Arc<SingleSolver>,
     frames: Vec<Frame>,
     backwards_reachable_states: Vec<BackwardsReachableState>,
     currently_blocking_id: Option<usize>,
@@ -41,9 +41,9 @@ pub struct Updr {
 
 impl Updr {
     /// Initialize a UPDR search
-    pub fn new(solver_conf: Arc<SolverConf>) -> Updr {
+    pub fn new(solver_conf: Arc<SingleSolver>) -> Updr {
         Updr {
-            solver_conf,
+            solver: solver_conf,
             frames: vec![],
             backwards_reachable_states: vec![],
             currently_blocking_id: None,
@@ -71,7 +71,7 @@ impl Updr {
                     // println!("m: {}", t);
                     if module
                         .implies_cex(
-                            &self.solver_conf,
+                            self.solver.as_conf(),
                             &self.frames[found_state.known_absent_until_frame + 1].terms,
                             &Term::negate(t.clone()),
                         )
@@ -103,7 +103,7 @@ impl Updr {
         // Search for a new state.
         let last_frame = self.frames.last().unwrap();
         // println!("last_frame.terms {}", &last_frame.terms[0]);
-        let counter_example = module.safe_cex(&self.solver_conf, &last_frame.terms);
+        let counter_example = module.safe_cex(self.solver.as_conf(), &last_frame.terms);
         if module.module.proofs.is_empty() || counter_example.is_none() {
             // println!("None");
             // Nothing to block.
@@ -158,7 +158,7 @@ impl Updr {
             || (frame_index == 1
                 && module
                     .implies_cex(
-                        &self.solver_conf,
+                        self.solver.as_conf(),
                         &self.frames[0].terms,
                         &Term::negate(as_term.clone()),
                     )
@@ -229,9 +229,14 @@ impl Updr {
                 if self.frames[i + 1].terms.contains(&negated) {
                     continue;
                 }
-                if let CexResult::UnsatCore(_) =
-                    module.trans_cex(&[&self.solver_conf], &prev_terms, &negated, true, None)
-                {
+                if let CexResult::UnsatCore(_) = module.trans_cex(
+                    self.solver.as_ref(),
+                    &prev_terms,
+                    &negated,
+                    true,
+                    None,
+                    true,
+                ) {
                     self.frames[i + 1].strengthen(negated.clone());
                 } else {
                     break 'push_frames;
@@ -253,7 +258,7 @@ impl Updr {
     ) -> CexOrCore {
         // run UPDR
         let prev_frame = &self.frames[frame_index];
-        let out = module.get_pred(&self.solver_conf, &prev_frame.terms, term_or_model);
+        let out = module.get_pred(self.solver.as_conf(), &prev_frame.terms, term_or_model);
 
         // if let TermOrModel::Model(model) = term_or_model {
         //     if let CexOrCore::Core(out) = &out {
@@ -397,7 +402,7 @@ impl Updr {
                     .filter(|t| t != term && !removed.contains(t))
                     .collect();
                 if module
-                    .implies_cex(&self.solver_conf, &f_minus_t, term)
+                    .implies_cex(self.solver.as_conf(), &f_minus_t, term)
                     .is_some()
                     && !module
                         .module
@@ -429,7 +434,7 @@ impl Updr {
                     continue;
                 }
                 if let CexResult::UnsatCore(_) =
-                    module.trans_cex(&[&self.solver_conf], &prev_terms, term, true, None)
+                    module.trans_cex(self.solver.as_ref(), &prev_terms, term, true, None, true)
                 {
                     self.frames[i + 1].strengthen(term.clone());
                 }
@@ -468,7 +473,7 @@ impl Updr {
             // println!("checking inductiveness of frame {}", i);
             for term in &self.frames[i].terms {
                 if module
-                    .implies_cex(&self.solver_conf, &self.frames[i + 1].terms, term)
+                    .implies_cex(self.solver.as_conf(), &self.frames[i + 1].terms, term)
                     .is_some()
                 {
                     is_inductive = false;

--- a/inference/src/updr.rs
+++ b/inference/src/updr.rs
@@ -229,14 +229,9 @@ impl Updr {
                 if self.frames[i + 1].terms.contains(&negated) {
                     continue;
                 }
-                if let CexResult::UnsatCore(_) = module.trans_cex(
-                    &[&self.solver_conf],
-                    &prev_terms,
-                    &negated,
-                    false,
-                    true,
-                    None,
-                ) {
+                if let CexResult::UnsatCore(_) =
+                    module.trans_cex(&[&self.solver_conf], &prev_terms, &negated, true, None)
+                {
                     self.frames[i + 1].strengthen(negated.clone());
                 } else {
                     break 'push_frames;
@@ -434,7 +429,7 @@ impl Updr {
                     continue;
                 }
                 if let CexResult::UnsatCore(_) =
-                    module.trans_cex(&[&self.solver_conf], &prev_terms, term, false, true, None)
+                    module.trans_cex(&[&self.solver_conf], &prev_terms, term, true, None)
                 {
                     self.frames[i + 1].strengthen(term.clone());
                 }

--- a/inference/src/weaken.rs
+++ b/inference/src/weaken.rs
@@ -697,10 +697,8 @@ where
     }
 
     pub fn get_id(&self, prefix: &QuantifierPrefix, body: &O) -> Option<usize> {
-        self.bodies
-            .get(body)
-            .unwrap()
-            .iter()
+        let ids = self.bodies.get(body)?;
+        ids.iter()
             .copied()
             .find(|id| self.to_prefixes[id].contains(prefix))
     }

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1.0.40"
 regex = "1.8.4"
 pretty_env_logger = "0.5.0"
 log = "0.4.19"
+rayon = "1.7.0"
 
 [dev-dependencies]
 test-log = "0.2.11"

--- a/solver/Cargo.toml
+++ b/solver/Cargo.toml
@@ -14,6 +14,7 @@ serde_derive = "1.0.164"
 thiserror = "1.0.40"
 regex = "1.8.4"
 pretty_env_logger = "0.5.0"
+log = "0.4.19"
 
 [dev-dependencies]
 test-log = "0.2.11"

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -69,6 +69,16 @@ impl GenericBackend {
         self.opts.seed = seed;
         return self;
     }
+
+    /// Get the solver type.
+    pub fn get_solver_type(&self) -> SolverType {
+        self.solver_type
+    }
+
+    /// Get the solver timeout.
+    pub fn get_timeout_ms(&self) -> Option<usize> {
+        self.opts.timeout_ms
+    }
 }
 
 fn sort_cardinality(universes: &HashMap<String, usize>, sort: &Sort) -> usize {

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -223,6 +223,14 @@ impl Backend for &GenericBackend {
             .collect();
         FOModel { universe, interp }
     }
+
+    fn returns_minimal(&self) -> bool {
+        // TODO: make sure CVC4 and CVC5 return minimal models
+        match self.solver_type {
+            SolverType::Z3 => false,
+            SolverType::Cvc4 | SolverType::Cvc5 => true,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -33,6 +33,17 @@ pub enum SolverType {
     Cvc5,
 }
 
+impl SolverType {
+    /// Returns the name of the binary of this [`SolverType`].
+    pub fn bin_name(&self) -> &'static str {
+        match self {
+            SolverType::Z3 => "z3",
+            SolverType::Cvc5 => "cvc5",
+            SolverType::Cvc4 => "cvc4",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct GenericOptions {
     timeout_ms: Option<usize>,

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -71,7 +71,7 @@ impl GenericBackend {
     }
 
     /// Get the solver type.
-    pub fn get_solver_type(&self) -> SolverType {
+    pub fn solver_type(&self) -> SolverType {
         self.solver_type
     }
 

--- a/solver/src/basics.rs
+++ b/solver/src/basics.rs
@@ -1,0 +1,264 @@
+// Copyright 2022-2023 VMware, Inc.
+// SPDX-License-Identifier: BSD-2-Clause
+
+//! Traits defining a very basic interface to SMT solvers and a few implementations of them.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use fly::{
+    semantics::Model,
+    syntax::{Signature, Term},
+};
+use smtlib::proc::{SatResp, SmtPid, SolverError};
+
+use crate::conf::SolverConf;
+
+/// Check the following SMT query with the given solver configuration.
+/// The query is defined by the query configuration, a sequence of assertions,
+/// and a sequence of assumptions which are mapped from integer keys (which would
+/// later represent them in an unsat core) and a `bool` determining whether they
+/// should be assumed to be true or false.
+fn check_sat_conf(
+    solver_conf: &SolverConf,
+    query_conf: &QueryConf<SmtPid>,
+    assertions: &[Term],
+    assumptions: &HashMap<usize, (Term, bool)>,
+) -> Result<BasicSolverResp, SolverError> {
+    let start_time = std::time::Instant::now();
+    let log_result = |res: String| {
+        log::debug!(
+            "            {:?}(timeout={}) returned {res} after {}ms ({} assertions, {} assumptions)",
+            solver_conf.solver_type(),
+            solver_conf.get_timeout_ms().unwrap_or(0) / 1000,
+            start_time.elapsed().as_millis(),
+            assertions.len(),
+            assumptions.len(),
+        );
+    };
+    let mut solver = solver_conf.solver(query_conf.sig, query_conf.n_states);
+    if query_conf
+        .cancelers
+        .as_ref()
+        .is_some_and(|c| !c.add_canceler(solver.pid()))
+    {
+        return Err(SolverError::Killed);
+    }
+
+    for t in assertions {
+        solver.assert(t);
+    }
+
+    let mut solver_assumptions = HashMap::new();
+    for (i, (t, b)) in assumptions {
+        let ind = solver.get_indicator(i.to_string().as_str());
+        solver.assert(&Term::iff(&ind, t));
+        solver_assumptions.insert(ind, *b);
+    }
+
+    let resp = match solver.check_sat(solver_assumptions) {
+        Ok(SatResp::Sat) => {
+            log_result("SAT".to_string());
+            let get_model_resp = if query_conf.minimal_model {
+                solver.get_minimal_model()
+            } else {
+                solver.get_model()
+            };
+            get_model_resp.map(BasicSolverResp::Sat)
+        }
+        Ok(SatResp::Unsat) => solver.get_unsat_core().map(|core| {
+            log_result("UNSAT".to_string());
+            BasicSolverResp::Unsat(
+                core.into_iter()
+                    .map(|ind| match ind.0 {
+                        Term::Id(s) => s[6..].parse::<usize>().unwrap(),
+                        _ => panic!("indicator is not Term::Id"),
+                    })
+                    .collect(),
+            )
+        }),
+        Ok(SatResp::Unknown(reason)) => {
+            log_result(format!("unknown: {reason}"));
+            Ok(BasicSolverResp::Unknown(reason))
+        }
+        Err(err) => {
+            log_result(format!("error: {err}"));
+            Err(err)
+        }
+    };
+
+    if query_conf.save_tee {
+        solver.save_tee();
+    }
+
+    resp
+}
+
+/// Defines a configuration for performing a solver query.
+pub struct QueryConf<'a, C: BasicSolverCanceler> {
+    /// The signature used
+    pub sig: &'a Signature,
+    /// The number of states
+    pub n_states: usize,
+    /// Optional [`SolverCancelers`] which can be used to cancel the query at any time
+    pub cancelers: Option<SolverCancelers<C>>,
+    /// Whether to return a minimal model in case of satifiability
+    pub minimal_model: bool,
+    /// Whether to save the solver tee after the query
+    pub save_tee: bool,
+}
+
+/// A basic solver response
+pub enum BasicSolverResp {
+    /// A sat response together with a satisfying trace
+    Sat(Vec<Model>),
+    /// An unsat response together with an unsat core
+    Unsat(HashSet<usize>),
+    /// An unknown response together with a reason
+    Unknown(String),
+}
+
+/// A basic solver interface
+pub trait BasicSolver: Sync + Send {
+    /// A canceler type for this solver, able to cancel queries at any time
+    type Canceler: BasicSolverCanceler;
+
+    /// Check the satisfiability of the following query using the solver.
+    /// The query is defined by a query configuration, a sequence of assertions,
+    /// and a sequence of assumptions which are mapped from integer keys (which
+    /// would later represent them in an unsat core) and a `bool` determining
+    /// whether they should be assumed to be true or false.
+    fn check_sat(
+        &self,
+        query_conf: &QueryConf<Self::Canceler>,
+        assertions: &[Term],
+        assumptions: &HashMap<usize, (Term, bool)>,
+    ) -> Result<BasicSolverResp, SolverError>;
+}
+
+/// A basic canceler object for a solver, able to cancel queries at any time
+pub trait BasicSolverCanceler: Sync + Send {
+    /// Cancel the query associated with this canceler.
+    fn cancel(&self);
+}
+
+/// Maintains a set of [`BasicSolverCanceler`]'s which can be used to cancel queries whenever necessary.
+/// Composed of a `bool` which tracks whether the set has been canceled, followed by the
+/// [`BasicSolverCanceler`]'s of the solvers it tracks.
+pub struct SolverCancelers<C: BasicSolverCanceler>(Arc<Mutex<(bool, Vec<C>)>>);
+
+impl<C: BasicSolverCanceler> Clone for SolverCancelers<C> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<C: BasicSolverCanceler> Default for SolverCancelers<C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<C: BasicSolverCanceler> SolverCancelers<C> {
+    /// Create a new empty set of solver cancelers.
+    pub fn new() -> Self {
+        SolverCancelers(Arc::new(Mutex::new((false, vec![]))))
+    }
+
+    /// Add the given canceler to the set of cancelers.
+    ///
+    /// Returns `true` if the [`BasicSolverCanceler`] was added, or `false` if the set has already been canceled.
+    pub fn add_canceler(&self, canceler: C) -> bool {
+        let mut cancelers = self.0.lock().unwrap();
+        if cancelers.0 {
+            false
+        } else {
+            cancelers.1.push(canceler);
+            true
+        }
+    }
+
+    /// Cancel all solvers tracked by this set of cancelers.
+    pub fn cancel(&self) {
+        let mut cancelers = self.0.lock().unwrap();
+        cancelers.0 = true;
+        for canceler in cancelers.1.drain(..) {
+            canceler.cancel();
+        }
+    }
+}
+
+/// A basic solver which uses a single solver configuration
+pub struct SingleSolver(SolverConf);
+
+/// A set of solvers used in a fallback fashion: on each query the solvers
+/// are tried sequentially until (1) one of them returns a sat or unsat response,
+/// (2) all solvers return unknown, or (3) the query is canceled.
+pub struct FallbackSolvers(Vec<SolverConf>);
+
+impl BasicSolverCanceler for SmtPid {
+    fn cancel(&self) {
+        self.kill()
+    }
+}
+
+impl SingleSolver {
+    /// Create a new solver with the given configuration.
+    pub fn new(conf: SolverConf) -> Self {
+        Self(conf)
+    }
+
+    /// Return a reference to the solver configuration used.
+    pub fn as_conf(&self) -> &SolverConf {
+        &self.0
+    }
+}
+
+impl BasicSolver for SingleSolver {
+    type Canceler = SmtPid;
+
+    fn check_sat(
+        &self,
+        query_conf: &QueryConf<Self::Canceler>,
+        assertions: &[Term],
+        assumptions: &HashMap<usize, (Term, bool)>,
+    ) -> Result<BasicSolverResp, SolverError> {
+        match check_sat_conf(&self.0, query_conf, assertions, assumptions) {
+            Ok(BasicSolverResp::Unknown(reason)) | Err(SolverError::CouldNotMinimize(reason)) => {
+                Ok(BasicSolverResp::Unknown(reason))
+            }
+            res => res,
+        }
+    }
+}
+
+impl FallbackSolvers {
+    /// Create a new set of fallback solvers with the given configurations.
+    pub fn new(confs: Vec<SolverConf>) -> Self {
+        Self(confs)
+    }
+}
+
+impl BasicSolver for FallbackSolvers {
+    type Canceler = SmtPid;
+
+    fn check_sat(
+        &self,
+        query_conf: &QueryConf<Self::Canceler>,
+        assertions: &[Term],
+        assumptions: &HashMap<usize, (Term, bool)>,
+    ) -> Result<BasicSolverResp, SolverError> {
+        let mut unknowns: Vec<String> = vec![];
+        for solver_conf in &self.0 {
+            match check_sat_conf(solver_conf, query_conf, assertions, assumptions) {
+                Ok(BasicSolverResp::Unknown(reason))
+                | Err(SolverError::CouldNotMinimize(reason)) => {
+                    unknowns.push(reason);
+                }
+                res => return res,
+            }
+        }
+
+        Ok(BasicSolverResp::Unknown(unknowns.join("\n")))
+    }
+}

--- a/solver/src/basics.rs
+++ b/solver/src/basics.rs
@@ -147,6 +147,11 @@ pub trait BasicSolverCanceler: Sync + Send {
 /// Maintains a set of [`BasicSolverCanceler`]'s which can be used to cancel queries whenever necessary.
 /// Composed of a `bool` which tracks whether the set has been canceled, followed by the
 /// [`BasicSolverCanceler`]'s of the solvers it tracks.
+///
+/// Note that this can be used recursively to create hierarchical cancellation, since [`SolverCancelers`]
+/// itself implements [`BasicSolverCanceler`]. That is, multiple [`SolverCancelers`] -- which can be canceled
+/// individually -- can be aggregated within a higher-order [`SolverCancelers`] which can cancel them all at once.
+/// This enables a tree-like structure where the cancellation of a node cancels all of its descendants.
 pub struct SolverCancelers<C: BasicSolverCanceler>(Arc<Mutex<(bool, Vec<C>)>>);
 
 impl<C: BasicSolverCanceler> Clone for SolverCancelers<C> {

--- a/solver/src/conf.rs
+++ b/solver/src/conf.rs
@@ -14,14 +14,6 @@ use crate::{
 
 use fly::syntax::Signature;
 
-fn solver_default_bin(t: SolverType) -> &'static str {
-    match t {
-        SolverType::Z3 => "z3",
-        SolverType::Cvc5 => "cvc5",
-        SolverType::Cvc4 => "cvc4",
-    }
-}
-
 /// Wrapper around the configuration needed to launch a solver.
 #[derive(Debug, Clone)]
 pub struct SolverConf {
@@ -47,7 +39,7 @@ impl SolverConf {
         timeout_s: usize,
         seed: usize,
     ) -> Self {
-        let solver_bin = solver_path(solver_default_bin(backend_type));
+        let solver_bin = solver_path(backend_type.bin_name());
         let tee: Option<PathBuf> = if smt {
             let dir = log_dir(Path::new(fname));
             create_dir_all(&dir).expect("could not create log dir");

--- a/solver/src/conf.rs
+++ b/solver/src/conf.rs
@@ -74,4 +74,14 @@ impl SolverConf {
         backend.seed(seed);
         SolverConf { backend, tee }
     }
+
+    /// Get the solver type.
+    pub fn get_solver_type(&self) -> SolverType {
+        self.backend.get_solver_type()
+    }
+
+    /// Get the solver timeout.
+    pub fn get_timeout_ms(&self) -> Option<usize> {
+        self.backend.get_timeout_ms()
+    }
 }

--- a/solver/src/conf.rs
+++ b/solver/src/conf.rs
@@ -3,10 +3,24 @@
 
 //! Holds the configuration need to launch a solver.
 
-use std::path::PathBuf;
+use std::fs::{self, create_dir_all};
+use std::path::{Path, PathBuf};
 
-use crate::{backends::GenericBackend, imp::Solver};
+use crate::{
+    backends::{GenericBackend, SolverType},
+    imp::Solver,
+    log_dir, solver_path,
+};
+
 use fly::syntax::Signature;
+
+fn solver_default_bin(t: SolverType) -> &'static str {
+    match t {
+        SolverType::Z3 => "z3",
+        SolverType::Cvc5 => "cvc5",
+        SolverType::Cvc4 => "cvc4",
+    }
+}
 
 /// Wrapper around the configuration needed to launch a solver.
 #[derive(Debug, Clone)]
@@ -23,5 +37,41 @@ impl SolverConf {
         // TODO: failures to start the solver should be bubbled up to user nicely
         Solver::new(sig, n_states, &self.backend, self.tee.as_deref())
             .expect("could not start solver")
+    }
+
+    /// Get a new solver configuration with the specified settings
+    pub fn new(
+        backend_type: SolverType,
+        smt: bool,
+        fname: &String,
+        timeout: usize,
+        seed: usize,
+    ) -> Self {
+        let solver_bin = solver_path(solver_default_bin(backend_type));
+        let tee: Option<PathBuf> = if smt {
+            let dir = log_dir(Path::new(fname));
+            create_dir_all(&dir).expect("could not create log dir");
+            if let Ok(rdir) = dir.read_dir() {
+                for entry in rdir {
+                    match entry {
+                        Err(_) => {}
+                        Ok(name) => {
+                            _ = fs::remove_file(name.path());
+                        }
+                    }
+                }
+            }
+            Some(dir)
+        } else {
+            None
+        };
+        let mut backend = GenericBackend::new(backend_type, &solver_bin);
+        backend.timeout_ms(if timeout > 0 {
+            Some(timeout * 1000)
+        } else {
+            None
+        });
+        backend.seed(seed);
+        SolverConf { backend, tee }
     }
 }

--- a/solver/src/conf.rs
+++ b/solver/src/conf.rs
@@ -44,7 +44,7 @@ impl SolverConf {
         backend_type: SolverType,
         smt: bool,
         fname: &String,
-        timeout: usize,
+        timeout_s: usize,
         seed: usize,
     ) -> Self {
         let solver_bin = solver_path(solver_default_bin(backend_type));
@@ -66,8 +66,8 @@ impl SolverConf {
             None
         };
         let mut backend = GenericBackend::new(backend_type, &solver_bin);
-        backend.timeout_ms(if timeout > 0 {
-            Some(timeout * 1000)
+        backend.timeout_ms(if timeout_s > 0 {
+            Some(timeout_s * 1000)
         } else {
             None
         });
@@ -76,8 +76,8 @@ impl SolverConf {
     }
 
     /// Get the solver type.
-    pub fn get_solver_type(&self) -> SolverType {
-        self.backend.get_solver_type()
+    pub fn solver_type(&self) -> SolverType {
+        self.backend.solver_type()
     }
 
     /// Get the solver timeout.

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -40,6 +40,9 @@ pub trait Backend {
         indicators: &HashSet<String>,
         model: &Sexp,
     ) -> FOModel;
+
+    /// Indicates whether this solver returns minimal models when `(get-model)` is called.
+    fn returns_minimal(&self) -> bool;
 }
 
 /// An FOModel ("first-order model") gives a cardinality to each universe and an
@@ -371,6 +374,10 @@ impl<B: Backend> Solver<B> {
     /// cardinalities. Finally, it returns the model with these cardinality
     /// constraints in place.
     pub fn get_minimal_model(&mut self) -> Result<Vec<Model>, SolverError> {
+        if self.backend.returns_minimal() {
+            return self.get_model();
+        }
+
         let start = std::time::Instant::now();
         let assumptions = self.last_assumptions.take();
         // initially, assume anything used by the last check_sat call

--- a/solver/src/imp.rs
+++ b/solver/src/imp.rs
@@ -340,7 +340,7 @@ impl<B: Backend> Solver<B> {
                 Ok(true)
             }
             SatResp::Unsat => Ok(false),
-            SatResp::Unknown(msg) => panic!("could not check card {card}: {msg}"),
+            SatResp::Unknown(msg) => Err(SolverError::CouldNotMinimize(msg)),
         }
     }
 

--- a/solver/src/lib.rs
+++ b/solver/src/lib.rs
@@ -15,6 +15,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod backends;
+pub mod basics;
 pub mod conf;
 pub mod imp;
 pub mod models;

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -6,6 +6,7 @@
 use bounded::checker::CheckerAnswer;
 use codespan_reporting::diagnostic::{Diagnostic, Label};
 use path_slash::PathExt;
+use solver::basics::SingleSolver;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -596,7 +597,7 @@ impl App {
                 println!("{}", printer::fmt(&m));
             }
             Command::UpdrVerify(ref args @ VerifyArgs { .. }) => {
-                let conf = Arc::new(args.get_solver_conf());
+                let conf = Arc::new(SingleSolver::new(args.get_solver_conf()));
                 let mut updr = Updr::new(conf);
                 let _result = updr.search(&m);
             }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -217,7 +217,7 @@ struct InferenceConfigArgs {
 }
 
 impl InferenceConfigArgs {
-    fn to_cfg(&self, sig: &Signature) -> InferenceConfig {
+    fn to_cfg(&self, sig: &Signature, fname: String) -> InferenceConfig {
         let qf_body = match &self.qf_body {
             None => fixpoint::defaults::QF_BODY,
             Some(qf_body_str) => {
@@ -234,6 +234,7 @@ impl InferenceConfigArgs {
         };
 
         let mut cfg = InferenceConfig {
+            fname,
             cfg: self.q_cfg_args.to_cfg(sig),
             qf_body,
             max_size: self.max_size.unwrap_or(fixpoint::defaults::MAX_QUANT),
@@ -580,10 +581,11 @@ impl App {
                     ..
                 },
             ) => {
-                let conf = args.get_solver_conf();
                 m.inline_defs();
-                let infer_cfg = qargs.infer_cfg.to_cfg(&m.signature);
-                qalpha_by_qf_body(infer_cfg, &conf, &m, !args.no_print_invariant);
+                let infer_cfg = qargs
+                    .infer_cfg
+                    .to_cfg(&m.signature, args.infer_cmd.file().to_string());
+                qalpha_by_qf_body(infer_cfg, &m, !args.no_print_invariant);
                 if args.time {
                     timing::report();
                 }


### PR DESCRIPTION
This defines a `BasicSolver` trait in `solver/src/basics.rs`, which allows making very basic `check-sat` queries which return a `sat` result together with a trace, an `unsat` result together with an unsat-core, or `unknown`. By abstracting this basic functionality it is possible to implement this trait for a single `SolverConf`, as well as for a vector of `SolverConf`'s in two different ways, once as `FallbackSolvers` tried sequentially and second as `ParallelSolvers` tried in parallel. This is utilized in `qalpha`, which now uses `ParallelSolvers` for its inductiveness and safety checks by default, and is configurable to use `FallbackSolvers` instead via `--fallback`. The simulation queries in `qalpha` still use a single `SolverConf`, now abstracted behind the `BasicSolver` trait as well.

Solver cancellation has also been moved out of the inference code and made more generic, using the new `BasicSolverCanceler` trait and `SolverCancelers` struct, which aggregates multiple `BasicSolverCanceler`'s and itself implements `BasicSolverCanceler`. This is used recursively to create hierarchical tree-like cancellation, where the cancellation of a node cancels all of its descendants. The idea is that functions should only cancel queries which they (perhaps recursively) launched and not assume anything about the behavior of their callers. When the result is bubbled up to those callers, they should cancel their queries according to their own desired behavior. This allows more general applicablity which is independent of the specific goals of any single use-case, (in this case `qalpha`, which cancels all solvers on the first `sat` result.)

Another change is that now transition queries parallelize over disjunctive transitions, with proper cancellation if a `sat` response is encountered.