### PR TITLE
Better set program

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,18 +105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +118,6 @@ name = "bounded"
 version = "0.1.0"
 dependencies = [
  "biodivine-lib-bdd",
- "bitvec",
  "cadical",
  "fly",
  "fxhash",
@@ -472,12 +459,6 @@ dependencies = [
  "serde_derive",
  "thiserror",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fxhash"
@@ -915,12 +896,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,12 +1155,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "temporal-verifier"
@@ -1597,15 +1566,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/bounded/Cargo.toml
+++ b/bounded/Cargo.toml
@@ -10,6 +10,5 @@ solver = { path = "../solver" }
 itertools = "0.10.5"
 thiserror = "1.0.40"
 biodivine-lib-bdd = "0.5.1"
-bitvec = "1.0.1"
 cadical = "0.1.14"
 fxhash = "0.2.1"

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -4,16 +4,17 @@
 //! A bounded model checker for flyvy programs. Use `translate` to turn a flyvy `Module`
 //! into a `BoundedProgram`, then use `interpret` to evaluate it.
 
-use bitvec::prelude::*;
-use fly::{ouritertools::OurItertools, semantics::*, sorts::*, syntax::*, transitions::*};
-use std::collections::{BTreeSet, VecDeque};
+use fly::{ouritertools::OurItertools, semantics::*, syntax::*, transitions::*};
+use itertools::Itertools;
+use std::collections::VecDeque;
+use std::fmt::{Debug, Formatter};
 use thiserror::Error;
 
 // We use FxHashMap and FxHashSet because the hash function performance is about 25% faster
 // and the bounded model checker is essentially a hashing microbenchmark :)
 use fxhash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-/// Map from uninterpreted sort names to sizes
+/// Map from uninterpreted sort names to their sizes.
 // Here is the one place we use a std HashMap. It's not a performance problem because it's not used
 // in the inner loop of the model checker, and it provides a more ergonomic public api to this module.
 type UniverseBounds = std::collections::HashMap<String, usize>;
@@ -23,12 +24,6 @@ fn cardinality(universe: &UniverseBounds, sort: &Sort) -> usize {
         Sort::Bool => 2,
         Sort::Uninterpreted(sort) => *universe.get(sort).unwrap(),
     }
-}
-
-macro_rules! btreeset {
-    ($($v:expr),* $(,)?) => {{
-        BTreeSet::from([$($v,)*])
-    }};
 }
 
 /// The result of a successful run of the bounded model checker
@@ -42,31 +37,30 @@ pub enum CheckerAnswer {
     Convergence,
 }
 
-#[allow(missing_docs)]
+/// The result of an unsuccessful attempt to translate the input module.
 #[derive(Error, Debug, PartialEq)]
 pub enum TranslationError {
-    #[error("sort checking error: {0}")]
-    SortError(SortError),
+    /// The module contained a sort that wasn't in the universe
     #[error("sort {0} not found in universe {1:#?}")]
     UnknownSort(String, UniverseBounds),
+    /// The transition system extraction failed
     #[error("{0}")]
     ExtractionError(ExtractionError),
-    #[error("unknown identifier {0}")]
-    UnknownId(String),
+    /// The translated formula was not a conjunction
+    #[error("the set checker currently only handles initial conditions that are a conjunction")]
+    InitNotConj,
+    /// The transition system extraction found more than one transition relation
+    #[error("the set checker currently only handles a single transition relation")]
+    MultipleTrs,
+    /// The term could not be translated to an imperative transition
+    #[error("could not translate to transition {0}")]
+    CouldNotTranslateToTransition(Term),
+    /// The term could not be translated to a formula
     #[error("could not translate to propositional logic {0}")]
-    CouldNotTranslateToAst(Term),
+    CouldNotTranslateToFormula(Term),
+    /// The term could not be translated to an element of a sort
     #[error("could not translate to element {0}")]
     CouldNotTranslateToElement(Term),
-    #[error("we don't support negating no-ops, but found {0:?}")]
-    NegatedNoOp(Ast),
-    #[error("expected guard, found: {0:#?}")]
-    ExpectedGuard(Ast),
-    #[error("expected update, found: {0:#?}")]
-    ExpectedUpdate(Ast),
-    #[error("expected guard or update, found: {0:#?}")]
-    ExpectedGuardOrUpdate(Ast),
-    #[error("one of the generated updates updated the immutable relation {0}")]
-    UpdateViolatedImmutability(String),
 }
 
 /// Combined entry point to both translate and search the module.
@@ -77,7 +71,7 @@ pub fn check(
     compress_traces: TraceCompression,
     print_timing: bool,
 ) -> Result<CheckerAnswer, TranslationError> {
-    let (program, indices) = translate(module, universe)?;
+    let (program, context) = translate(module, universe, print_timing)?;
     match interpret(&program, depth, compress_traces, print_timing) {
         InterpreterResult::Unknown => Ok(CheckerAnswer::Unknown),
         InterpreterResult::Convergence => Ok(CheckerAnswer::Convergence),
@@ -115,7 +109,8 @@ pub fn check(
                                     .chain([2])
                                     .collect();
                                 Interpretation::new(&shape, |elements| {
-                                    state.0[indices[&(r.name.as_str(), elements.to_vec())]]
+                                    state
+                                        .get(context.indices[&(r.name.as_str(), elements.to_vec())])
                                         as Element
                                 })
                             })
@@ -128,13 +123,17 @@ pub fn check(
     }
 }
 
-/// A map from (relation name, arguments) pairs to their index in the [BoundedState] bit vector.
+/// A map from (name, arguments) pairs to their index in the [BoundedState] bit vector.
 #[derive(Debug, PartialEq)]
-struct Indices<'a>(HashMap<(&'a str, Vec<Element>), usize>);
+struct Context<'a> {
+    signature: &'a Signature,
+    universe: &'a UniverseBounds,
+    indices: HashMap<(&'a str, Vec<Element>), usize>,
+}
 
-impl Indices<'_> {
+impl Context<'_> {
     /// Compute an index for the given signature and universe bounds
-    fn new<'a>(signature: &'a Signature, universe: &UniverseBounds) -> Indices<'a> {
+    fn new<'a>(signature: &'a Signature, universe: &'a UniverseBounds) -> Context<'a> {
         let indices = signature
             .relations
             .iter()
@@ -142,76 +141,86 @@ impl Indices<'_> {
                 relation
                     .args
                     .iter()
-                    .map(|sort| cardinality(universe, sort))
-                    .map(|card| (0..card).collect::<Vec<Element>>())
+                    .map(|sort| 0..cardinality(universe, sort))
                     .multi_cartesian_product_fixed()
-                    .map(|element| (relation.name.as_str(), element))
+                    .map(|elements| (relation.name.as_str(), elements))
                     .collect::<Vec<_>>()
             })
             .enumerate()
             .map(|(i, x)| (x, i))
             .collect();
-        Indices(indices)
-    }
-
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
-impl<'a> std::ops::Index<&(&'a str, Vec<Element>)> for Indices<'a> {
-    type Output = usize;
-    fn index(&self, key: &(&'a str, Vec<Element>)) -> &usize {
-        &self.0[key]
+        Context {
+            signature,
+            universe,
+            indices,
+        }
     }
 }
 
-/// Compile-time upper bound on the bounded universe size. The bounded
-const STATE_LEN: usize = 128; // should be a multiple of 64 for alignment reasons
+/// Compile-time upper bound on the bounded universe size.
+const STATE_LEN: usize = 128;
+type StateData = u8;
+const STATE_DATA_BITS: usize = std::mem::size_of::<StateData>() * 8;
 
 /// A state in the bounded system. Conceptually, this is an interpretation of the signature on the
 /// bounded universe. We represent states concretely as a bitvector, where each bit represents the
-/// presence of a tuple in a relation. The order of the bits is determined by [Indices].
-#[derive(Clone, Debug, Eq, PartialOrd, Ord)]
-pub struct BoundedState(BitArr!(for STATE_LEN));
+/// presence of a tuple in a relation. The order of the bits is determined by [Context].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd)]
+struct BoundedState([StateData; STATE_LEN / STATE_DATA_BITS]);
 
