### PR TITLE
Expose public API to sort checking 

### DIFF
--- a/bounded/src/bdd.rs
+++ b/bounded/src/bdd.rs
@@ -637,14 +637,14 @@ pub fn bdd_to_term<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fly::sorts::sort_check_and_infer;
+    use fly::sorts::sort_check_module;
 
     #[test]
     fn checker_bdd_basic() -> Result<(), CheckerError> {
         let source = include_str!("../../temporal-verifier/tests/examples/basic2.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([]);
 
         assert!(matches!(
@@ -664,7 +664,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
         assert!(matches!(
@@ -680,7 +680,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
         let bug = check(&module, &universe, Some(12), false)?;
@@ -699,7 +699,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/consensus.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::from([
             ("node".to_string(), 1),
             ("quorum".to_string(), 1),
@@ -719,7 +719,7 @@ mod tests {
         let source =
             include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
         assert!(matches!(
             check(&module, &universe, None, false)?,
@@ -733,7 +733,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/basic2.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([]);
 
         assert!(matches!(
@@ -753,7 +753,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
         assert!(matches!(
@@ -769,7 +769,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
         let bug = check_reversed(&module, &universe, Some(12), false)?;
@@ -788,7 +788,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/consensus.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::from([
             ("node".to_string(), 1),
             ("quorum".to_string(), 1),
@@ -808,7 +808,7 @@ mod tests {
         let source =
             include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
         assert!(matches!(
             check_reversed(&module, &universe, None, false)?,

--- a/bounded/src/sat.rs
+++ b/bounded/src/sat.rs
@@ -524,14 +524,14 @@ fn dimacs(cnf: &Cnf, context: &Context) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fly::sorts::sort_check_and_infer;
+    use fly::sorts::sort_check_module;
 
     #[test]
     fn checker_sat_basic() -> Result<(), CheckerError> {
         let source = include_str!("../../temporal-verifier/tests/examples/basic2.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([]);
 
         assert_eq!(CheckerAnswer::Unknown, check(&module, &universe, 0, false)?);
@@ -548,7 +548,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
         assert_eq!(
@@ -564,7 +564,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = HashMap::from([("node".to_string(), 2)]);
 
         let bug = check(&module, &universe, 12, false)?;
@@ -581,7 +581,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/consensus.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::from([
             ("node".to_string(), 2),
             ("quorum".to_string(), 2),
@@ -601,7 +601,7 @@ mod tests {
         let source =
             include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
         assert_eq!(
             CheckerAnswer::Unknown,

--- a/bounded/src/set.rs
+++ b/bounded/src/set.rs
@@ -1211,7 +1211,7 @@ impl<'a> Transitions<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fly::sorts::sort_check_and_infer;
+    use fly::sorts::sort_check_module;
 
     fn includes(set: &str, elements: Vec<Element>, context: &Context) -> Guard {
         Guard {
@@ -1417,7 +1417,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
 
         let mut m = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut m).unwrap();
+        sort_check_module(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
         let context = Context::new(&m.signature, &universe);
 
@@ -1518,7 +1518,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
 
         let mut m = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut m).unwrap();
+        sort_check_module(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("node".to_string(), 2)]);
         let (target, _) = translate(&m, &universe, false)?;
 
@@ -1540,7 +1540,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/consensus.fly");
 
         let mut m = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut m).unwrap();
+        sort_check_module(&mut m).unwrap();
         let universe = std::collections::HashMap::from([
             ("node".to_string(), 2),
             ("quorum".to_string(), 2),
@@ -1557,7 +1557,7 @@ mod tests {
         let source =
             include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
         let universe = std::collections::HashMap::new();
         assert_eq!(
             Ok(CheckerAnswer::Convergence),
@@ -1576,7 +1576,7 @@ assume forall a:x. !f(a) & !g(a)
 assume always forall a:x. ((g'(a) <-> f(a)) & (f'(a) <-> f(a)))
         ";
         let mut m = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut m).unwrap();
+        sort_check_module(&mut m).unwrap();
         let universe = std::collections::HashMap::from([("x".to_string(), 5)]);
         let (target, _) = translate(&m, &universe, false)?;
         assert_eq!(1, target.trs.len());

--- a/bounded/src/smt.rs
+++ b/bounded/src/smt.rs
@@ -89,7 +89,7 @@ pub fn check(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fly::sorts::sort_check_and_infer;
+    use fly::sorts::sort_check_module;
     use solver::backends::{GenericBackend, SolverType};
     use solver::solver_path;
 
@@ -105,7 +105,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/basic2.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
 
         assert_eq!(CheckerAnswer::Unknown, check(&module, &conf(), 0, false)?);
         assert!(matches!(
@@ -121,7 +121,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/lockserver.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
 
         assert_eq!(CheckerAnswer::Unknown, check(&module, &conf(), 10, false)?);
 
@@ -134,7 +134,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/tests/examples/lockserver_buggy.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
 
         let bug = check(&module, &conf(), 12, false)?;
         assert!(matches!(bug, CheckerAnswer::Counterexample(..)));
@@ -150,7 +150,7 @@ mod tests {
         let source = include_str!("../../temporal-verifier/examples/consensus.fly");
 
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
 
         assert_eq!(CheckerAnswer::Unknown, check(&module, &conf(), 5, false)?);
 
@@ -162,7 +162,7 @@ mod tests {
         let source =
             include_str!("../../temporal-verifier/tests/examples/success/immutability.fly");
         let mut module = fly::parser::parse(source).unwrap();
-        sort_check_and_infer(&mut module).unwrap();
+        sort_check_module(&mut module).unwrap();
 
         assert_eq!(CheckerAnswer::Unknown, check(&module, &conf(), 10, false)?);
         Ok(())

--- a/fly/src/lib.rs
+++ b/fly/src/lib.rs
@@ -26,3 +26,58 @@ pub mod syntax;
 pub mod term;
 pub mod timing;
 pub mod transitions;
+
+#[cfg(test)]
+mod test_sorts_public {
+    // these tests are here so that we are forced to use the public API to sort inference
+    use crate::{
+        parser::{self, parse_signature},
+        sorts::Scope,
+        syntax::{Binder, Quantifier, Sort, Term},
+    };
+
+    #[test]
+    fn test_sorts_public() {
+        let sig = parse_signature(
+            "
+            sort round
+            immutable le(round, round): bool
+            ",
+        );
+        let ctx = Scope::new(&sig).expect("could not create context");
+        {
+            // check that le(r,r) sort checks in context [r:round]
+            let mut ctx = ctx.clone();
+            ctx.add_variable("r", &Sort::Uninterpreted("round".to_owned()))
+                .expect("could not add x to the scope");
+            let sort = ctx
+                .sort_check_term(&mut parser::term("le(r,r)"))
+                .expect("unexpected sort checking error");
+            assert_eq!(sort, Sort::Bool);
+        }
+        // check that le(r,r) does *not* sort check in the empty context
+        assert!(ctx
+            .sort_check_term(&mut crate::parser::term("le(r,r)"))
+            .is_err());
+        // check that sort inference can figure out r:round in this quantifier
+        let mut t = parser::term("forall r. le(r,r)");
+        let sort = ctx
+            .sort_check_term(&mut t)
+            .expect("unexpected sort checking error");
+        assert_eq!(sort, Sort::Bool);
+        match &t {
+            Term::Quantified {
+                quantifier: Quantifier::Forall,
+                binders,
+                body: _,
+            } => match &binders[..] {
+                // check that sort inference filled in the annotation correctly
+                [Binder { name: _, sort }] => {
+                    assert_eq!(sort, &Sort::Uninterpreted("round".to_owned()))
+                }
+                _ => panic!("wrong number of variables"),
+            },
+            _ => panic!("wrong AST node"),
+        }
+    }
+}

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -427,14 +427,17 @@ impl Context<'_> {
         &mut self,
         name: String,
         sort: RelationOrIndividual,
-        shadowing_constraint: ShadowingConstraint,
+        shadow: ShadowingConstraint,
     ) -> Result<(), SortError> {
-        match self.bound_names.insert(name.clone(), sort) {
-            Some(_) if shadowing_constraint == ShadowingConstraint::Disallow => {
-                Err(SortError::RedeclaredName(name))
+        match shadow {
+            ShadowingConstraint::Disallow if self.bound_names.contains_key(&name) => {
+                return Err(SortError::RedeclaredName(name))
             }
-            _ => Ok(()),
+            _ => (),
         }
+
+        self.bound_names.insert(name, sort);
+        Ok(())
     }
 
     // doesn't allow `binders` to shadow each other, but does allow them to

--- a/fly/src/sorts.rs
+++ b/fly/src/sorts.rs
@@ -3,7 +3,7 @@
 
 //! Infer and check sorts.
 //!
-//! The main entry point is [sort_check_and_infer].
+//! The main entry point is [sort_check_module].
 //!
 //! The parser represents missing sort annotations as `Sort::Uninterpreted("")`.
 //! One of the main purposes of sort inference is to replace these placeholders
@@ -92,7 +92,7 @@ pub enum SortError {
 /// provide a [Span] to locate this error in the source code. The AST has
 /// limited span information, so some errors will be returned without location
 /// information (the span will be `None` in that case).
-pub fn sort_check_and_infer(module: &mut Module) -> Result<(), (SortError, Option<Span>)> {
+pub fn sort_check_module(module: &mut Module) -> Result<(), (SortError, Option<Span>)> {
     let mut sorts = HashSet::new();
     for sort in &module.signature.sorts {
         if !sorts.insert(sort.clone()) {

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -552,7 +552,7 @@ pub struct Signature {
 }
 
 impl Signature {
-    /// Get the index of an unintereted sort.
+    /// Get the index of an uninterpreted sort.
     pub fn sort_idx(&self, sort: &Sort) -> usize {
         match sort {
             Sort::Bool => panic!("invalid sort {sort}"),
@@ -594,7 +594,7 @@ impl Signature {
 
     /// Check if `name` is a relation in the signature, or a primed version of
     /// one.
-    pub fn contains_name(&self, name: &str) -> bool {
+    pub fn contains_relation(&self, name: &str) -> bool {
         let symbol_no_primes = name.trim_end_matches(|c| c == '\'');
         return self.relations.iter().any(|r| r.name == symbol_no_primes);
     }

--- a/fly/src/syntax.rs
+++ b/fly/src/syntax.rs
@@ -564,6 +564,11 @@ impl Signature {
         }
     }
 
+    /// Check if `name` is the name of an uninterpreted sort in the signature
+    pub fn contains_sort(&self, name: &str) -> bool {
+        self.sorts.iter().any(|s| s == name)
+    }
+
     /// Get the declaration for a given name.
     ///
     /// Removes trailing primes from name and gives the underlying relation.

--- a/solver/src/backends.rs
+++ b/solver/src/backends.rs
@@ -141,7 +141,7 @@ impl Backend for &GenericBackend {
         let mut part_interp = PartialInterp::for_model(&model);
         let mut symbols = model.symbols.iter().collect::<Vec<_>>();
         symbols.sort_unstable_by_key(|(symbol, _)| {
-            let in_signature = sig.contains_name(symbol);
+            let in_signature = sig.contains_relation(symbol);
             // sort the model-only signatures first
             //
             // NOTE: this is just a heuristic to evaluate auxilliary functions
@@ -218,7 +218,7 @@ impl Backend for &GenericBackend {
         let interp = part_interp
             .interps
             .into_iter()
-            .filter(|(symbol, _)| sig.contains_name(symbol))
+            .filter(|(symbol, _)| sig.contains_relation(symbol))
             .map(|(symbol, (interp, _))| (symbol, interp))
             .collect();
         FOModel { universe, interp }

--- a/temporal-verifier/src/command.rs
+++ b/temporal-verifier/src/command.rs
@@ -534,7 +534,7 @@ impl App {
             }
         };
 
-        let r = sorts::sort_check_and_infer(&mut m);
+        let r = sorts::sort_check_module(&mut m);
         if let Err((err, span)) = r {
             eprintln!("sort checking error:");
 


### PR DESCRIPTION
This PR cleans up the sort checker and introduces a public API for sort checking individual terms in a scope. 

Here's a little example:

```
let sig = parse_signature(
    "
    sort round
    immutable le(round, round): bool
    ",
);
let mut ctx = Scope::new(&sig).expect("could not create context");
ctx.add_variable("r", &Sort::Id("round".to_owned()))
    .expect("could not add x to the scope");
let sort = ctx
    .sort_check_term(&mut parser::term("le(r,r)"))
    .expect("unexpected sort checking error");
assert_eq!(sort, Sort::Bool);
```