### PR TITLE
Add documentation on using command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,21 @@ cargo run -- verify temporal-verifier/examples/lockserver.fly
 
 cargo run -- infer qalpha temporal-verifier/examples/lockserver.fly --max-exist 0 --until-safe
 
+# invariant inference with qalpha
+# note: this example takes several minutes to run
 env RUST_LOG=info cargo run --release -- \
   infer qalpha temporal-verifier/examples/consensus_epr.fly --time \
   --custom-quant --sort quorum --sort node --sort value \
   --max-exist 1 --abort-unsafe --until-safe --minimal-smt \
   --extend-depth 1 --extend-width 10
-# note: this last example takes several minutes to run
+
+# bounded model checking
+cargo run -r -- set-check temporal-verifier/examples/consensus.fly \
+  --bound node=2 --bound value=2 --bound quorum=2
+
+## bounded model checking using a sat solver
+cargo run -r -- sat-check temporal-verifier/examples/consensus.fly \
+  --bound node=2 --bound value=2 --bound quorum=2 --depth=15
 ```
 
 ### Prerequisites

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -357,17 +357,23 @@ impl BoundedArgs {
 
 #[derive(clap::Subcommand, Clone, Debug, PartialEq, Eq)]
 enum Command {
+    /// Verify all assertions using user-provided invariants.
     Verify(VerifyArgs),
+    /// Verify assertions by inferring invariants with UPDR.
     UpdrVerify(VerifyArgs),
+    /// Infer invariants using other invariant inference algorithms.
     Infer(InferArgs),
+    /// Parse and re-print a fly file (for debugging)
     Print {
         /// File name for a .fly file
         file: String,
     },
+    /// Parse a fly file, inline definitions, and print (for debugging)
     Inline {
         /// File name for a .fly file
         file: String,
     },
+    /// Apply bounded model checking to each assertion using a set of states.
     SetCheck {
         #[command(flatten)]
         bounded: BoundedArgs,
@@ -375,7 +381,10 @@ enum Command {
         #[arg(long)]
         compress_traces: bool,
     },
+    /// Apply bounded model checking to each assertion using a SAT solver.
     SatCheck(BoundedArgs),
+    /// Apply bounded model checking to each assertion using binary decision
+    /// diagrams (BDDs).
     BddCheck {
         #[command(flatten)]
         bounded: BoundedArgs,
@@ -383,6 +392,7 @@ enum Command {
         #[arg(long)]
         reversed: bool,
     },
+    /// Apply bounded model checking to each assertion using an SMT solver.
     SmtCheck {
         #[command(flatten)]
         bounded: BoundedArgs, // universe bounds are unused


### PR DESCRIPTION
Added documentation to subcommands so `--help` is useful.

Added some examples of using the bounded model checkers to the README.

Fixes #84.