-impl std::hash::Hash for BoundedState {
-    // Override the hash for bitvec::BitArray to use a slice of words rather than bit-by-bit.
-    fn hash<H>(&self, h: &mut H)
-    where
-        H: std::hash::Hasher,
-    {
-        usize::hash_slice(self.0.as_raw_slice(), h)
+impl BoundedState {
+    const ZERO: BoundedState = BoundedState([0; STATE_LEN / STATE_DATA_BITS]);
+
+    fn get(&self, index: usize) -> bool {
+        assert!(index < STATE_LEN, "STATE_LEN is too small");
+        let idx = index / STATE_DATA_BITS;
+        // `STATE_DATA_BITS - 1 - ` fixes ordering
+        let bit = STATE_DATA_BITS - 1 - (index % STATE_DATA_BITS);
+
+        ((self.0[idx] >> bit) & 1) != 0
+    }
+
+    fn set(&mut self, index: usize, value: bool) {
+        assert!(index < STATE_LEN, "STATE_LEN is too small");
+        let idx = index / STATE_DATA_BITS;
+        // `STATE_DATA_BITS - 1 - ` fixes ordering
+        let bit = STATE_DATA_BITS - 1 - (index % STATE_DATA_BITS);
+
+        if value {
+            self.0[idx] |= 1 << bit;
+        } else {
+            self.0[idx] &= !(1 << bit);
+        }
     }
 }
 
-impl PartialEq for BoundedState {
-    // Override eq for bitvec::BitArray to use a slice of words rather than bit-by-bit.
-    fn eq(&self, other: &BoundedState) -> bool {
-        let xs = self.0.as_raw_slice();
-        let ys = other.0.as_raw_slice();
-        let mut i = 0;
-        while i < xs.len() {
-            if xs[i] != ys[i] {
-                return false;
+impl Debug for BoundedState {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "[")?;
+        let mut max = STATE_LEN - 1;
+        while !self.get(max) {
+            if max == 0 {
+                return write!(f, "]");
             }
-            i += 1;
+            max -= 1;
         }
-        true
+        for i in 0..=max {
+            write!(f, "{}", self.get(i) as usize)?;
+        }
+        write!(f, "]")
     }
 }
 
 /// A BoundedProgram is a set of initial states, a set of transitions, and a safety property
 #[derive(Clone, Debug, PartialEq)]
-pub struct BoundedProgram {
+struct BoundedProgram {
     /// List of initial states
     inits: Vec<BoundedState>,
     /// List of transitions to potentially take at each step. The transition relation is the
     /// disjunction of all these transitions.
     trs: Vec<Transition>,
-    /// Safety property to check in each reachable state, expressed in DNF, i.e., the outer Vec is
-    /// an "or" of the inner Vecs, and each inner Vec is the "and" of its Guards.
-    safes: Vec<Vec<Guard>>,
+    /// Safety property to check in each reachable state.
+    safe: Formula,
 }
 
 /// A Transition is a deterministic partial function on states expressed as a guarded update.
@@ -219,41 +228,51 @@ pub struct BoundedProgram {
 /// state.
 /// If the (and of the) guard(s) is false, then the transition is not enabled.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Transition {
+struct Transition {
     guards: Vec<Guard>,
     updates: Vec<Update>,
-}
-
-impl Transition {
-    /// Make a Transition
-    pub fn new(guards: Vec<Guard>, updates: Vec<Update>) -> Transition {
-        Transition { guards, updates }
-    }
+    slow_guard: Formula,
 }
 
 /// A Guard is a logical literal, i.e., a possibly negated relation applied to an argument tuple
 /// such as `r(x, y)` or `!r(x, y)`. The relation and argument tuple are represented by an index
-/// into an ambient `Indices` map.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Guard {
-    /// The index representing the relation and argument tuple. Indexes into an ambient `Indices`
+/// into an ambient `Context` map.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct Guard {
+    /// The index representing the relation and argument tuple. Indexes into an ambient `Context`
     /// map.
     index: usize,
-
     /// True for positive literal, false for negative literal
     value: bool,
 }
 
 /// An Update is either an insertion or a removal of a tuple from a relation. The relation and
-/// argument tuple are represented by an index into an ambient `Indices` map.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Update {
-    /// The index representing the relation and argument tuple. Indexes into an ambient `Indices`
+/// argument tuple are represented by an index into an ambient `Context` map.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct Update {
+    /// The index representing the relation and argument tuple. Indexes into an ambient `Context`
     /// map.
     index: usize,
-
     /// True for insertion, false for removal
-    value: bool,
+    formula: Formula,
+}
+
+impl Transition {
+    fn from_conjunction(trs: impl IntoIterator<Item = Transition>) -> Transition {
+        let mut guards: HashSet<_> = HashSet::default();
+        let mut updates: HashSet<_> = HashSet::default();
+        let mut slow_guard = Formula::always_true();
+        for tr in trs {
+            guards.extend(tr.guards);
+            updates.extend(tr.updates);
+            slow_guard = Formula::and([slow_guard, tr.slow_guard]);
+        }
+        Transition {
+            guards: guards.into_iter().sorted().collect(),
+            updates: updates.into_iter().sorted().collect(),
+            slow_guard,
+        }
+    }
 }
 
 /// Translate a flyvy module into a BoundedProgram, given the bounds on the sort sizes.
@@ -262,15 +281,16 @@ pub struct Update {
 /// The translator ignores proof blocks.
 fn translate<'a>(
     module: &'a Module,
-    universe: &UniverseBounds,
-) -> Result<(BoundedProgram, Indices<'a>), TranslationError> {
+    universe: &'a UniverseBounds,
+    print_timing: bool,
+) -> Result<(BoundedProgram, Context<'a>), TranslationError> {
     for relation in &module.signature.relations {
         if relation.sort != Sort::Bool {
             panic!("non-bool relations in checker (use Module::convert_non_bool_relations)")
         }
     }
 
-    let indices = Indices::new(&module.signature, universe);
+    let context = Context::new(&module.signature, universe);
 
     for sort in &module.signature.sorts {
         if !universe.contains_key(sort) {
@@ -285,148 +305,122 @@ fn translate<'a>(
         panic!("definitions in checker (use Module::inline_defs)")
     }
 
+    println!("starting translation...");
+    let timer = std::time::Instant::now();
+
     let d = extract(module).map_err(TranslationError::ExtractionError)?;
-    let inits = d.inits.iter().chain(&d.axioms).cloned();
-    let transitions = d
-        .transitions
-        .iter()
-        .chain(d.mutable_axioms(&module.signature.relations))
-        .cloned();
-    let safeties = d.proofs.iter().map(|proof| proof.safety.x.clone());
 
-    let normalize = |term: Term| -> Result<Ast, TranslationError> {
-        // change uses of nullary relations from Term::Id(name) to Term::App(name, 0, vec![])
-        // because expand_quantifiers doesn't know about what names correspond to relations
-        // and only cares about Apps with 0 vs. 1 prime
-        let term = nullary_id_to_app(term, &module.signature.relations);
-        // push primes inwards
-        let term = fly::term::prime::Next::new(&module.signature).normalize(&term);
-        // convert Forall to And and Exists to Or, eagerly evaluating when possible
-        let term = term_to_ast(&term, universe, &HashMap::default())?;
-        // simplify Ands and Ors into DNF
-        Ok(distribute_conjunction(term))
-    };
+    let formula = |term| term_to_formula(&normalize(term, &context), &context, &HashMap::default());
 
-    let inits = normalize(Term::and(inits))?;
-    let trs = normalize(Term::and(transitions))?;
-    let safes = normalize(Term::and(safeties))?;
-
-    let get_guards_from_dnf = |valued: Ast| -> Result<Vec<Vec<Guard>>, TranslationError> {
-        valued
-            .get_or()
-            .into_iter()
-            .map(|term| {
-                term.get_and()
-                    .into_iter()
-                    .map(|term| term.get_guard(&indices))
-                    .collect::<Result<Vec<_>, _>>()
-            })
-            .collect::<Result<Vec<_>, _>>()
-    };
-
-    // inits should just be guards at this point
-    let inits: Vec<Vec<Guard>> = get_guards_from_dnf(inits)?;
-
-    // change inits from guards over the state space to states
-    let inits: Vec<BoundedState> = inits
+    // get cube
+    let mut init = BoundedState::ZERO;
+    let mut constrained = HashSet::default();
+    let inits = formula(Term::and(&d.inits))?;
+    for constraint in inits.get_and() {
+        if let Formula::Guard(Guard { index, value }) = constraint {
+            init.set(index, value);
+            constrained.insert(index);
+        } else {
+            return Err(TranslationError::InitNotConj);
+        }
+    }
+    // enumerate cube
+    let mut inits = vec![init];
+    for index in 0..context.indices.len() {
+        if !constrained.contains(&index) {
+            let mut with_unconstrained = inits.clone();
+            for init in &mut with_unconstrained {
+                init.set(index, true);
+            }
+            inits.append(&mut with_unconstrained);
+        }
+    }
+    // filter by axioms
+    let axiom = formula(Term::and(&d.axioms))?;
+    let inits = inits
         .into_iter()
-        .flat_map(|conjunction| {
-            // compute all the constrained elements by adding them to a single state
-            let mut init = BoundedState(BitArray::ZERO);
-            let mut constrained = btreeset![];
-            for guard in &conjunction {
-                init.0.set(guard.index, guard.value);
-                constrained.insert(guard.index);
-            }
-
-            // compute all the unconstrained elements by doubling the number of states each time
-            let mut inits = vec![init];
-            for index in 0..indices.len() {
-                if !constrained.contains(&index) {
-                    inits = inits
-                        .into_iter()
-                        .flat_map(|state| {
-                            let mut with_unconstrained = state.clone();
-                            with_unconstrained.0.set(index, true);
-                            vec![state, with_unconstrained]
-                        })
-                        .collect();
-                }
-            }
-            inits
-        })
+        .filter(|init| axiom.evaluate(init))
         .collect();
 
-    let mut unconstrained_delta = 0;
-    let trs: Vec<Transition> = trs
-        .get_or()
+    // compute imperative transitions
+    assert!(d
+        .mutable_axioms(&module.signature.relations)
+        .next()
+        .is_none());
+    let trs = match d.transitions.len() {
+        0 => vec![],
+        1 => traverse_disjunction(
+            &normalize(d.transitions[0].clone(), &context),
+            &context,
+            &HashMap::default(),
+            &|term, assignments| term_to_transition(term, &context, assignments),
+        )?,
+        _ => return Err(TranslationError::MultipleTrs),
+    };
+    let trs: Vec<_> = trs
         .into_iter()
-        .map(|term: Ast| {
-            // build transitions from constrained elements
-            let mut tr = Transition::new(vec![], vec![]);
-            let mut constrained = btreeset![];
-            for term in term.get_and() {
-                if let Ok(guard) = term.clone().get_guard(&indices) {
-                    tr.guards.push(guard);
-                } else if let Ok(update) = term.clone().get_update(&indices) {
-                    constrained.insert(update.index);
-                    tr.updates.push(update);
-                } else if let Ast::NoOp(set, element) = term {
-                    constrained.insert(indices[&(set.as_str(), element)]);
-                } else {
-                    return Err(TranslationError::ExpectedGuardOrUpdate(term));
-                }
+        .filter(|tr| tr.slow_guard != Formula::always_false())
+        .flat_map(|tr| {
+            // get cube
+            let mut constrained: HashSet<usize> = HashSet::default();
+            for &Update { index, .. } in &tr.updates {
+                constrained.insert(index);
             }
-
-            // compute all the unconstrained future elements by doubling
+            // enumerate cube
             let mut trs = vec![tr];
-            for index in 0..indices.len() {
-                if !constrained.contains(&index) {
-                    let ((relation, _), _) = indices.0.iter().find(|(_, i)| **i == index).unwrap();
-                    let mut relations = module.signature.relations.iter();
-                    if relations.find(|r| &r.name == relation).unwrap().mutable {
-                        trs = trs
-                            .into_iter()
-                            .flat_map(|tr| {
-                                let mut a = tr.clone();
-                                let mut b = tr;
-                                let matches = |g: &Guard, value| *g == Guard { index, value };
-                                if !a.guards.iter().any(|g| matches(g, true)) {
-                                    a.updates.push(Update { index, value: true });
-                                }
-                                if !b.guards.iter().any(|g| matches(g, false)) {
-                                    b.updates.push(Update {
-                                        index,
-                                        value: false,
-                                    });
-                                }
-                                vec![a, b]
-                            })
-                            .collect();
+            for ((name, _), index) in &context.indices {
+                let mut relations = module.signature.relations.iter();
+                if !constrained.contains(index)
+                    && relations.find(|r| &r.name == name).unwrap().mutable
+                {
+                    let mut with_unconstrained = trs.clone();
+                    for i in 0..trs.len() {
+                        if !trs[i].guards.iter().any(|g| g.index == *index && g.value) {
+                            with_unconstrained[i].updates.push(Update {
+                                index: *index,
+                                formula: Formula::always_true(),
+                            });
+                        }
+                        if !trs[i].guards.iter().any(|g| g.index == *index && !g.value) {
+                            trs[i].updates.push(Update {
+                                index: *index,
+                                formula: Formula::always_false(),
+                            });
+                        }
                     }
+                    trs.append(&mut with_unconstrained);
                 }
             }
-            unconstrained_delta += trs.len() - 1;
-            Ok(trs)
+            // filter out no-ops
+            for tr in &mut trs {
+                tr.updates.retain(|update| {
+                    update.formula
+                        != Formula::Guard(Guard {
+                            index: update.index,
+                            value: true,
+                        })
+                });
+            }
+            trs
         })
-        .collect::<Result<Vec<Vec<Transition>>, _>>()?
-        .into_iter()
-        .flatten()
         .collect();
 
-    if unconstrained_delta > 0 {
+    // compute safety property
+    let safes = d.proofs.iter().map(|proof| proof.safety.x.clone());
+    let safe = formula(Term::and(safes))?;
+
+    if print_timing {
         println!(
-            "some relations were unconstrained, added {unconstrained_delta} transitions to constrain them"
+            "translation finished in {:0.1}s",
+            timer.elapsed().as_secs_f64()
         );
     }
 
-    // disjunction of conjunction of guards
-    let safes: Vec<Vec<Guard>> = get_guards_from_dnf(safes)?;
-
+    // do sanity checks on the transitions
     for tr in &trs {
-        let mut indices_to_sets: Vec<&str> = Vec::with_capacity(indices.len());
-        indices_to_sets.resize(indices.len(), ""); // cap vs len
-        for ((r, _), i) in &indices.0 {
+        let mut indices_to_sets: Vec<&str> = Vec::with_capacity(context.indices.len());
+        indices_to_sets.resize(context.indices.len(), ""); // cap vs len
+        for ((r, _), i) in &context.indices {
             indices_to_sets[*i] = r;
         }
 
@@ -440,35 +434,138 @@ fn translate<'a>(
                 .unwrap()
                 .mutable
             {
-                return Err(TranslationError::UpdateViolatedImmutability(
-                    indices_to_sets[update.index].to_string(),
-                ));
+                panic!("one of the generated updates violated immutability");
             }
         }
-        // check that all of the transitions can be run
+        // check that all guards and updates target different indices
         for a in &tr.guards {
-            if tr.guards.iter().any(|b| {
-                matches!((a, b), (
-                    Guard { index: a, value: false },
-                    Guard { index: b, value: true },
-                )
-                | (
-                    Guard { index: a, value: true, },
-                    Guard { index: b, value: false, },
-                ) if a == b)
-            }) {
-                panic!("found an untakeable transition\n{tr:?}");
+            if tr.guards.iter().any(|b| a != b && a.index == b.index) {
+                panic!("found two guards with the same index\n{tr:?}");
             }
         }
-        // check that all redundant updates have been removed
-        for &Guard { index, value } in &tr.guards {
-            if tr.updates.contains(&Update { index, value }) {
-                panic!("found an unremoved redundant update")
+        for a in &tr.updates {
+            if tr.updates.iter().any(|b| a != b && a.index == b.index) {
+                panic!("found two updates with the same index\n{tr:?}");
             }
+        }
+        // check no updates are redundant
+        for &Guard { index, value } in &tr.guards {
+            if tr.updates.contains(&Update {
+                index,
+                formula: match value {
+                    true => Formula::always_true(),
+                    false => Formula::always_false(),
+                },
+            }) {
+                panic!("found an update that was redundant with a guard")
+            }
+        }
+        for Update { index, formula } in &tr.updates {
+            if let Formula::Guard(guard) = formula {
+                if *index == guard.index && guard.value {
+                    panic!("found an update that doesn't do anything")
+                }
+            }
+        }
+        assert!(tr.slow_guard != Formula::always_false());
+    }
+
+    Ok((BoundedProgram { inits, trs, safe }, context))
+}
+
+/// A first-order, single-vocabulary propositional formula.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum Formula {
+    And(Vec<Formula>),
+    Or(Vec<Formula>),
+    Guard(Guard),
+}
+
+impl Formula {
+    fn always_true() -> Formula {
+        Formula::And(vec![])
+    }
+
+    fn always_false() -> Formula {
+        Formula::Or(vec![])
+    }
+
+    fn and(terms: impl IntoIterator<Item = Formula>) -> Formula {
+        let terms: HashSet<_> = terms.into_iter().flat_map(Formula::get_and).collect();
+        if terms.iter().any(|term| *term == Formula::always_false()) {
+            return Formula::always_false();
+        }
+        if terms.len() == 1 {
+            terms.into_iter().next().unwrap()
+        } else {
+            Formula::And(terms.into_iter().sorted().collect())
         }
     }
 
-    Ok((BoundedProgram { inits, trs, safes }, indices))
+    fn get_and(self) -> Vec<Formula> {
+        match self {
+            Formula::And(terms) => terms,
+            term => vec![term],
+        }
+    }
+
+    fn or(terms: impl IntoIterator<Item = Formula>) -> Formula {
+        let terms: HashSet<_> = terms.into_iter().flat_map(Formula::get_or).collect();
+        if terms.iter().any(|term| *term == Formula::always_true()) {
+            return Formula::always_true();
+        }
+        if terms.len() == 1 {
+            terms.into_iter().next().unwrap()
+        } else {
+            Formula::Or(terms.into_iter().sorted().collect())
+        }
+    }
+
+    fn get_or(self) -> Vec<Formula> {
+        match self {
+            Formula::Or(terms) => terms,
+            term => vec![term],
+        }
+    }
+
+    fn not(self) -> Formula {
+        match self {
+            Formula::And(terms) => Formula::or(terms.into_iter().map(Formula::not)),
+            Formula::Or(terms) => Formula::and(terms.into_iter().map(Formula::not)),
+            Formula::Guard(Guard { index, value }) => Formula::Guard(Guard {
+                index,
+                value: !value,
+            }),
+        }
+    }
+
+    fn iff(self, other: Formula) -> Formula {
+        Formula::or(vec![
+            Formula::and(vec![self.clone(), other.clone()]),
+            Formula::and(vec![self.not(), other.not()]),
+        ])
+    }
+
+    fn ite(self, t: Formula, f: Formula) -> Formula {
+        Formula::or(vec![
+            Formula::and(vec![self.clone(), t]),
+            Formula::and(vec![self.not(), f]),
+        ])
+    }
+
+    fn evaluate(&self, state: &BoundedState) -> bool {
+        match self {
+            Formula::And(terms) => terms.iter().all(|term| term.evaluate(state)),
+            Formula::Or(terms) => terms.iter().any(|term| term.evaluate(state)),
+            Formula::Guard(Guard { index, value }) => state.get(*index) == *value,
+        }
+    }
+}
+
+fn normalize(term: Term, context: &Context) -> Term {
+    let term = nullary_id_to_app(term, &context.signature.relations);
+    let term = fly::term::prime::Next::new(context.signature).normalize(&term);
+    term
 }
 
 fn nullary_id_to_app(term: Term, relations: &[RelationDecl]) -> Term {
@@ -511,332 +608,267 @@ fn nullary_id_to_app(term: Term, relations: &[RelationDecl]) -> Term {
     }
 }
 
-/// A simplified syntax::Term that appears after quantifier enumeration.
-/// It structurally enforces negation normal form, and has logical semantics.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Ast {
-    // logic
-    /// A conjunction of terms. True is represented by And(set![]).
-    And(BTreeSet<Ast>),
-    /// A disjunction of terms. False is represented by Or(set![]).
-    Or(BTreeSet<Ast>),
-
-    // guards
-    /// An inclusion test
-    Includes(String, Vec<Element>), // r(x)
-    /// An exclusion test
-    Excludes(String, Vec<Element>), // !r(x)
-
-    // updates
-    /// An insertion
-    Insert(String, Vec<Element>), // r'(x)
-    /// A removal
-    Remove(String, Vec<Element>), // !r'(x)
-    /// A no-op (used for verifying that the module constrains all elements)
-    NoOp(String, Vec<Element>), // r'(x) = r(x)
-                                // r'(x) != r(x) could exist but isn't supported
-}
-
-impl Ast {
-    fn get_and(self) -> BTreeSet<Ast> {
-        match self {
-            Ast::And(terms) => terms,
-            _ => btreeset![self],
-        }
-    }
-
-    fn get_or(self) -> BTreeSet<Ast> {
-        match self {
-            Ast::Or(terms) => terms,
-            _ => btreeset![self],
-        }
-    }
-
-    fn get_guard(self, indices: &Indices) -> Result<Guard, TranslationError> {
-        match self {
-            Ast::Includes(set, element) => Ok(Guard {
-                index: indices[&(set.as_str(), element)],
-                value: true,
-            }),
-            Ast::Excludes(set, element) => Ok(Guard {
-                index: indices[&(set.as_str(), element)],
-                value: false,
-            }),
-            _ => Err(TranslationError::ExpectedGuard(self)),
-        }
-    }
-
-    fn get_update(self, indices: &Indices) -> Result<Update, TranslationError> {
-        match self {
-            Ast::Insert(set, element) => Ok(Update {
-                index: indices[&(set.as_str(), element)],
-                value: true,
-            }),
-            Ast::Remove(set, element) => Ok(Update {
-                index: indices[&(set.as_str(), element)],
-                value: false,
-            }),
-            _ => Err(TranslationError::ExpectedUpdate(self)),
-        }
-    }
-
-    fn contradicts(&self, other: &Ast) -> bool {
-        matches!((self, other),
-            (Ast::Includes(a, b), Ast::Excludes(c, d))
-            | (Ast::Excludes(a, b), Ast::Includes(c, d))
-            | (Ast::Insert(a, b), Ast::Remove(c, d))
-            | (Ast::Insert(a, b), Ast::NoOp(c, d))
-            | (Ast::Remove(a, b), Ast::Insert(c, d))
-            | (Ast::Remove(a, b), Ast::NoOp(c, d))
-            | (Ast::NoOp(a, b), Ast::Insert(c, d))
-            | (Ast::NoOp(a, b), Ast::Remove(c, d))
-                if a == c && b == d
-        )
-    }
-}
-
-fn and(terms: BTreeSet<Ast>) -> Ast {
-    // flatten
-    let terms: BTreeSet<Ast> = terms.into_iter().flat_map(Ast::get_and).collect();
-    // short circuit if possible
-    for a in &terms {
-        if *a == Ast::Or(btreeset![]) || terms.iter().any(|b| a.contradicts(b)) {
-            return Ast::Or(btreeset![]);
-        }
-    }
-    // remove redundant updates
-    let old = terms;
-    let mut terms = btreeset![];
-    for term in &old {
-        if let Ast::Insert(set, element) = term.clone() {
-            if old.contains(&Ast::Includes(set.clone(), element.clone())) {
-                terms.insert(Ast::NoOp(set, element));
-                continue;
-            }
-        } else if let Ast::Remove(set, element) = term.clone() {
-            if old.contains(&Ast::Excludes(set.clone(), element.clone())) {
-                terms.insert(Ast::NoOp(set, element));
-                continue;
-            }
-        }
-
-        terms.insert(term.clone());
-    }
-    // check for `(A or B) and (A or C)`
-    'outer: loop {
-        let old = terms.clone();
-        for a in &old {
-            if let Ast::Or(xs) = a {
-                for b in &old {
-                    if a != b {
-                        if let Ast::Or(ys) = b {
-                            for x in xs {
-                                if ys.contains(x) {
-                                    let mut xs = xs.clone();
-                                    let mut ys = ys.clone();
-                                    xs.remove(x);
-                                    ys.remove(x);
-
-                                    let c = and(btreeset![or(xs), or(ys)]);
-                                    let mut zs = distribute_conjunction(c).get_or();
-                                    zs.insert(x.clone());
-
-                                    terms.remove(a);
-                                    terms.remove(b);
-                                    terms.insert(or(zs));
-                                    continue 'outer;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        break;
-    }
-    // unwrap if there's just one element
-    if terms.len() == 1 {
-        terms.pop_last().unwrap()
-    } else {
-        Ast::And(terms)
-    }
-}
-
-fn or(terms: BTreeSet<Ast>) -> Ast {
-    // flatten
-    let mut terms: BTreeSet<Ast> = terms.into_iter().flat_map(Ast::get_or).collect();
-    // short circuit if possible
-    for a in &terms {
-        if *a == Ast::And(btreeset![]) || terms.iter().any(|b| a.contradicts(b)) {
-            return Ast::And(btreeset![]);
-        }
-    }
-    // check for `(A and B) or (A and B and C)` and remove the superset
-    let old = terms.clone();
-    for a in &old {
-        if let Ast::And(xs) = a {
-            for b in &old {
-                if a != b && (xs.contains(b) || matches!(b, Ast::And(ys) if xs.is_superset(ys))) {
-                    terms.remove(a);
-                    break;
-                }
-            }
-        }
-    }
-    // check for `(A and B) or (A and (not B))`
-    'outer: loop {
-        let old = terms.clone();
-        for a in &old {
-            if let Ast::And(xs) = a {
-                for b in &old {
-                    if a != b {
-                        if let Ast::And(ys) = b {
-                            if xs.len() == ys.len() {
-                                let mut unique = xs.symmetric_difference(ys);
-                                let p = unique.next().unwrap();
-                                let q = unique.next().unwrap();
-                                if unique.next().is_none() && p.contradicts(q) {
-                                    let zs = xs.intersection(ys).cloned().collect();
-                                    terms.remove(a);
-                                    terms.remove(b);
-                                    terms.insert(and(zs));
-                                    continue 'outer;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        break;
-    }
-    // unwrap if there's just one element
-    if terms.len() == 1 {
-        terms.pop_last().unwrap()
-    } else {
-        Ast::Or(terms)
-    }
-}
-
-fn not(term: Ast) -> Result<Ast, TranslationError> {
-    match term {
-        Ast::And(terms) => Ok(or(terms.into_iter().map(not).collect::<Result<_, _>>()?)),
-        Ast::Or(terms) => Ok(and(terms.into_iter().map(not).collect::<Result<_, _>>()?)),
-        Ast::Includes(set, element) => Ok(Ast::Excludes(set, element)),
-        Ast::Excludes(set, element) => Ok(Ast::Includes(set, element)),
-        // this makes sense because Ast has logical semantics
-        Ast::Insert(set, element) => Ok(Ast::Remove(set, element)),
-        Ast::Remove(set, element) => Ok(Ast::Insert(set, element)),
-        Ast::NoOp(_, _) => Err(TranslationError::NegatedNoOp(term)),
-    }
-}
-
-fn iff(x: Ast, y: Ast) -> Result<Ast, TranslationError> {
-    Ok(or(btreeset![
-        and(btreeset![x.clone(), y.clone()]),
-        and(btreeset![not(x)?, not(y)?]),
-    ]))
-}
-
-fn term_to_ast(
+fn traverse_disjunction<T>(
     term: &Term,
-    universe: &UniverseBounds,
+    context: &Context,
     assignments: &HashMap<String, Element>,
-) -> Result<Ast, TranslationError> {
-    let ast = |term| term_to_ast(term, universe, assignments);
-    let element = |term| term_to_element(term, universe, assignments);
+    func: &impl Fn(&Term, &HashMap<String, Element>) -> Result<T, TranslationError>,
+) -> Result<Vec<T>, TranslationError> {
+    let traverse = |term| traverse_disjunction(term, context, assignments, func);
+    let vec: Vec<T> = match term {
+        Term::NAryOp(NOp::Or, terms) => {
+            let vecs = terms
+                .iter()
+                .map(traverse)
+                .collect::<Result<Vec<Vec<T>>, _>>()?;
+            vecs.into_iter().flatten().collect()
+        }
+        Term::Quantified {
+            quantifier: Quantifier::Exists,
+            binders,
+            body,
+        } => {
+            let vecs = binders
+                .iter()
+                .map(|b| cardinality(context.universe, &b.sort))
+                .map(|card| (0..card).collect::<Vec<Element>>())
+                .multi_cartesian_product_fixed()
+                .map(|elements| {
+                    let mut new_assignments = assignments.clone();
+                    assert_eq!(binders.len(), elements.len());
+                    for (binder, element) in binders.iter().zip(elements) {
+                        new_assignments.insert(binder.name.to_string(), element);
+                    }
+                    traverse_disjunction(body, context, &new_assignments, func)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            vecs.into_iter().flatten().collect()
+        }
+        term => vec![func(term, assignments)?],
+    };
+    Ok(vec)
+}
 
-    let ast: Ast = match term {
-        Term::Literal(true) => Ast::And(btreeset![]),
-        Term::Literal(false) => Ast::Or(btreeset![]),
+fn term_to_transition(
+    term: &Term,
+    context: &Context,
+    assignments: &HashMap<String, Element>,
+) -> Result<Transition, TranslationError> {
+    let transition = |term| term_to_transition(term, context, assignments);
+    let formula = |term| term_to_formula(term, context, assignments);
+    let element = |term| term_to_element(term, context, assignments);
+
+    let transition: Transition = match term {
+        Term::NAryOp(NOp::And, terms) => {
+            let trs = terms
+                .iter()
+                .map(transition)
+                .collect::<Result<Vec<_>, _>>()?;
+            Transition::from_conjunction(trs)
+        }
+        Term::Quantified {
+            quantifier: Quantifier::Forall,
+            binders,
+            body,
+        } => {
+            let trs = binders
+                .iter()
+                .map(|b| cardinality(context.universe, &b.sort))
+                .map(|card| (0..card).collect::<Vec<Element>>())
+                .multi_cartesian_product_fixed()
+                .map(|elements| {
+                    let mut new_assignments = assignments.clone();
+                    assert_eq!(binders.len(), elements.len());
+                    for (binder, element) in binders.iter().zip(elements) {
+                        new_assignments.insert(binder.name.to_string(), element);
+                    }
+                    term_to_transition(body, context, &new_assignments)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Transition::from_conjunction(trs)
+        }
+        Term::Literal(true) => Transition {
+            guards: vec![],
+            updates: vec![],
+            slow_guard: Formula::always_true(),
+        },
+        Term::App(_, 0, _) => match formula(term)? {
+            Formula::Guard(guard) => Transition {
+                guards: vec![guard],
+                updates: vec![],
+                slow_guard: Formula::always_true(),
+            },
+            _ => unreachable!(),
+        },
+        Term::App(name, 1, args) => match formula(&Term::App(name.clone(), 0, args.clone()))? {
+            Formula::Guard(Guard { index, value }) => Transition {
+                guards: vec![],
+                updates: vec![Update {
+                    index,
+                    formula: match value {
+                        true => Formula::always_true(),
+                        false => Formula::always_false(),
+                    },
+                }],
+                slow_guard: Formula::always_true(),
+            },
+            _ => unreachable!(),
+        },
+        Term::UnaryOp(UOp::Not, body) => {
+            let mut tr = transition(body)?;
+            if tr.guards.len() == 1
+                && tr.updates.is_empty()
+                && tr.slow_guard == Formula::always_true()
+            {
+                tr.guards[0].value = !tr.guards[0].value;
+            } else if tr.guards.is_empty()
+                && tr.updates.len() == 1
+                && tr.slow_guard == Formula::always_true()
+            {
+                tr.updates[0].formula = tr.updates[0].formula.clone().not();
+            } else if tr.guards.is_empty() && tr.updates.is_empty() {
+                tr.slow_guard = tr.slow_guard.not();
+            } else {
+                return Err(TranslationError::CouldNotTranslateToTransition(
+                    term.clone(),
+                ));
+            }
+            tr
+        }
+        Term::BinOp(BinOp::Iff | BinOp::Equals, left, right)
+            if matches!(**left, Term::App(_, 1, _)) =>
+        {
+            if let Term::App(name, 1, args) = &**left {
+                let args = args.iter().map(element).collect::<Result<Vec<_>, _>>()?;
+                let index = context.indices[&(name.as_str(), args)];
+                let formula = formula(right)?;
+                Transition {
+                    guards: vec![],
+                    updates: vec![Update { index, formula }],
+                    slow_guard: Formula::always_true(),
+                }
+            } else {
+                unreachable!()
+            }
+        }
+        Term::BinOp(BinOp::NotEquals, left, right) => transition(&Term::UnaryOp(
+            UOp::Not,
+            Box::new(Term::equals(&**left, &**right)),
+        ))?,
+        Term::BinOp(BinOp::Implies, left, right) if element(left) == Ok(1) => transition(right)?,
+        Term::BinOp(BinOp::Implies, left, _) if element(left) == Ok(0) => Transition {
+            guards: vec![],
+            updates: vec![],
+            slow_guard: Formula::always_true(),
+        },
+        term => Transition {
+            guards: vec![],
+            updates: vec![],
+            slow_guard: formula(term)?,
+        },
+    };
+    Ok(transition)
+}
+
+fn term_to_formula(
+    term: &Term,
+    context: &Context,
+    assignments: &HashMap<String, Element>,
+) -> Result<Formula, TranslationError> {
+    let formula = |term| term_to_formula(term, context, assignments);
+    let element = |term| term_to_element(term, context, assignments);
+
+    let formula: Formula = match term {
+        Term::Literal(true) => Formula::always_true(),
+        Term::Literal(false) => Formula::always_false(),
         Term::Id(id) => match assignments.get(id) {
-            Some(0) => Ast::Or(btreeset![]),
-            Some(1) => Ast::And(btreeset![]),
-            _ => return Err(TranslationError::CouldNotTranslateToAst(term.clone())),
+            Some(1) => Formula::always_true(),
+            Some(0) => Formula::always_false(),
+            _ => {
+                return Err(TranslationError::CouldNotTranslateToTransition(
+                    term.clone(),
+                ))
+            }
         },
         Term::App(name, 0, args) => {
             let args = args.iter().map(element).collect::<Result<Vec<_>, _>>()?;
-            Ast::Includes(name.clone(), args)
+            Formula::Guard(Guard {
+                index: context.indices[&(name.as_str(), args)],
+                value: true,
+            })
         }
-        Term::App(name, 1, args) => {
-            let args = args.iter().map(element).collect::<Result<Vec<_>, _>>()?;
-            Ast::Insert(name.clone(), args)
-        }
-        Term::UnaryOp(UOp::Not, term) => not(ast(term)?)?,
-        Term::BinOp(BinOp::Iff, a, b) => iff(ast(a)?, ast(b)?)?,
+        Term::UnaryOp(UOp::Not, term) => formula(term)?.not(),
+        Term::BinOp(BinOp::Iff, a, b) => formula(a)?.iff(formula(b)?),
         Term::BinOp(BinOp::Equals, a, b) => match (element(a), element(b)) {
-            (Ok(a), Ok(b)) if a == b => Ast::And(btreeset![]),
-            (Ok(a), Ok(b)) if a != b => Ast::Or(btreeset![]),
-            _ => iff(ast(a)?, ast(b)?)?,
+            (Ok(a), Ok(b)) if a == b => Formula::always_true(),
+            (Ok(a), Ok(b)) if a != b => Formula::always_false(),
+            _ => formula(a)?.iff(formula(b)?),
         },
         Term::BinOp(BinOp::NotEquals, a, b) => {
-            not(ast(&Term::BinOp(BinOp::Equals, a.clone(), b.clone()))?)?
+            formula(&Term::BinOp(BinOp::Equals, a.clone(), b.clone()))?.not()
         }
-        Term::BinOp(BinOp::Implies, a, b) => or(btreeset![not(ast(a)?)?, ast(b)?]),
-        Term::NAryOp(NOp::And, terms) => and(terms.iter().map(ast).collect::<Result<_, _>>()?),
-        Term::NAryOp(NOp::Or, terms) => or(terms.iter().map(ast).collect::<Result<_, _>>()?),
-        Term::Ite { cond, then, else_ } => or(btreeset![
-            and(btreeset![ast(cond)?, ast(then)?]),
-            and(btreeset![not(ast(cond)?)?, ast(else_)?])
-        ]),
+        Term::BinOp(BinOp::Implies, a, b) => Formula::or(vec![formula(a)?.not(), formula(b)?]),
+        Term::NAryOp(NOp::And, terms) => {
+            Formula::and(terms.iter().map(formula).collect::<Result<Vec<_>, _>>()?)
+        }
+        Term::NAryOp(NOp::Or, terms) => {
+            Formula::or(terms.iter().map(formula).collect::<Result<Vec<_>, _>>()?)
+        }
+        Term::Ite { cond, then, else_ } => formula(cond)?.ite(formula(then)?, formula(else_)?),
         Term::Quantified {
             quantifier,
             binders,
             body,
         } => {
-            // adapted from semantics.rs
-            assert!(!binders.is_empty());
-            let shape: Vec<usize> = binders
+            let terms = binders
                 .iter()
-                .map(|b| cardinality(universe, &b.sort))
-                .collect();
-            let names: Vec<&String> = binders.iter().map(|b| &b.name).collect();
-            // evaluate on all combinations of values for quantified sorts
-            let set = shape
-                .iter()
-                .map(|&card| (0..card).collect::<Vec<Element>>())
+                .map(|b| cardinality(context.universe, &b.sort))
+                .map(|card| (0..card).collect::<Vec<Element>>())
                 .multi_cartesian_product_fixed()
                 .map(|elements| {
-                    // extend context with all variables bound to these `elements`
                     let mut new_assignments = assignments.clone();
-                    for (name, element) in names.iter().zip(elements) {
-                        new_assignments.insert(name.to_string(), element);
+                    assert_eq!(binders.len(), elements.len());
+                    for (binder, element) in binders.iter().zip(elements) {
+                        new_assignments.insert(binder.name.to_string(), element);
                     }
-                    term_to_ast(body, universe, &new_assignments)
+                    term_to_formula(body, context, &new_assignments)
                 })
-                .collect::<Result<BTreeSet<_>, _>>()?;
+                .collect::<Result<Vec<_>, _>>()?;
             match quantifier {
-                Quantifier::Forall => and(set),
-                Quantifier::Exists => or(set),
+                Quantifier::Forall => Formula::and(terms),
+                Quantifier::Exists => Formula::or(terms),
             }
         }
         Term::UnaryOp(UOp::Prime | UOp::Always | UOp::Eventually, _)
         | Term::UnaryOp(UOp::Next | UOp::Previous, _)
         | Term::BinOp(BinOp::Until | BinOp::Since, ..)
-        | Term::App(..) => return Err(TranslationError::CouldNotTranslateToAst(term.clone())),
+        | Term::App(..) => return Err(TranslationError::CouldNotTranslateToFormula(term.clone())),
     };
-    Ok(ast)
+    Ok(formula)
 }
 
 fn term_to_element(
     term: &Term,
-    universe: &UniverseBounds,
+    context: &Context,
     assignments: &HashMap<String, Element>,
 ) -> Result<Element, TranslationError> {
-    let ast = |term| term_to_ast(term, universe, assignments);
-    let element = |term| term_to_element(term, universe, assignments);
+    let formula = |term| term_to_formula(term, context, assignments);
+    let element = |term| term_to_element(term, context, assignments);
 
     let element: Element = match term {
         Term::Literal(_)
         | Term::UnaryOp(UOp::Not, ..)
         | Term::BinOp(BinOp::Iff | BinOp::Equals | BinOp::NotEquals | BinOp::Implies, ..)
         | Term::NAryOp(NOp::And | NOp::Or, ..)
-        | Term::Quantified { .. } => match ast(term)? {
-            Ast::And(set) if set.is_empty() => 1,
-            Ast::Or(set) if set.is_empty() => 0,
+        | Term::Quantified { .. } => match formula(term)? {
+            formula if formula == Formula::always_true() => 1,
+            formula if formula == Formula::always_false() => 0,
             _ => return Err(TranslationError::CouldNotTranslateToElement(term.clone())),
         },
-        Term::Id(id) => assignments[id],
+        Term::Id(id) => match assignments.get(id) {
+            Some(x) => *x,
+            None => panic!("no assignment found for {id}"),
+        },
         Term::Ite { cond, then, else_ } => match element(cond)? {
             1 => element(then)?,
             0 => element(else_)?,
@@ -848,42 +880,6 @@ fn term_to_element(
         | Term::App(..) => return Err(TranslationError::CouldNotTranslateToElement(term.clone())),
     };
     Ok(element)
-}
-
-// this actually ends up converting to DNF in context
-// steps from en.wikipedia.org/wiki/Conjunctive_normal_form
-// 1. Convert to negation normal form
-//    - the not() constructor does this internally
-// 2. Standardize variables
-//    - expand_quantifiers() deals with this
-// 3. Skolemize the statement
-//    - expand_quantifiers() deals with this
-// 4. Drop all universal quantifiers
-//    - expand_quantifiers() deals with this
-// 5. Distribute ORs inwards over ANDs
-//    - what this function does
-fn distribute_conjunction(term: Ast) -> Ast {
-    match term {
-        Ast::And(terms) if !terms.is_empty() => {
-            // A and (B or C or D) and (E or F) =
-            // (A and B and E) or (A and C and E) or (A and D and E) or
-            // (A and B and F) or (A and C and F) or (A and D and F)
-            // so we actually just want multi_cartesian_product_fixed, great
-            // we have to convert to and from Vec for multi_cartesian_product_fixed
-            or(terms
-                .into_iter()
-                .map(distribute_conjunction)
-                .map(|term| term.get_or().into_iter().collect::<Vec<_>>())
-                .multi_cartesian_product_fixed()
-                .map(|vec| and(vec.into_iter().collect::<BTreeSet<_>>()))
-                .collect())
-        }
-        Ast::Or(terms) => {
-            // or() internally flattens nested Ors
-            or(terms.into_iter().map(distribute_conjunction).collect())
-        }
-        _ => term,
-    }
 }
 
 /// Whether to compress traces by keeping only the last state
@@ -908,8 +904,8 @@ impl From<bool> for TraceCompression {
 /// A sequence of states that may or may not be compressed. Here, a "compressed" trace is just its
 /// last state together with its depth. (The depth of a trace is the number of transitions it
 /// contains, or one less than the number of states it contains.)
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum Trace {
+#[derive(Clone, Debug, PartialEq)]
+enum Trace {
     /// Uncompressed trace, which keeps all states
     Trace(Vec<BoundedState>),
     /// Compressed trace, keeping only the last state and its depth
@@ -964,7 +960,7 @@ impl Trace {
 
 /// The bounded model checker will either find a counterexample or say "no bugs found"
 #[derive(Debug, PartialEq)]
-pub enum InterpreterResult {
+enum InterpreterResult {
     /// The checker found a counterexample, here it is
     Counterexample(Trace),
     /// The checker could not find any counterexamples
@@ -998,7 +994,10 @@ fn interpret(
         .map(|state| Trace::new(state, compress_traces))
         .collect();
 
-    let transitions: Transitions = program.trs.iter().collect();
+    let mut transitions = Transitions::new();
+    for tr in &program.trs {
+        transitions.insert(tr);
+    }
 
     let mut current_depth = 0;
     let start_time = std::time::Instant::now();
@@ -1023,11 +1022,7 @@ fn interpret(
         }
 
         let state = trace.last();
-        if !program.safes.iter().any(|guards| {
-            guards
-                .iter()
-                .all(|guard| state.0[guard.index] == guard.value)
-        }) {
+        if !program.safe.evaluate(state) {
             return InterpreterResult::Counterexample(trace);
         }
 
@@ -1035,12 +1030,12 @@ fn interpret(
             let trs = transitions.get_subsets(state);
 
             for tr in trs {
-                let mut next = state.clone();
+                let mut next = *state;
                 tr.updates
                     .iter()
-                    .for_each(|update| next.0.set(update.index, update.value));
+                    .for_each(|update| next.set(update.index, update.formula.evaluate(state)));
                 if !seen.contains(&next) {
-                    seen.insert(next.clone());
+                    seen.insert(next);
                     if seen.len() % 1_000_000 == 0 {
                         let elapsed = start_time.elapsed().as_secs_f64();
                         println!(
@@ -1118,59 +1113,95 @@ impl<'a> Transitions<'a> {
     // Destination passing style helper to recursively collect all the transitions whose guards are
     // a subset of the given set.
     fn get_subsets_into_vec(&self, set: &BoundedState, out: &mut Vec<&'a Transition>) {
-        out.extend(self.data.iter().cloned());
+        out.extend(self.data.iter().filter(|tr| tr.slow_guard.evaluate(set)));
         for (key, child) in &self.children {
-            if set.0[key.index] == key.value {
+            if set.get(key.index) == key.value {
                 child.get_subsets_into_vec(set, out);
             }
         }
     }
 }
 
-impl<'a> FromIterator<&'a Transition> for Transitions<'a> {
-    fn from_iter<I: IntoIterator<Item = &'a Transition>>(iter: I) -> Self {
-        let mut ans = Transitions::new();
-        for tr in iter {
-            ans.insert(tr);
-        }
-        ans
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use fly::sorts::sort_check_and_infer;
 
-    fn includes(set: &str, elements: Vec<Element>, indices: &Indices) -> Guard {
+    fn includes(set: &str, elements: Vec<Element>, context: &Context) -> Guard {
         Guard {
-            index: indices[&(set, elements)],
+            index: context.indices[&(set, elements)],
             value: true,
         }
     }
-    fn excludes(set: &str, elements: Vec<Element>, indices: &Indices) -> Guard {
+    fn excludes(set: &str, elements: Vec<Element>, context: &Context) -> Guard {
         Guard {
-            index: indices[&(set, elements)],
+            index: context.indices[&(set, elements)],
             value: false,
         }
     }
-    fn insert(set: &str, elements: Vec<Element>, indices: &Indices) -> Update {
+    fn insert(set: &str, elements: Vec<Element>, context: &Context) -> Update {
         Update {
-            index: indices[&(set, elements)],
-            value: true,
+            index: context.indices[&(set, elements)],
+            formula: Formula::always_true(),
         }
     }
-    fn remove(set: &str, elements: Vec<Element>, indices: &Indices) -> Update {
+    fn remove(set: &str, elements: Vec<Element>, context: &Context) -> Update {
         Update {
-            index: indices[&(set, elements)],
-            value: false,
+            index: context.indices[&(set, elements)],
+            formula: Formula::always_false(),
+        }
+    }
+    fn transition(guards: Vec<Guard>, updates: Vec<Update>) -> Transition {
+        Transition {
+            guards: guards.into_iter().sorted().collect(),
+            updates: updates.into_iter().sorted().collect(),
+            slow_guard: Formula::always_true(),
         }
     }
     fn state(iter: impl IntoIterator<Item = u8>) -> BoundedState {
-        let mut out = BoundedState(BitArray::ZERO);
+        let mut out = BoundedState::ZERO;
         for (i, x) in iter.into_iter().enumerate() {
-            out.0.set(i, x == 1);
+            out.set(i, x == 1);
         }
         out
+    }
+
+    #[test]
+    fn checker_set_states() {
+        let mut s = state([0, 1, 0, 1]);
+
+        assert!(!s.get(0));
+        assert!(s.get(1));
+        assert!(!s.get(2));
+        assert!(s.get(3));
+
+        s.set(0, true);
+        s.set(2, true);
+
+        assert!(s.get(0));
+        assert!(s.get(1));
+        assert!(s.get(2));
+        assert!(s.get(3));
+
+        s.set(2, false);
+        s.set(3, false);
+
+        assert!(s.get(0));
+        assert!(s.get(1));
+        assert!(!s.get(2));
+        assert!(!s.get(3));
+
+        let mut a = BoundedState::ZERO;
+        let mut b = BoundedState::ZERO;
+        a.0[1] = 1; // [0, 1, 0, 0, ...]
+        b.0[0] = 1; // [1, 0, 0, 0, ...]
+        assert!(a < b);
+
+        assert!(state([0]) < state([1]));
+        assert!(state([0, 1, 0, 1]) < state([1, 0, 1, 0]));
+        assert!(state([0, 1, 0, 0]) < state([0, 1, 0, 1]));
+        assert!(state([0, 0, 1, 1]) < state([0, 1, 0, 0]));
+        assert!(state([0, 0, 1, 0]) < state([0, 0, 1, 1]));
     }
 
     #[test]
@@ -1178,19 +1209,19 @@ mod tests {
         let program = BoundedProgram {
             inits: vec![state([0])],
             trs: vec![
-                Transition::new(vec![], vec![]),
-                Transition::new(
+                transition(vec![], vec![]),
+                transition(
                     vec![],
                     vec![Update {
                         index: 0,
-                        value: true,
+                        formula: Formula::always_true(),
                     }],
                 ),
             ],
-            safes: vec![vec![Guard {
+            safe: Formula::Guard(Guard {
                 index: 0,
                 value: false,
-            }]],
+            }),
         };
         let result0 = interpret(&program, Some(0), TraceCompression::No, false);
         let result1 = interpret(&program, Some(1), TraceCompression::No, false);
@@ -1205,7 +1236,7 @@ mod tests {
         let program = BoundedProgram {
             inits: vec![state([1, 0, 0, 0])],
             trs: vec![
-                Transition::new(
+                transition(
                     vec![Guard {
                         index: 0,
                         value: true,
@@ -1213,15 +1244,15 @@ mod tests {
                     vec![
                         Update {
                             index: 0,
-                            value: false,
+                            formula: Formula::always_false(),
                         },
                         Update {
                             index: 1,
-                            value: true,
+                            formula: Formula::always_true(),
                         },
                     ],
                 ),
-                Transition::new(
+                transition(
                     vec![Guard {
                         index: 1,
                         value: true,
@@ -1229,15 +1260,15 @@ mod tests {
                     vec![
                         Update {
                             index: 1,
-                            value: false,
+                            formula: Formula::always_false(),
                         },
                         Update {
                             index: 2,
-                            value: true,
+                            formula: Formula::always_true(),
                         },
                     ],
                 ),
-                Transition::new(
+                transition(
                     vec![Guard {
                         index: 2,
                         value: true,
@@ -1245,15 +1276,15 @@ mod tests {
                     vec![
                         Update {
                             index: 2,
-                            value: false,
+                            formula: Formula::always_false(),
                         },
                         Update {
                             index: 3,
-                            value: true,
+                            formula: Formula::always_true(),
                         },
                     ],
                 ),
-                Transition::new(
+                transition(
                     vec![Guard {
                         index: 3,
                         value: true,
@@ -1261,19 +1292,19 @@ mod tests {
                     vec![
                         Update {
                             index: 3,
-                            value: false,
+                            formula: Formula::always_false(),
                         },
                         Update {
                             index: 0,
-                            value: true,
+                            formula: Formula::always_true(),
                         },
                     ],
                 ),
             ],
-            safes: vec![vec![Guard {
+            safe: Formula::Guard(Guard {
                 index: 3,
                 value: false,
-            }]],
+            }),
         };
         let result1 = interpret(&program, Some(0), TraceCompression::No, false);
         let result2 = interpret(&program, Some(1), TraceCompression::No, false);
@@ -1296,121 +1327,98 @@ mod tests {
     }
 
     #[test]
-    fn checker_set_translate_lockserver() -> Result<(), TranslationError> {
+    fn checker_set_lockserver_translation() -> Result<(), TranslationError> {
         let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
 
         let mut m = fly::parser::parse(source).unwrap();
         sort_check_and_infer(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
-        let indices = Indices::new(&m.signature, &universe);
+        let context = Context::new(&m.signature, &universe);
 
-        let mut trs = vec![];
-        // (forall N:node. ((lock_msg(N))') <-> lock_msg(N) | N = n)
-        trs.extend(vec![
-            Transition::new(vec![], vec![insert("lock_msg", vec![0], &indices)]),
-            Transition::new(vec![], vec![insert("lock_msg", vec![1], &indices)]),
-        ]);
-        // (forall N:node. server_holds_lock & lock_msg(n) &
-        //     !((server_holds_lock)') &
-        //     (((lock_msg(N))') <-> lock_msg(N) & N != n) &
-        //     (((grant_msg(N))') <-> grant_msg(N) | N = n)) &
-        trs.extend(vec![
-            Transition::new(
+        let trs = vec![
+            transition(
+                vec![includes("grant_msg", vec![0], &context)],
                 vec![
-                    includes("lock_msg", vec![1], &indices),
-                    includes("server_holds_lock", vec![], &indices),
-                ],
-                vec![
-                    insert("grant_msg", vec![1], &indices),
-                    remove("lock_msg", vec![1], &indices),
-                    remove("server_holds_lock", vec![], &indices),
+                    insert("holds_lock", vec![0], &context),
+                    remove("grant_msg", vec![0], &context),
                 ],
             ),
-            Transition::new(
+            transition(
+                vec![includes("grant_msg", vec![1], &context)],
                 vec![
-                    includes("lock_msg", vec![0], &indices),
-                    includes("server_holds_lock", vec![], &indices),
-                ],
-                vec![
-                    insert("grant_msg", vec![0], &indices),
-                    remove("lock_msg", vec![0], &indices),
-                    remove("server_holds_lock", vec![], &indices),
+                    insert("holds_lock", vec![1], &context),
+                    remove("grant_msg", vec![1], &context),
                 ],
             ),
-        ]);
-        // (forall N:node. grant_msg(n) &
-        //     (((grant_msg(N))') <-> grant_msg(N) & N != n) &
-        //     (((holds_lock(N))') <-> holds_lock(N) | N = n)) &
-        trs.extend(vec![
-            Transition::new(
-                vec![includes("grant_msg", vec![0], &indices)],
+            transition(
+                vec![includes("holds_lock", vec![0], &context)],
                 vec![
-                    insert("holds_lock", vec![0], &indices),
-                    remove("grant_msg", vec![0], &indices),
+                    insert("unlock_msg", vec![0], &context),
+                    remove("holds_lock", vec![0], &context),
                 ],
             ),
-            Transition::new(
-                vec![includes("grant_msg", vec![1], &indices)],
+            transition(
+                vec![includes("holds_lock", vec![1], &context)],
                 vec![
-                    insert("holds_lock", vec![1], &indices),
-                    remove("grant_msg", vec![1], &indices),
+                    insert("unlock_msg", vec![1], &context),
+                    remove("holds_lock", vec![1], &context),
                 ],
             ),
-        ]);
-        // (forall N:node. holds_lock(n) &
-        //     (((holds_lock(N))') <-> holds_lock(N) & N != n) &
-        //     (((unlock_msg(N))') <-> unlock_msg(N) | N = n)) &
-        trs.extend(vec![
-            Transition::new(
-                vec![includes("holds_lock", vec![0], &indices)],
+            transition(
                 vec![
-                    insert("unlock_msg", vec![0], &indices),
-                    remove("holds_lock", vec![0], &indices),
+                    includes("lock_msg", vec![0], &context),
+                    includes("server_holds_lock", vec![], &context),
+                ],
+                vec![
+                    insert("grant_msg", vec![0], &context),
+                    remove("lock_msg", vec![0], &context),
+                    remove("server_holds_lock", vec![], &context),
                 ],
             ),
-            Transition::new(
-                vec![includes("holds_lock", vec![1], &indices)],
+            transition(
                 vec![
-                    insert("unlock_msg", vec![1], &indices),
-                    remove("holds_lock", vec![1], &indices),
+                    includes("lock_msg", vec![1], &context),
+                    includes("server_holds_lock", vec![], &context),
+                ],
+                vec![
+                    insert("grant_msg", vec![1], &context),
+                    remove("lock_msg", vec![1], &context),
+                    remove("server_holds_lock", vec![], &context),
                 ],
             ),
-        ]);
-        // (forall N:node. unlock_msg(n) &
-        //     (((unlock_msg(N))') <-> unlock_msg(N) & N != n) &
-        //     ((server_holds_lock)'))
-        trs.extend(vec![
-            Transition::new(
-                vec![includes("unlock_msg", vec![0], &indices)],
+            transition(
+                vec![includes("unlock_msg", vec![0], &context)],
                 vec![
-                    insert("server_holds_lock", vec![], &indices),
-                    remove("unlock_msg", vec![0], &indices),
+                    insert("server_holds_lock", vec![], &context),
+                    remove("unlock_msg", vec![0], &context),
                 ],
             ),
-            Transition::new(
-                vec![includes("unlock_msg", vec![1], &indices)],
+            transition(
+                vec![includes("unlock_msg", vec![1], &context)],
                 vec![
-                    insert("server_holds_lock", vec![], &indices),
-                    remove("unlock_msg", vec![1], &indices),
+                    insert("server_holds_lock", vec![], &context),
+                    remove("unlock_msg", vec![1], &context),
                 ],
             ),
-        ]);
+            transition(vec![], vec![insert("lock_msg", vec![0], &context)]),
+            transition(vec![], vec![insert("lock_msg", vec![1], &context)]),
+        ];
 
         let expected = BoundedProgram {
             inits: vec![state([0, 0, 0, 0, 0, 0, 0, 0, 1])],
             trs,
-            safes: vec![
-                vec![excludes("holds_lock", vec![0], &indices)],
-                vec![excludes("holds_lock", vec![1], &indices)],
-            ],
+            safe: Formula::Or(vec![
+                Formula::Guard(excludes("holds_lock", vec![0], &context)),
+                Formula::Guard(excludes("holds_lock", vec![1], &context)),
+            ]),
         };
 
-        let (target, _) = translate(&m, &universe)?;
+        let (target, _) = translate(&m, &universe, false)?;
         assert_eq!(target.inits, expected.inits);
-        assert_eq!(target.safes, expected.safes);
+        assert_eq!(target.safe, expected.safe);
         assert_eq!(
-            target.trs.iter().collect::<BTreeSet<_>>(),
-            expected.trs.iter().collect::<BTreeSet<_>>()
+            expected.trs.iter().sorted().collect::<Vec<_>>(),
+            target.trs.iter().sorted().collect::<Vec<_>>(),
         );
 
         let output = interpret(&target, None, TraceCompression::No, false);
@@ -1420,13 +1428,13 @@ mod tests {
     }
 
     #[test]
-    fn checker_set_translate_lockserver_buggy() -> Result<(), TranslationError> {
+    fn checker_set_lockserver_buggy() -> Result<(), TranslationError> {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
 
         let mut m = fly::parser::parse(source).unwrap();
         sort_check_and_infer(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
-        let (target, _) = translate(&m, &universe)?;
+        let (target, _) = translate(&m, &universe, false)?;
 
         let bug = interpret(&target, Some(12), TraceCompression::No, false);
         if let InterpreterResult::Counterexample(trace) = &bug {
@@ -1442,7 +1450,7 @@ mod tests {
     }
 
     #[test]
-    fn checker_set_translate_consensus() -> Result<(), TranslationError> {
+    fn checker_set_consensus() -> Result<(), TranslationError> {
         let source = include_str!("../../temporal-verifier/examples/consensus.fly");
 
         let mut m = fly::parser::parse(source).unwrap();
@@ -1452,9 +1460,8 @@ mod tests {
             ("quorum".to_string(), 2),
             ("value".to_string(), 2),
         ]);
-        let (target, _) = translate(&m, &universe)?;
-        let output = interpret(&target, Some(10), TraceCompression::No, false);
-        assert_eq!(output, InterpreterResult::Unknown);
+        let output = check(&m, &universe, Some(10), TraceCompression::No, false)?;
+        assert_eq!(output, CheckerAnswer::Unknown);
 
         Ok(())
     }
@@ -1470,5 +1477,23 @@ mod tests {
             Ok(CheckerAnswer::Convergence),
             check(&module, &universe, Some(10), true.into(), false)
         );
+    }
+
+    #[test]
+    fn checker_set_copy_relation_size() -> Result<(), TranslationError> {
+        let source = "
+sort x
+mutable f(x): bool
+mutable g(x): bool
+
+assume forall a:x. !f(a) & !g(a)
+assume always forall a:x. ((g'(a) <-> f(a)) & (f'(a) <-> f(a)))
+        ";
+        let mut m = fly::parser::parse(source).unwrap();
+        sort_check_and_infer(&mut m).unwrap();
+        let universe = std::collections::HashMap::from([("x".to_string(), 5)]);
+        let (target, _) = translate(&m, &universe, false)?;
+        assert_eq!(1, target.trs.len());
+        Ok(())
     }
 }

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -519,14 +519,19 @@ impl Formula {
     }
 
     fn and(terms: impl IntoIterator<Item = Formula>) -> Formula {
-        let terms: HashSet<_> = terms.into_iter().flat_map(Formula::get_and).collect();
+        let mut terms: Vec<_> = terms
+            .into_iter()
+            .flat_map(Formula::get_and)
+            .sorted()
+            .collect();
+        terms.dedup();
+
         if terms.iter().any(|term| *term == Formula::always_false()) {
-            return Formula::always_false();
-        }
-        if terms.len() == 1 {
-            terms.into_iter().next().unwrap()
+            Formula::always_false()
+        } else if terms.len() == 1 {
+            terms.pop().unwrap()
         } else {
-            Formula::And(terms.into_iter().sorted().collect())
+            Formula::And(terms)
         }
     }
 
@@ -538,14 +543,19 @@ impl Formula {
     }
 
     fn or(terms: impl IntoIterator<Item = Formula>) -> Formula {
-        let terms: HashSet<_> = terms.into_iter().flat_map(Formula::get_or).collect();
+        let mut terms: Vec<_> = terms
+            .into_iter()
+            .flat_map(Formula::get_or)
+            .sorted()
+            .collect();
+        terms.dedup();
+
         if terms.iter().any(|term| *term == Formula::always_true()) {
-            return Formula::always_true();
-        }
-        if terms.len() == 1 {
-            terms.into_iter().next().unwrap()
+            Formula::always_true()
+        } else if terms.len() == 1 {
+            terms.pop().unwrap()
         } else {
-            Formula::Or(terms.into_iter().sorted().collect())
+            Formula::Or(terms)
         }
     }
 
@@ -568,16 +578,16 @@ impl Formula {
     }
 
     fn iff(self, other: Formula) -> Formula {
-        Formula::or(vec![
-            Formula::and(vec![self.clone(), other.clone()]),
-            Formula::and(vec![self.not(), other.not()]),
+        Formula::or([
+            Formula::and([self.clone(), other.clone()]),
+            Formula::and([self.not(), other.not()]),
         ])
     }
 
     fn ite(self, t: Formula, f: Formula) -> Formula {
-        Formula::or(vec![
-            Formula::and(vec![self.clone(), t]),
-            Formula::and(vec![self.not(), f]),
+        Formula::or([
+            Formula::and([self.clone(), t]),
+            Formula::and([self.not(), f]),
         ])
     }
 

--- a/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.2.snap
+++ b/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.2.snap
@@ -4,6 +4,8 @@ description: "--name=2 -- set-check --bound 'node=3' --print-timing false tests/
 expression: combined_stdout_stderr
 ---
 starting translation...
+enumerating 1 initial states
+enumerating 15 transitions
 starting search from depth 0. there are 1 initial states in the queue.
 considering new depth: 1. queue length is 2. seen 4 unique states.
 considering new depth: 2. queue length is 5. seen 10 unique states.

--- a/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.2.snap
+++ b/temporal-verifier/tests/examples/snapshots/lockserver_buggy.fly.2.snap
@@ -3,6 +3,7 @@ source: temporal-verifier/tests/test_examples.rs
 description: "--name=2 -- set-check --bound 'node=3' --print-timing false tests/examples/lockserver_buggy.fly"
 expression: combined_stdout_stderr
 ---
+starting translation...
 starting search from depth 0. there are 1 initial states in the queue.
 considering new depth: 1. queue length is 2. seen 4 unique states.
 considering new depth: 2. queue length is 5. seen 10 unique states.


### PR DESCRIPTION
This PR replaces the DNF based approach to translating flyvy modules to imperative programs with a pattern-matching based approach. This makes translation significantly faster; however, it comes at the cost of not being able to translate as many programs. This is worth it for now, as it lets us support running the paxos example.

@tchajed This PR will be hard to review, because there are a lot of changes. However, a lot of the lines of diffs come from reordering the things inside the file, which I have split off into it's own commit. You should verify that the first commit is just moving things around, and make your actual review using the rest of the commits. If the second commit is too large to review, let me know and I'll try to split it up.